### PR TITLE
Fix #131: remove DS204 entry from wrong dcm file.

### DIFF
--- a/Sensor_Temperature.dcm
+++ b/Sensor_Temperature.dcm
@@ -96,12 +96,6 @@ K OneWire 1Wire Dallas Maxim
 F http://datasheets.maximintegrated.com/en/ds/DS18S20.pdf
 $ENDCMP
 #
-$CMP DS2401
-D Silicon Serial Number TO-92
-K OneWire 1Wire Maxim Dallas ID
-F http://pdfserv.maximintegrated.com/en/ds/DS2401.pdf
-$ENDCMP
-#
 $CMP DS28EA00
 D 1-Wire Digital Thermometer with Sequence Detect and PIO
 K 1Wire OneWire Maxim Dallas


### PR DESCRIPTION
Fix for #131. (Strangely this error is only reported by a nightly build not by the stable 4.0.6)
