### PR TITLE
Remove problematic spaces in gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text = auto
+* text=auto


### PR DESCRIPTION
I get the error message " is not a valid attribute name: .gitattributes:1"
According to http://stegriff.co.uk/upblog/gitattributes-error-is-not-a-valid-attribute-name this is because there are spaces around the equal sign.