### PR TITLE
Correct tilde in dcm files

### DIFF
--- a/Graphic.dcm
+++ b/Graphic.dcm
@@ -1,174 +1,174 @@
 EESchema-DOCLIB  Version 2.0
 #
-$CMP ~Logo_Open_Hardware_Large
+$CMP Logo_Open_Hardware_Large
 D Large Open hardware Logo
 K Logo
 F ~
 $ENDCMP
 #
-$CMP ~Logo_Open_Hardware_Small
+$CMP Logo_Open_Hardware_Small
 D small Open Hardware Logo
 K Logo
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Arrow45_Large
+$CMP SYM_Arrow45_Large
 D 300mil filled 45° arrow symbol
 K symbol arrow angled 45°
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Arrow45_Normal
+$CMP SYM_Arrow45_Normal
 D 200mil filled 45° arrow symbol
 K symbol arrow angled 45°
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Arrow45_Small
+$CMP SYM_Arrow45_Small
 D small (160mil) filled 45° arrow symbol
 K symbol arrow angled 45°
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Arrow45_Tiny
+$CMP SYM_Arrow45_Tiny
 D small (100mil) filled 45° arrow symbol
 K symbol arrow angled 45°
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Arrow45_XLarge
+$CMP SYM_Arrow45_XLarge
 D 400mil filled 45° arrow symbol
 K symbol arrow 45° angled
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Arrow_Large
+$CMP SYM_Arrow_Large
 D 300mil filled arrow symbol
 K symbol arrow
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Arrow_Normal
+$CMP SYM_Arrow_Normal
 D 200mil filled arrow symbol
 K symbol arrow
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Arrow_Small
+$CMP SYM_Arrow_Small
 D small (160mil) filled arrow symbol
 K symbol arrow
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Arrow_Tiny
+$CMP SYM_Arrow_Tiny
 D small (100mil) filled arrow symbol
 K symbol arrow
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Arrow_XLarge
+$CMP SYM_Arrow_XLarge
 D 400mil filled arrow symbol
 K symbol arrow
 F ~
 $ENDCMP
 #
-$CMP ~SYM_ESD_Large
+$CMP SYM_ESD_Large
 D large ESD warning symbol / "Do not touch"
 K symbol ESD
 F ~
 $ENDCMP
 #
-$CMP ~SYM_ESD_Small
+$CMP SYM_ESD_Small
 D small ESD warning symbol / "Do not touch"
 K symbol ESD
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Earth_Protective_Large
+$CMP SYM_Earth_Protective_Large
 D large protective earth symbol
 K graphical symbol earth protective
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Earth_Protective_Small
+$CMP SYM_Earth_Protective_Small
 D small protective earth symbol
 K graphical symbol earth protective
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Flash_Large
+$CMP SYM_Flash_Large
 D large flash symbol
 K graphic symbol flash VAC 220VAC 110VAC power
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Flash_Small
+$CMP SYM_Flash_Small
 D small flash symbol
 K graphic symbol flash VAC 220VAC 110VAC power
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Flash_XLarge
+$CMP SYM_Flash_XLarge
 D extra large flash symbol
 K graphic symbol flash VAC 220VAC 110VAC power
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Hot_Large
+$CMP SYM_Hot_Large
 D large hot surface warning sign
 K symbol logo hot surface warning heat
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Hot_Small
+$CMP SYM_Hot_Small
 D small hot surface warning sign
 K symbol logo hot surface warning heat
 F ~
 $ENDCMP
 #
-$CMP ~SYM_LASER_Large
+$CMP SYM_LASER_Large
 D large LASER radiation warning sign
 K symbol logo laser warning
 F ~
 $ENDCMP
 #
-$CMP ~SYM_LASER_Small
+$CMP SYM_LASER_Small
 D small LASER radiation warning sign
 K symbol logo laser warning
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Magnet_Large
+$CMP SYM_Magnet_Large
 D large magnetic field warning sign
 K symbol logo magnetic field warning
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Magnet_Small
+$CMP SYM_Magnet_Small
 D small magnetic field warning sign
 K symbol logo magnetic field warning
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Radio_Waves_Large
+$CMP SYM_Radio_Waves_Large
 D large radio waves warning sign
 K symbol logo radio waves warning radiation
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Radio_Waves_Small
+$CMP SYM_Radio_Waves_Small
 D small radio waves warning sign
 K symbol logo radio waves warning radiation
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Radioactive_Large
+$CMP SYM_Radioactive_Large
 D large radioactive radiation warning sign
 K symbol logo radioactive radiation warning heat
 F ~
 $ENDCMP
 #
-$CMP ~SYM_Radioactive_Radiation_Small
+$CMP SYM_Radioactive_Radiation_Small
 D small radioactive radiation warning sign
 K symbol logo radioactive radiation warning
 F ~

--- a/power.dcm
+++ b/power.dcm
@@ -450,19 +450,19 @@ D negative power-supply/ground power-flag symbol
 K Power Flag Symbol
 $ENDCMP
 #
-$CMP ~Earth
+$CMP Earth
 D Ground power flag symbol
 K power pwr gnd ground
 F ~
 $ENDCMP
 #
-$CMP ~Earth_Clean
+$CMP Earth_Clean
 D Clean Earth power flag symbol
 K power pwr gnd ground clean signal
 F ~
 $ENDCMP
 #
-$CMP ~Earth_Protective
+$CMP Earth_Protective
 D Protective Earth power flag symbol
 K power pwr earth protective gnd ground clean
 F ~


### PR DESCRIPTION
Graphics.dcm and power.dcm files have tilde prepended to the component name filed. KiCad issues errors when opening these libraries (e.g. 21:06:55: Alias '~Earth_Protective' not found in library: 'D:\Mitja\Plate\Kicad_libs\official_libs\kicad-symbols\power.dcm' at line 465 offset 23)

Looking at the original files from https://github.com/KiCad/kicad-library I concluded that tilde was inserted when porting libraries.