### PR TITLE
update Atmel datasheet now located at microchip.com

### DIFF
--- a/MCU_Atmel_8051.dcm
+++ b/MCU_Atmel_8051.dcm
@@ -3,49 +3,49 @@ EESchema-DOCLIB  Version 2.0
 $CMP AT89C2051-PU
 D PDIP20, 2k Flash, 128B SRAM
 K MCS-51 8bit Flash Microcontroller
-F http://www.atmel.com/Images/doc0368.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0368.pdf
 $ENDCMP
 #
 $CMP AT89C2051-SU
 D SO20, 2k Flash, 128B SRAM
 K MCS-51 8bit Flash Microcontroller
-F http://www.atmel.com/Images/doc0368.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0368.pdf
 $ENDCMP
 #
 $CMP AT89C4051-PU
 D DIP20, 2k Flash, 128B SRAM
 K MCS-51 8bit Flash Microcontroller
-F http://www.atmel.com/Images/doc1001.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1001.pdf
 $ENDCMP
 #
 $CMP AT89C4051-SU
 D SO20, 2k Flash, 128B SRAM
 K MCS-51 8bit Flash Microcontroller
-F http://www.atmel.com/Images/doc1001.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1001.pdf
 $ENDCMP
 #
 $CMP AT89S2051-PU
 D PDIP20, 2k Flash, 256B SRAM
 K MCS-51 8bit Flash Microcontroller
-F http://www.atmel.com/Images/doc3390.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc3390.pdf
 $ENDCMP
 #
 $CMP AT89S2051-SU
 D SO20, 2k Flash, 256B SRAM
 K MCS-51 8bit Flash Microcontroller
-F http://www.atmel.com/Images/doc3390.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc3390.pdf
 $ENDCMP
 #
 $CMP AT89S4051-24PU
 D PDIP20, 4k Flash, 256B SRAM
 K MCS-51 8bit Flash Microcontroller
-F http://www.atmel.com/Images/doc3390.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc3390.pdf
 $ENDCMP
 #
 $CMP AT89S4051-24SU
 D SO20, 4k Flash, 256B SRAM
 K MCS-51 8bit Flash Microcontroller
-F http://www.atmel.com/Images/doc3390.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc3390.pdf
 $ENDCMP
 #
 #End Doc Library

--- a/MCU_Atmel_ATMEGA.dcm
+++ b/MCU_Atmel_ATMEGA.dcm
@@ -3,1657 +3,1657 @@ EESchema-DOCLIB  Version 2.0
 $CMP ATMEGA128-16AU
 D TQFP64, 128k Flash, 4k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2467.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2467.pdf
 $ENDCMP
 #
 $CMP ATMEGA128-16MU
 D QFN/MLF64, 128k Flash, 4k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2467.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2467.pdf
 $ENDCMP
 #
 $CMP ATMEGA1280-16AU
 D TQFP100, 128k Flash, 8k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA1281-16AU
 D TQFP64, 128k Flash, 8k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA1281-16MU
 D MLF/QFN64, 128k Flash, 8k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA1284-AU
 D TQFP44, 128k Flash, 16k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA1284-MU
 D VQFN44, 128k Flash, 16k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA1284-PU
 D PDIP40, 128k Flash, 16k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA1284P-AU
 D TQFP44, 128k Flash, 16k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA1284P-MU
 D VQFN44, 128k Flash, 16k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA1284P-PU
 D PDIP40, 128k Flash, 16k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA128A-AU
 D TQFP64, 128k Flash, 4k SRAM, 4k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc8151.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8151.pdf
 $ENDCMP
 #
 $CMP ATMEGA128A-MU
 D MLF/QFN64, 128k Flash, 4k SRAM, 4k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc8151.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8151.pdf
 $ENDCMP
 #
 $CMP ATMEGA16-16AU
 D TQFP44, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2466.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2466.pdf
 $ENDCMP
 #
 $CMP ATMEGA16-16MU
 D QFN/MLF44, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2466.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2466.pdf
 $ENDCMP
 #
 $CMP ATMEGA16-16PU
 D PDIP40, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2466.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2466.pdf
 $ENDCMP
 #
 $CMP ATMEGA161-4AC
 D TQFP44, 16k Flash, 1K SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc1228.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1228.pdf
 $ENDCMP
 #
 $CMP ATMEGA161-4PC
 D PDIP40, 16k Flash, 1K SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc1228.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1228.pdf
 $ENDCMP
 #
 $CMP ATMEGA162-16AU
 D TQFP44, 16k Flash, 1K SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-2513-8-bit-avr-microntroller-atmega162_datasheet-summary.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2513-8-bit-avr-microntroller-atmega162_datasheet-summary.pdf
 $ENDCMP
 #
 $CMP ATMEGA162-16MU
 D QFN/MLF44, 16k Flash, 1K SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-2513-8-bit-avr-microntroller-atmega162_datasheet-summary.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2513-8-bit-avr-microntroller-atmega162_datasheet-summary.pdf
 $ENDCMP
 #
 $CMP ATMEGA162-16PU
 D PDIP40, 16k Flash, 1K SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-2513-8-bit-avr-microntroller-atmega162_datasheet-summary.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2513-8-bit-avr-microntroller-atmega162_datasheet-summary.pdf
 $ENDCMP
 #
 $CMP ATMEGA163-4AC
 D TQFP44, 16k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc1142.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1142.pdf
 $ENDCMP
 #
 $CMP ATMEGA163-4PC
 D PDIP40, 16k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc1142.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1142.pdf
 $ENDCMP
 #
 $CMP ATMEGA164A-AU
 D TQFP44, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA164A-MU
 D VQFN44, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA164A-PU
 D PDIP40, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA164P-20AU
 D TQFP44, 16k Flash, 1k SRAM, 512k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA164P-20MU
 D MLF/QFN44, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA164P-20PU
 D PDIP40, 16k Flash, 1k SRAM, 512k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA164PA-AU
 D TQFP44, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA164PA-MU
 D VQFN44, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA164PA-PU
 D PDIP40, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA165-8AI
 D TQFP64, 16k Flash, 1k SRAM, 512k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2573.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2573.pdf
 $ENDCMP
 #
 $CMP ATMEGA165-8MI
 D QFN/MLF64, 16k Flash, 1k SRAM, 512k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2573.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2573.pdf
 $ENDCMP
 #
 $CMP ATMEGA165A-AU
 D TQFP64, 16k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA165A-MU
 D QFN/MLF64, 16k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA165P-16AU
 D TQFP64, 16k Flash, 1k SRAM, 512k EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/Images/doc8019.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8019.pdf
 $ENDCMP
 #
 $CMP ATMEGA165P-16MU
 D QFN/MLF64, 16k Flash, 1k SRAM, 512k EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/Images/doc8019.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8019.pdf
 $ENDCMP
 #
 $CMP ATMEGA165PA-AU
 D TQFP64, 16k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA165PA-MU
 D QFN/MLF64, 16k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA168-20AU
 D TQFP32, 16k Flash, 512B SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
 $ENDCMP
 #
 $CMP ATMEGA168-20MU
 D QFN/MLF32, 16k Flash, 512B SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
 $ENDCMP
 #
 $CMP ATMEGA168-20PU
 D PDIP28 Narrow, 16k Flash, 512B SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
 $ENDCMP
 #
 $CMP ATMEGA168A-AU
 D TQFP32, 16k Flash, 1kB SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA168A-MMH
 D QFN/MLF28, 16k Flash, 1kB SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA168A-MU
 D QFN/MLF32, 16k Flash, 1kB SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA168A-PU
 D PDIP28 Narrow, 16k Flash, 1kB SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA168PA-AU
 D TQFP32, 16k Flash, 1kB SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA168PA-MMH
 D QFN/MLF28, 16k Flash, 1kB SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA168PA-MU
 D QFN/MLF32, 16k Flash, 1kB SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA168PA-PU
 D PDIP28 Narrow, 16k Flash, 1kB SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA169-16AU
 D TQFP64, 16k Flash, 1k SRAM, 512k EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD
-F http://www.atmel.com/Images/doc2514.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2514.pdf
 $ENDCMP
 #
 $CMP ATMEGA169-16MU
 D QFN/MLF64, 16k Flash, 1k SRAM, 512k EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD
-F http://www.atmel.com/Images/doc2514.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2514.pdf
 $ENDCMP
 #
 $CMP ATMEGA169A-AU
 D TQFP64, 16k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD PicoPower
-F http://www.atmel.com/images/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA169A-MU
 D QFN/MLF64, 16k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD PicoPower
-F http://www.atmel.com/images/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA169P-16AU
 D TQFP64, 16k Flash, 1k SRAM, 512k EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD PicoPower
-F http://www.atmel.com/Images/doc8018.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8018.pdf
 $ENDCMP
 #
 $CMP ATMEGA169P-16MU
 D QFN/MLF64, 16k Flash, 1k SRAM, 512k EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD PicoPower
-F http://www.atmel.com/Images/doc8018.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8018.pdf
 $ENDCMP
 #
 $CMP ATMEGA169PA-AU
 D TQFP64, 16k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD PicoPower
-F http://www.atmel.com/images/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA169PA-MU
 D QFN/MLF64, 16k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD PicoPower
-F http://www.atmel.com/images/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA16A-AU
 D TQFP44, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc8154.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8154.pdf
 $ENDCMP
 #
 $CMP ATMEGA16A-MU
 D QFN/MLF44, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc8154.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8154.pdf
 $ENDCMP
 #
 $CMP ATMEGA16A-PU
 D PDIP40, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc8154.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8154.pdf
 $ENDCMP
 #
 $CMP ATMEGA16M1-AU
 D TQFP32, 16k Flash, 1k SRAM, 512B EEPROM, CAN
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc8209.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8209.pdf
 $ENDCMP
 #
 $CMP ATMEGA16M1-MU
 D QFN32, 16k Flash, 1k SRAM, 512B EEPROM, CAN
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc8209.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8209.pdf
 $ENDCMP
 #
 $CMP ATMEGA16U2-AU
 D TQFP-32, 16k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc7799.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc7799.pdf
 $ENDCMP
 #
 $CMP ATMEGA16U4-AU
 D TQFP44, 16K Flash, 1.25K SRAM, 512B EEPROM, USB2.0
 K AVR 8bit Microcontroller MegaAVR USB
-F http://www.atmel.com/images/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA16U4-MU
 D QFN44, 16K Flash, 1.25K SRAM, 512B EEPROM, USB2.0
 K AVR 8bit Microcontroller MegaAVR USB
-F http://www.atmel.com/images/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA16U4RC-AU
 D TQFP44, 16K Flash, 1.25K SRAM, 512B EEPROM, USB2.0, RC Osc
 K AVR 8bit Microcontroller MegaAVR USB
-F http://www.atmel.com/images/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA16U4RC-MU
 D QFN44, 16K Flash, 1.25K SRAM, 512B EEPROM, USB2.0, RC Osc
 K AVR 8bit Microcontroller MegaAVR USB
-F http://www.atmel.com/images/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA2560-16AU
 D TQFP100, 256k Flash, 8k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA2561-16AU
 D TQFP64, 256k Flash, 8k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA2561-16MU
 D MLF/QFN64, 256k Flash, 8k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA32-16AU
 D TQFP44, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2503.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2503.pdf
 $ENDCMP
 #
 $CMP ATMEGA32-16MU
 D QFN/MLF44, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2503.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2503.pdf
 $ENDCMP
 #
 $CMP ATMEGA32-16PU
 D PDIP40, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2503.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2503.pdf
 $ENDCMP
 #
 $CMP ATMEGA323-4AC
 D TQFP44, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc1457.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1457.pdf
 $ENDCMP
 #
 $CMP ATMEGA323-4PC
 D PDIP40, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc1457.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1457.pdf
 $ENDCMP
 #
 $CMP ATMEGA324A-AU
 D TQFP44, 32k Flash, 2k SRAM, 1K EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA324A-MU
 D VQFN44, 32k Flash, 2k SRAM, 1K EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA324A-PU
 D PDIP40, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA324P-20AU
 D TQFP44, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA324P-20MU
 D MLF/QFN44, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA324P-20PU
 D PDIP40, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA324PA-AU
 D TQFP44, 32k Flash, 2k SRAM, 1K EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA324PA-MU
 D VQFN44, 32k Flash, 2k SRAM, 1K EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA324PA-PU
 D PDIP40, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA325-16AU
 D TQFP64, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2570.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2570.pdf
 $ENDCMP
 #
 $CMP ATMEGA325-16MU
 D MLF/QFN64, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR 
-F http://www.atmel.com/Images/doc2570.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2570.pdf
 $ENDCMP
 #
 $CMP ATMEGA3250-16AU
 D TQFP100, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2570.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2570.pdf
 $ENDCMP
 #
 $CMP ATMEGA325A-AU
 D TQFP64, 32k Flash, 2k SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA325A-MU
 D QFN/MLF64, 32k Flash, 2k SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA325PA-AU
 D TQFP64, 32k Flash, 2k SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA325PA-MU
 D QFN/MLF64, 32k Flash, 2k SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA328-AU
 D TQFP32, 32k Flash, 2kB SRAM, 1kB EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA328-MMH
 D ATMEGA328A, QFN/MLF28, 32k Flash, 2kB SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA328-MU
 D QFN/MLF32, 32k Flash, 2kB SRAM, 1kB EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA328-PU
 D PDIP28 Narrow, 32k Flash, 2kB SRAM, 1kB EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA328P-AU
 D TQFP32, 32k Flash, 2kB SRAM, 1kB EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA328P-MMH
 D QFN/MLF28, 32k Flash, 2kB SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA328P-MU
 D QFN/MLF32, 32k Flash, 2kB SRAM, 1kB EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA328P-PU
 D PDIP28 Narrow, 32k Flash, 2kB SRAM, 1kB EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA328PB-AU
 D TQFP32, 32k Flash, 2kB SRAM, 1K EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-42397-8-bit-avr-microcontroller-atmega328pb_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-42397-8-bit-avr-microcontroller-atmega328pb_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA328PB-MU
 D VQFN32, Exposed Pad, 32k Flash, 2kB SRAM, 1K EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-42397-8-bit-avr-microcontroller-atmega328pb_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-42397-8-bit-avr-microcontroller-atmega328pb_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA329-16AU
 D TQFP64, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2552.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2552.pdf
 $ENDCMP
 #
 $CMP ATMEGA329-16MU
 D QFN/MLF64, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2552.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2552.pdf
 $ENDCMP
 #
 $CMP ATMEGA3290-16AU
 D TQFP100, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2552.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2552.pdf
 $ENDCMP
 #
 $CMP ATMEGA329A-AU
 D TQFP64, 32k Flash, 2k SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD PicoPower
-F http://www.atmel.com/images/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA329A-MU
 D ATMEGA329PA, QFN/MLF64, 32k Flash, 2k SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD PicoPower
-F http://www.atmel.com/images/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA329PA-AU
 D TQFP64, 32k Flash, 2k SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD PicoPower
-F http://www.atmel.com/images/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA329PA-MU
 D QFN/MLF64, 32k Flash, 2k SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD PicoPower
-F http://www.atmel.com/images/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA32A-AU
 D TQFP44, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8155-8-bit-microcontroller-avr-atmega32a_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8155-8-bit-microcontroller-avr-atmega32a_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA32A-MU
 D QFN/MLF44, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8155-8-bit-microcontroller-avr-atmega32a_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8155-8-bit-microcontroller-avr-atmega32a_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA32A-PU
 D PDIP40, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8155-8-bit-microcontroller-avr-atmega32a_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8155-8-bit-microcontroller-avr-atmega32a_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA32M1-AU
 D TQFP32, 32k Flash, 2k SRAM, 1kB EEPROM, CAN
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc8209.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8209.pdf
 $ENDCMP
 #
 $CMP ATMEGA32M1-MU
 D QFN32, 32k Flash, 2k SRAM, 1kB EEPROM, CAN
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc8209.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8209.pdf
 $ENDCMP
 #
 $CMP ATMEGA32U2-AU
 D TQFP-32, 32k Flash, 1024B SRAM, 1024B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc7799.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc7799.pdf
 $ENDCMP
 #
 $CMP ATMEGA32U4-AU
 D TQFP44, 32K Flash, 2.5K SRAM, 1K EEPROM, USB2.0
 K AVR 8bit Microcontroller MegaAVR USB
-F http://www.atmel.com/images/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA32U4-MU
 D QFN44, 32K Flash, 2.5K SRAM, 1K EEPROM, USB2.0
 K AVR 8bit Microcontroller MegaAVR USB
-F http://www.atmel.com/images/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA32U4RC-AU
 D TQFP44, 32K Flash, 2.5K SRAM, 1K EEPROM, USB2.0
 K AVR 8bit Microcontroller MegaAVR USB
-F http://www.atmel.com/images/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA32U4RC-MU
 D QFN44, 32K Flash, 2.5K SRAM, 1K EEPROM, USB2.0
 K AVR 8bit Microcontroller MegaAVR USB
-F http://www.atmel.com/images/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA48-20AU
 D TQFP32, 4k Flash, 256B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
 $ENDCMP
 #
 $CMP ATMEGA48-20MU
 D QFN/MLF32, 4k Flash, 256B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
 $ENDCMP
 #
 $CMP ATMEGA48-20PU
 D PDIP28 Narrow, 4k Flash, 256B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
 $ENDCMP
 #
 $CMP ATMEGA48A-AU
 D TQFP32, 4k Flash, 512B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA48A-MMH
 D QFN/MLF28, 4k Flash, 512B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA48A-MU
 D QFN/MLF32, 4k Flash, 512B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA48A-PU
 D PDIP28 Narrow, 4k Flash, 512B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA48PA-AU
 D TQFP32, 4k Flash, 512B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA48PA-MMH
 D QFN/MLF28, 4k Flash, 512B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA48PA-MU
 D QFN/MLF32, 4k Flash, 512B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA48PA-PU
 D PDIP28 Narrow, 4k Flash, 512B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA64-16AU
 D TQFP64, 64k Flash, 4k SRAM, 2k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-2490-8-bit-avr-microcontroller-atmega64-l_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2490-8-bit-avr-microcontroller-atmega64-l_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA64-16MU
 D QFN/MLF64, 64k Flash, 4k SRAM, 2k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-2490-8-bit-avr-microcontroller-atmega64-l_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2490-8-bit-avr-microcontroller-atmega64-l_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA640-16AU
 D TQFP100, 64k Flash, 8k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA644-20AU
 D TQFP44, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2593.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2593.pdf
 $ENDCMP
 #
 $CMP ATMEGA644-20MU
 D ATMEGA644A, QFN/MLF44, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2593.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2593.pdf
 $ENDCMP
 #
 $CMP ATMEGA644-20PU
 D PDIP40, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2593.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2593.pdf
 $ENDCMP
 #
 $CMP ATMEGA644A-AU
 D TQFP44, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA644A-MU
 D VQFN44, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA644A-PU
 D PDIP40, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA644P-20AU
 D TQFP44, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA644P-20MU
 D MLF/QFN44, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA644P-20PU
 D PDIP40, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA644PA-AU
 D TQFP44, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA644PA-MU
 D VQFN44, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA644PA-PU
 D PDIP40, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/Images/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8272-8-bit-AVR-microcontroller-ATmega164A_PA-324A_PA-644A_PA-1284_P_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA645-16AU
 D TQFP64, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR 
-F http://www.atmel.com/Images/doc2570.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2570.pdf
 $ENDCMP
 #
 $CMP ATMEGA645-16MU
 D MLF/QFN64, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR 
-F http://www.atmel.com/Images/doc2570.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2570.pdf
 $ENDCMP
 #
 $CMP ATMEGA6450-16AU
 D TQFP100, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2570.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2570.pdf
 $ENDCMP
 #
 $CMP ATMEGA645A-AU
 D TQFP64, 64k Flash, 4k SRAM, 2k EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA645A-MU
 D QFN/MLF64, 64k Flash, 4k SRAM, 2k EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA645P-AU
 D TQFP64, 64k Flash, 4k SRAM, 2k EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA645P-MU
 D QFN/MLF64, 64k Flash, 4k SRAM, 2k EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8285-8-bit-avr-microcontroller-atmega165a_pa_325a_pa_3250a_pa_645a_p_6450a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA649-16AU
 D TQFP64, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2552.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2552.pdf
 $ENDCMP
 #
 $CMP ATMEGA649-16MU
 D QFN/MLF64, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2552.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2552.pdf
 $ENDCMP
 #
 $CMP ATMEGA6490-16AU
 D TQFP100, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2552.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2552.pdf
 $ENDCMP
 #
 $CMP ATMEGA649A-AU
 D TQFP64, 64k Flash, 4k SRAM, 2k EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD PicoPower
-F http://www.atmel.com/images/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA649A-MU
 D QFN/MLF64, 64k Flash, 4k SRAM, 2k EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD PicoPower
-F http://www.atmel.com/images/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA649P-AU
 D TQFP64, 64k Flash, 4k SRAM, 2k EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD PicoPower
-F http://www.atmel.com/images/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA649P-MU
 D QFN/MLF64, 64k Flash, 4k SRAM, 2k EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD PicoPower
-F http://www.atmel.com/images/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA64A-AU
 D TQFP64, 64k Flash, 4k SRAM, 2k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8160-8-bit-avr-microcontroller-atmega64a-datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8160-8-bit-avr-microcontroller-atmega64a-datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA64A-MU
 D QFN/MLF64, 64k Flash, 4k SRAM, 2k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8160-8-bit-avr-microcontroller-atmega64a-datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8160-8-bit-avr-microcontroller-atmega64a-datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA64M1-AU
 D TQFP32, 64k Flash, 4k SRAM, 2kB EEPROM, CAN
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc8209.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8209.pdf
 $ENDCMP
 #
 $CMP ATMEGA64M1-MU
 D QFN32, 64k Flash, 4k SRAM, 2kB EEPROM, CAN
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc8209.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8209.pdf
 $ENDCMP
 #
 $CMP ATMEGA8-16AU
 D TQFP32, 8k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-2486-8-bit-avr-microcontroller-atmega8_l_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2486-8-bit-avr-microcontroller-atmega8_l_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA8-16MU
 D QFN/MLF32, 8k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-2486-8-bit-avr-microcontroller-atmega8_l_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2486-8-bit-avr-microcontroller-atmega8_l_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA8-16PU
 D PDIP28 Narrow, 8k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-2486-8-bit-avr-microcontroller-atmega8_l_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2486-8-bit-avr-microcontroller-atmega8_l_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA8515-16AU
 D TQFP44, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2512.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2512.pdf
 $ENDCMP
 #
 $CMP ATMEGA8515-16JU
 D PLCC44, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2512.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2512.pdf
 $ENDCMP
 #
 $CMP ATMEGA8515-16MU
 D QFN/MLF44, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2512.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2512.pdf
 $ENDCMP
 #
 $CMP ATMEGA8515-16PU
 D PDIP40, 8K Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2512.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2512.pdf
 $ENDCMP
 #
 $CMP ATMEGA8535-16AU
 D TQFP44, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2502.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2502.pdf
 $ENDCMP
 #
 $CMP ATMEGA8535-16JU
 D PLCC44, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2502.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2502.pdf
 $ENDCMP
 #
 $CMP ATMEGA8535-16MU
 D QFN/MLF44, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2502.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2502.pdf
 $ENDCMP
 #
 $CMP ATMEGA8535-16PU
 D PDIP40, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2502.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2502.pdf
 $ENDCMP
 #
 $CMP ATMEGA88-20AU
 D TQFP32, 8k Flash, 512B SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
 $ENDCMP
 #
 $CMP ATMEGA88-20MU
 D QFN/MLF32, 8k Flash, 512B SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
 $ENDCMP
 #
 $CMP ATMEGA88-20PU
 D PDIP28 Narrow, 8k Flash, 512B SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
 $ENDCMP
 #
 $CMP ATMEGA88A-AU
 D TQFP32, 8k Flash, 1kB SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA88A-MMH
 D QFN/MLF28, 8k Flash, 1kB SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA88A-MU
 D QFN/MLF32, 8k Flash, 1kB SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA88A-PU
 D PDIP28 Narrow, 8k Flash, 1kB SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA88PA-AU
 D TQFP32, 8k Flash, 1kB SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA88PA-MMH
 D QFN/MLF28, 8k Flash, 1kB SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA88PA-MU
 D QFN/MLF32, 8k Flash, 1kB SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA88PA-PU
 D PDIP28 Narrow, 8k Flash, 1kB SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://www.atmel.com/images/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA8A-AU
 D TQFP32, 8k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8159-8-bit-avr-microcontroller-atmega8a_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8159-8-bit-avr-microcontroller-atmega8a_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA8A-MU
 D QFN/MLF32, 8k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8159-8-bit-avr-microcontroller-atmega8a_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8159-8-bit-avr-microcontroller-atmega8a_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA8A-PU
 D PDIP28 Narrow, 8k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/images/atmel-8159-8-bit-avr-microcontroller-atmega8a_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8159-8-bit-avr-microcontroller-atmega8a_datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA8U2-AU
 D TQFP-32, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc7799.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc7799.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128A1-AU
 D TQFP100, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8067-8-and-16-bit-AVR-Microcontrollers-ATxmega64A1-ATxmega128A1_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8067-8-and-16-bit-AVR-Microcontrollers-ATxmega64A1-ATxmega128A1_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128A1U-AU
 D TQFP100, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, USB, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8385-8-and-16-bit-AVR-Microcontroller-ATxmega64A1U-ATxmega128A1U_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8385-8-and-16-bit-AVR-Microcontroller-ATxmega64A1U-ATxmega128A1U_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128A3-AU
 D TQFP64, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128A3-MH
 D QFN64, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128A3U-AU
 D TQFP64, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8386-8-and-16-bit-AVR-Microcontroller-ATxmega64A3U-128A3U-192A3U-256A3U_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8386-8-and-16-bit-AVR-Microcontroller-ATxmega64A3U-128A3U-192A3U-256A3U_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128A3U-MH
 D QFN64, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8386-8-and-16-bit-AVR-Microcontroller-ATxmega64A3U-128A3U-192A3U-256A3U_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8386-8-and-16-bit-AVR-Microcontroller-ATxmega64A3U-128A3U-192A3U-256A3U_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128A4-AU
 D TQFP44, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8069-8-and-16-bit-AVR-AMEGA-A4-Microcontrollers_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8069-8-and-16-bit-AVR-AMEGA-A4-Microcontrollers_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128A4-MH
 D VQFN44, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8069-8-and-16-bit-AVR-AMEGA-A4-Microcontrollers_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8069-8-and-16-bit-AVR-AMEGA-A4-Microcontrollers_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128A4U-AU
 D TQFP44, 128k Flash, 8k Boot, 2k SRAM, 1k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128A4U-MH
 D QFN44, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128B1-AU
 D TQFP100, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG, USB, LCD
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8330-8-and-16-bit-AVR-Microcontroller-XMEGA-B-ATxmega64B1-ATxmega128B1_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8330-8-and-16-bit-AVR-Microcontroller-XMEGA-B-ATxmega64B1-ATxmega128B1_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128B3-AU
 D TQFP64, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG, USB, LCD
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8074-8-and-16-bit-AVR-Microcontroller-XMEGA-B-ATxmega64B3-ATxmega128B3_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8074-8-and-16-bit-AVR-Microcontroller-XMEGA-B-ATxmega64B3-ATxmega128B3_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128B3-MH
 D QFN64, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG, USB, LCD
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8074-8-and-16-bit-AVR-Microcontroller-XMEGA-B-ATxmega64B3-ATxmega128B3_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8074-8-and-16-bit-AVR-Microcontroller-XMEGA-B-ATxmega64B3-ATxmega128B3_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128C3-AU
 D TQFP64, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8492-8-and-16-bit-AVR-microcontroller-ATxmega32C3_64C3_128C3_192C3_256C3_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8492-8-and-16-bit-AVR-microcontroller-ATxmega32C3_64C3_128C3_192C3_256C3_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128C3-MH
 D QFN64, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8492-8-and-16-bit-AVR-microcontroller-ATxmega32C3_64C3_128C3_192C3_256C3_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8492-8-and-16-bit-AVR-microcontroller-ATxmega32C3_64C3_128C3_192C3_256C3_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128D3-AU
 D TQFP64, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8134-8-16-bit-Atmel-XMEGA-D3-Microcontroller_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8134-8-16-bit-Atmel-XMEGA-D3-Microcontroller_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128D3-MH
 D QFN64, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8134-8-16-bit-Atmel-XMEGA-D3-Microcontroller_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8134-8-16-bit-Atmel-XMEGA-D3-Microcontroller_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128D4-AU
 D TQFP44, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8135-8-and-16-bit-AVR-microcontroller-ATxmega16D4-32D4-64D4-128D4_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8135-8-and-16-bit-AVR-microcontroller-ATxmega16D4-32D4-64D4-128D4_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA128D4-MH
 D VQFN44, 128k Flash, 8k Boot, 8k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8135-8-and-16-bit-AVR-microcontroller-ATxmega16D4-32D4-64D4-128D4_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8135-8-and-16-bit-AVR-microcontroller-ATxmega16D4-32D4-64D4-128D4_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA16A4-AU
 D TQFP44, 16k Flash, 4k Boot, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8069-8-and-16-bit-AVR-AMEGA-A4-Microcontrollers_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8069-8-and-16-bit-AVR-AMEGA-A4-Microcontrollers_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA16A4-MH
 D VQFN44, 16k Flash, 4k Boot, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8069-8-and-16-bit-AVR-AMEGA-A4-Microcontrollers_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8069-8-and-16-bit-AVR-AMEGA-A4-Microcontrollers_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA16A4U-AU
 D TQFP44, 16k Flash, 4k Boot, 2k SRAM, 1k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA16A4U-MH
 D QFN44, 16k Flash, 4k Boot, 2k SRAM, 1k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA16C4-AU
 D TQFP44, 16k Flash, 4k Boot, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8493-8-and-32-bit-AVR-XMEGA-Microcontrollers-ATxmega16C4-ATxmega32C4_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8493-8-and-32-bit-AVR-XMEGA-Microcontrollers-ATxmega16C4-ATxmega32C4_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA16C4-MH
 D VQFN44, 16k Flash, 4k Boot, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8493-8-and-32-bit-AVR-XMEGA-Microcontrollers-ATxmega16C4-ATxmega32C4_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8493-8-and-32-bit-AVR-XMEGA-Microcontrollers-ATxmega16C4-ATxmega32C4_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA16D4-AU
 D TQFP44, 16k Flash, 4k Boot, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8135-8-and-16-bit-AVR-microcontroller-ATxmega16D4-32D4-64D4-128D4_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8135-8-and-16-bit-AVR-microcontroller-ATxmega16D4-32D4-64D4-128D4_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA16D4-MH
 D VQFN44, 16k Flash, 4k Boot, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8135-8-and-16-bit-AVR-microcontroller-ATxmega16D4-32D4-64D4-128D4_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8135-8-and-16-bit-AVR-microcontroller-ATxmega16D4-32D4-64D4-128D4_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA16E5-AU
 D TQFP32, 16k Flash, 4k Boot, 2k SRAM, 512B EEPROM
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA16E5-M4U
 D UQFN32, 16k Flash, 4k Boot, 2k SRAM, 512B EEPROM
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA16E5-MU
 D VQFN32, 16k Flash, 4k Boot, 2k SRAM, 512B EEPROM
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA192A1-AU
 D TQFP100, 192k Flash, 8k Boot, 16k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8067-8-and-16-bit-AVR-Microcontrollers-ATxmega64A1-ATxmega128A1_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8067-8-and-16-bit-AVR-Microcontrollers-ATxmega64A1-ATxmega128A1_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA192A3-AU
 D TQFP64, 192k Flash, 8k Boot, 16k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA192A3-MH
 D QFN64, 192k Flash, 8k Boot, 16k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA192A3U-AU
 D TQFP64, 192k Flash, 8k Boot, 16k SRAM, 2k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8386-8-and-16-bit-AVR-Microcontroller-ATxmega64A3U-128A3U-192A3U-256A3U_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8386-8-and-16-bit-AVR-Microcontroller-ATxmega64A3U-128A3U-192A3U-256A3U_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA192A3U-MH
 D QFN64, 192k Flash, 8k Boot, 16k SRAM, 2k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8386-8-and-16-bit-AVR-Microcontroller-ATxmega64A3U-128A3U-192A3U-256A3U_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8386-8-and-16-bit-AVR-Microcontroller-ATxmega64A3U-128A3U-192A3U-256A3U_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA192C3-AU
 D TQFP64, 192k Flash, 8k Boot, 16k SRAM, 2k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8492-8-and-16-bit-AVR-microcontroller-ATxmega32C3_64C3_128C3_192C3_256C3_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8492-8-and-16-bit-AVR-microcontroller-ATxmega32C3_64C3_128C3_192C3_256C3_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA192C3-MH
 D QFN64, 192k Flash, 8k Boot, 16k SRAM, 2k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8492-8-and-16-bit-AVR-microcontroller-ATxmega32C3_64C3_128C3_192C3_256C3_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8492-8-and-16-bit-AVR-microcontroller-ATxmega32C3_64C3_128C3_192C3_256C3_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA192D3-AU
 D TQFP64, 192k Flash, 8k Boot, 16k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8134-8-16-bit-Atmel-XMEGA-D3-Microcontroller_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8134-8-16-bit-Atmel-XMEGA-D3-Microcontroller_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA192D3-MH
 D QFN64, 192k Flash, 8k Boot, 16k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8134-8-16-bit-Atmel-XMEGA-D3-Microcontroller_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8134-8-16-bit-Atmel-XMEGA-D3-Microcontroller_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA256A1-AU
 D TQFP100, 256k Flash, 8k Boot, 16k SRAM, 4k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8067-8-and-16-bit-AVR-Microcontrollers-ATxmega64A1-ATxmega128A1_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8067-8-and-16-bit-AVR-Microcontrollers-ATxmega64A1-ATxmega128A1_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA256A3-AU
 D TQFP64, 256k Flash, 8k Boot, 16k SRAM, 4k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA256A3-MH
 D ATXMEGA128A3, QFN64, 256k Flash, 8k Boot, 16k SRAM, 4k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA256A3B-AU
 D TQFP64, 256k Flash, 8k Boot, 16k SRAM, 4k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8116-8-and-16-bit-AVR-XMEGA-A3B-Microcontroller_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8116-8-and-16-bit-AVR-XMEGA-A3B-Microcontroller_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA256A3B-MH
 D MLF/QFN64, 256k Flash, 8k Boot, 16k SRAM, 4k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8116-8-and-16-bit-AVR-XMEGA-A3B-Microcontroller_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8116-8-and-16-bit-AVR-XMEGA-A3B-Microcontroller_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA256A3BU-AU
 D TQFP64, 256k Flash, 8k Boot, 16k SRAM, 4k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8362-8-and-16bit-AVR-microcontroller-ATxmega256A3BU_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8362-8-and-16bit-AVR-microcontroller-ATxmega256A3BU_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA256A3BU-MH
 D QFN64, 256k Flash, 8k Boot, 16k SRAM, 4k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8362-8-and-16bit-AVR-microcontroller-ATxmega256A3BU_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8362-8-and-16bit-AVR-microcontroller-ATxmega256A3BU_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA256A3U-AU
 D TQFP64, 256k Flash, 8k Boot, 16k SRAM, 4k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8386-8-and-16-bit-AVR-Microcontroller-ATxmega64A3U-128A3U-192A3U-256A3U_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8386-8-and-16-bit-AVR-Microcontroller-ATxmega64A3U-128A3U-192A3U-256A3U_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA256A3U-MH
 D QFN64, 256k Flash, 8k Boot, 16k SRAM, 4k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8386-8-and-16-bit-AVR-Microcontroller-ATxmega64A3U-128A3U-192A3U-256A3U_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8386-8-and-16-bit-AVR-Microcontroller-ATxmega64A3U-128A3U-192A3U-256A3U_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA256C3-AU
 D TQFP64, 256k Flash, 8k Boot, 16k SRAM, 4k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8492-8-and-16-bit-AVR-microcontroller-ATxmega32C3_64C3_128C3_192C3_256C3_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8492-8-and-16-bit-AVR-microcontroller-ATxmega32C3_64C3_128C3_192C3_256C3_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA256C3-MH
 D QFN64, 256k Flash, 8k Boot, 16k SRAM, 4k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8492-8-and-16-bit-AVR-microcontroller-ATxmega32C3_64C3_128C3_192C3_256C3_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8492-8-and-16-bit-AVR-microcontroller-ATxmega32C3_64C3_128C3_192C3_256C3_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA256D3-AU
 D TQFP64, 256k Flash, 8k Boot, 16k SRAM, 4k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8134-8-16-bit-Atmel-XMEGA-D3-Microcontroller_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8134-8-16-bit-Atmel-XMEGA-D3-Microcontroller_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA256D3-MH
 D QFN64, 256k Flash, 8k Boot, 16k SRAM, 4k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8134-8-16-bit-Atmel-XMEGA-D3-Microcontroller_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8134-8-16-bit-Atmel-XMEGA-D3-Microcontroller_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA32A4-AU
 D TQFP44, 32k Flash, 4k Boot, 4k SRAM, 1k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8069-8-and-16-bit-AVR-AMEGA-A4-Microcontrollers_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8069-8-and-16-bit-AVR-AMEGA-A4-Microcontrollers_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA32A4-MH
 D VQFN44, 32k Flash, 4k Boot, 4k SRAM, 1k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8069-8-and-16-bit-AVR-AMEGA-A4-Microcontrollers_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8069-8-and-16-bit-AVR-AMEGA-A4-Microcontrollers_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA32A4U-AU
 D ATXMEGA16A4U, TQFP44, 32k Flash, 4k Boot, 4k SRAM, 1k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA32A4U-MH
 D QFN44, 32k Flash, 4k Boot, 4k SRAM, 1k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA32C4-AU
 D TQFP44, 32k Flash, 4k Boot, 4k SRAM, 1k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8493-8-and-32-bit-AVR-XMEGA-Microcontrollers-ATxmega16C4-ATxmega32C4_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8493-8-and-32-bit-AVR-XMEGA-Microcontrollers-ATxmega16C4-ATxmega32C4_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA32C4-MH
 D VQFN44, 32k Flash, 4k Boot, 4k SRAM, 1k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8493-8-and-32-bit-AVR-XMEGA-Microcontrollers-ATxmega16C4-ATxmega32C4_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8493-8-and-32-bit-AVR-XMEGA-Microcontrollers-ATxmega16C4-ATxmega32C4_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA32D4-AU
 D TQFP44, 32k Flash, 4k Boot, 4k SRAM, 1k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8135-8-and-16-bit-AVR-microcontroller-ATxmega16D4-32D4-64D4-128D4_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8135-8-and-16-bit-AVR-microcontroller-ATxmega16D4-32D4-64D4-128D4_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA32D4-MH
 D VQFN44, 32k Flash, 4k Boot, 4k SRAM, 1k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8135-8-and-16-bit-AVR-microcontroller-ATxmega16D4-32D4-64D4-128D4_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8135-8-and-16-bit-AVR-microcontroller-ATxmega16D4-32D4-64D4-128D4_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA32E5-AU
 D TQFP32, 32k Flash, 4k Boot, 4k SRAM, 1k EEPROM
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA32E5-M4U
 D UQFN32, 32k Flash, 4k Boot, 4k SRAM, 1k EEPROM
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA32E5-MU
 D VQFN32, 32k Flash, 4k Boot, 4k SRAM, 1k EEPROM
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA384A1-AU
 D ATXMEGA128A1, TQFP100, 384k Flash, 8k Boot, 32k SRAM, 4k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8067-8-and-16-bit-AVR-Microcontrollers-ATxmega64A1-ATxmega128A1_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8067-8-and-16-bit-AVR-Microcontrollers-ATxmega64A1-ATxmega128A1_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64A1-AU
 D TQFP100, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8067-8-and-16-bit-AVR-Microcontrollers-ATxmega64A1-ATxmega128A1_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8067-8-and-16-bit-AVR-Microcontrollers-ATxmega64A1-ATxmega128A1_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64A1U-AU
 D TQFP100, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, USB, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8385-8-and-16-bit-AVR-Microcontroller-ATxmega64A1U-ATxmega128A1U_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8385-8-and-16-bit-AVR-Microcontroller-ATxmega64A1U-ATxmega128A1U_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64A3-AU
 D TQFP64, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64A3-MH
 D QFN64, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64A3U-AU
 D TQFP64, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8386-8-and-16-bit-AVR-Microcontroller-ATxmega64A3U-128A3U-192A3U-256A3U_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8386-8-and-16-bit-AVR-Microcontroller-ATxmega64A3U-128A3U-192A3U-256A3U_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64A3U-MH
 D QFN64, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8386-8-and-16-bit-AVR-Microcontroller-ATxmega64A3U-128A3U-192A3U-256A3U_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8386-8-and-16-bit-AVR-Microcontroller-ATxmega64A3U-128A3U-192A3U-256A3U_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64A4-AU
 D TQFP44, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8069-8-and-16-bit-AVR-AMEGA-A4-Microcontrollers_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8069-8-and-16-bit-AVR-AMEGA-A4-Microcontrollers_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64A4-MH
 D VQFN44, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8069-8-and-16-bit-AVR-AMEGA-A4-Microcontrollers_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8069-8-and-16-bit-AVR-AMEGA-A4-Microcontrollers_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64A4U-AU
 D TQFP44, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64A4U-MH
 D QFN44, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64B1-AU
 D TQFP100, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG, USB, LCD
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8330-8-and-16-bit-AVR-Microcontroller-XMEGA-B-ATxmega64B1-ATxmega128B1_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8330-8-and-16-bit-AVR-Microcontroller-XMEGA-B-ATxmega64B1-ATxmega128B1_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64B3-AU
 D TQFP64, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG, USB, LCD
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8074-8-and-16-bit-AVR-Microcontroller-XMEGA-B-ATxmega64B3-ATxmega128B3_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8074-8-and-16-bit-AVR-Microcontroller-XMEGA-B-ATxmega64B3-ATxmega128B3_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64B3-MH
 D QFN64, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG, USB, LCD
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8074-8-and-16-bit-AVR-Microcontroller-XMEGA-B-ATxmega64B3-ATxmega128B3_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8074-8-and-16-bit-AVR-Microcontroller-XMEGA-B-ATxmega64B3-ATxmega128B3_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64C3-AU
 D TQFP64, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8492-8-and-16-bit-AVR-microcontroller-ATxmega32C3_64C3_128C3_192C3_256C3_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8492-8-and-16-bit-AVR-microcontroller-ATxmega32C3_64C3_128C3_192C3_256C3_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64C3-MH
 D QFN64, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8492-8-and-16-bit-AVR-microcontroller-ATxmega32C3_64C3_128C3_192C3_256C3_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8492-8-and-16-bit-AVR-microcontroller-ATxmega32C3_64C3_128C3_192C3_256C3_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64D3-AU
 D TQFP64, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8134-8-16-bit-Atmel-XMEGA-D3-Microcontroller_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8134-8-16-bit-Atmel-XMEGA-D3-Microcontroller_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64D3-MH
 D QFN64, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8134-8-16-bit-Atmel-XMEGA-D3-Microcontroller_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8134-8-16-bit-Atmel-XMEGA-D3-Microcontroller_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64D4-AU
 D TQFP44, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8135-8-and-16-bit-AVR-microcontroller-ATxmega16D4-32D4-64D4-128D4_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8135-8-and-16-bit-AVR-microcontroller-ATxmega16D4-32D4-64D4-128D4_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA64D4-MH
 D VQFN44, 64k Flash, 4k Boot, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8135-8-and-16-bit-AVR-microcontroller-ATxmega16D4-32D4-64D4-128D4_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8135-8-and-16-bit-AVR-microcontroller-ATxmega16D4-32D4-64D4-128D4_datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA8E5-AU
 D TQFP32, 8k Flash, 2k Boot, 1k SRAM, 512B EEPROM
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA8E5-M4U
 D UQFN32, 8k Flash, 2k Boot, 1k SRAM, 512B EEPROM
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATXMEGA8E5-MU
 D VQFN32, 8k Flash, 2k Boot, 1k SRAM, 512B EEPROM
 K AVR 8/16bit Microcontroller XMegaAVR
-F http://www.atmel.com/Images/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8153-8-and-16-bit-AVR-Microcontroller-XMEGA-E-ATxmega8E5-ATxmega16E5-ATxmega32E5_Datasheet.pdf
 $ENDCMP
 #
 #End Doc Library

--- a/MCU_Atmel_ATTINY.dcm
+++ b/MCU_Atmel_ATTINY.dcm
@@ -3,721 +3,721 @@ EESchema-DOCLIB  Version 2.0
 $CMP ATTINY10-P
 D DIP8, 1k OTP Flash, No SRAM, 64B EEPROM (For reference only)
 K AVR 8-bit Microcontroller tinyAVR Discontinued
-F http://www.atmel.com/Images/doc1006.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1006.pdf
 $ENDCMP
 #
 $CMP ATTINY10-S
 D SO8, 1k OTP FLash, No SRAM, 64B EEPROM (For reference only)
 K AVR 8-bit Microcontroller tinyAVR Discontinued
-F http://www.atmel.com/Images/doc1006.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1006.pdf
 $ENDCMP
 #
 $CMP ATTINY10-TS
 D SOT-23-6, 1k Flash, 32B SRAM, No EEPROM, ADC
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-8127-avr-8-bit-microcontroller-attiny4-attiny5-attiny9-attiny10_datasheet-summary.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8127-avr-8-bit-microcontroller-attiny4-attiny5-attiny9-attiny10_datasheet-summary.pdf
 $ENDCMP
 #
 $CMP ATTINY11-6PC
 D PDIP8, 1k Flash, No SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc1006.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1006.pdf
 $ENDCMP
 #
 $CMP ATTINY11-6SC
 D SO8 Wide, 1k Flash, No SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc1006.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1006.pdf
 $ENDCMP
 #
 $CMP ATTINY12-4PC
 D PDIP8, 1k Flash, No SRAM, 64B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc1006.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1006.pdf
 $ENDCMP
 #
 $CMP ATTINY12-4SC
 D SO8 Wide, 1k Flash, No SRAM, 64B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc1006.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1006.pdf
 $ENDCMP
 #
 $CMP ATTINY13-20MMU
 D QFN/MLF10, 1k Flash, 64B SRAM, 64B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc2535.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2535.pdf
 $ENDCMP
 #
 $CMP ATTINY13-20MU
 D QFN/MLF20, 1k Flash, 64B SRAM, 64B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc2535.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2535.pdf
 $ENDCMP
 #
 $CMP ATTINY13-20PU
 D PDIP8, 1k Flash, 64B SRAM, 64B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc2535.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2535.pdf
 $ENDCMP
 #
 $CMP ATTINY13-20SSU
 D SO8, 1k Flash, 64B SRAM, 64B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc2535.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2535.pdf
 $ENDCMP
 #
 $CMP ATTINY13-20SU
 D SO8 Wide, 1k Flash, 64B SRAM, 64B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc2535.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2535.pdf
 $ENDCMP
 #
 $CMP ATTINY13A-MMF
 D QFN/MLF10, 1k Flash, 64B SRAM, 64B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8126.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8126.pdf
 $ENDCMP
 #
 $CMP ATTINY13A-MU
 D QFN/MLF20, 1k Flash, 64B SRAM, 64B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8126.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8126.pdf
 $ENDCMP
 #
 $CMP ATTINY13A-PU
 D PDIP8, 1k Flash, 64B SRAM, 64B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8126.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8126.pdf
 $ENDCMP
 #
 $CMP ATTINY13A-SSU
 D SO8, 1k Flash, 64B SRAM, 64B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8126.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8126.pdf
 $ENDCMP
 #
 $CMP ATTINY13A-SU
 D SO8 Wide, 1k Flash, 64B SRAM, 64B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8126.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8126.pdf
 $ENDCMP
 #
 $CMP ATTINY15-1PC
 D PDIP8, 1k Flash, No SRAM, 64B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc1187.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1187.pdf
 $ENDCMP
 #
 $CMP ATTINY15-1SC
 D SO8 Wide, 1k Flash, No SRAM, 64B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc1187.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1187.pdf
 $ENDCMP
 #
 $CMP ATTINY1634-MN
 D QFN/MLF20, 16k Flash, 1k SRAM, 256B EEPROM, ADC, ACI, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/Atmel-8303-8-bit-AVR-Microcontroller-tinyAVR-ATtiny1634_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8303-8-bit-AVR-Microcontroller-tinyAVR-ATtiny1634_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY1634-MU
 D QFN/MLF20, 16k Flash, 1k SRAM, 256B EEPROM, ADC, ACI, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/Atmel-8303-8-bit-AVR-Microcontroller-tinyAVR-ATtiny1634_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8303-8-bit-AVR-Microcontroller-tinyAVR-ATtiny1634_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY1634-SU
 D SOIC20, 16k Flash, 1k SRAM, 256B EEPROM, ADC, ACI, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/Atmel-8303-8-bit-AVR-Microcontroller-tinyAVR-ATtiny1634_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8303-8-bit-AVR-Microcontroller-tinyAVR-ATtiny1634_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY167-MU
 D MLF32, 16k Flash, 512B SRAM, 512B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR Automotive
-F http://www.atmel.com/Images/Atmel-8265-8-bit-AVR-Microcontroller-tinyAVR-ATtiny87-ATtiny167_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8265-8-bit-AVR-Microcontroller-tinyAVR-ATtiny87-ATtiny167_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY167-SU
 D SO20, 16k Flash, 512B SRAM, 512B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR Automotive
-F http://www.atmel.com/Images/Atmel-8265-8-bit-AVR-Microcontroller-tinyAVR-ATtiny87-ATtiny167_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8265-8-bit-AVR-Microcontroller-tinyAVR-ATtiny87-ATtiny167_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY167-XU
 D TSSOP20, 16k Flash, 512B SRAM, 512B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR Automotive
-F http://www.atmel.com/Images/Atmel-8265-8-bit-AVR-Microcontroller-tinyAVR-ATtiny87-ATtiny167_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8265-8-bit-AVR-Microcontroller-tinyAVR-ATtiny87-ATtiny167_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY20-MMH
 D VQFN20, 2k Flash, 128B SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-8235-8-bit-avr-microcontroller-attiny20_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8235-8-bit-avr-microcontroller-attiny20_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY20-SSU
 D S014, 2k Flash, 128B SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-8235-8-bit-avr-microcontroller-attiny20_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8235-8-bit-avr-microcontroller-attiny20_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY20-XU
 D TSS0P14, 2k Flash, 128B SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-8235-8-bit-avr-microcontroller-attiny20_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8235-8-bit-avr-microcontroller-attiny20_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY22-8PC
 D PDIP8, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc1273.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1273.pdf
 $ENDCMP
 #
 $CMP ATTINY22-8SC
 D SO8 Wide, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc1273.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1273.pdf
 $ENDCMP
 #
 $CMP ATTINY2313-20MU
 D MLF20, 2k Flash, 128B SRAM, 128B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc2543.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2543.pdf
 $ENDCMP
 #
 $CMP ATTINY2313-20PU
 D PDIP20, 2k Flash, 128B SRAM, 128B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc2543.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2543.pdf
 $ENDCMP
 #
 $CMP ATTINY2313-20SU
 D SO20, 2k Flash, 128B SRAM, 128B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc2543.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2543.pdf
 $ENDCMP
 #
 $CMP ATTINY2313A-PU
 D PDIP20, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8246.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8246.pdf
 $ENDCMP
 #
 $CMP ATTINY2313A-SU
 D SO20, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8246.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8246.pdf
 $ENDCMP
 #
 $CMP ATTINY24-20MU
 D QFN/MLF20, 2k Flash, 128B SRAM, 128B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8006.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8006.pdf
 $ENDCMP
 #
 $CMP ATTINY24-20PU
 D PDIP14, 2k Flash, 128B SRAM, 128B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8006.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8006.pdf
 $ENDCMP
 #
 $CMP ATTINY24-20SSU
 D SO14, 2k Flash, 128B SRAM, 128B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8006.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8006.pdf
 $ENDCMP
 #
 $CMP ATTINY24A-MMH
 D VQFN20, 2k Flash, 128B SRAM, 128B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8183.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8183.pdf
 $ENDCMP
 #
 $CMP ATTINY24A-MU
 D QFN/MLF20, 2k Flash, 128B SRAM, 128B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8183.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8183.pdf
 $ENDCMP
 #
 $CMP ATTINY24A-PU
 D PDIP14, 2k Flash, 128B SRAM, 128B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8183.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8183.pdf
 $ENDCMP
 #
 $CMP ATTINY24A-SSU
 D SO14, 2k Flash, 128B SRAM, 128B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8183.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8183.pdf
 $ENDCMP
 #
 $CMP ATTINY25-20MU
 D QFN/MLF20, 2k Flash, 128B SRAM, 128B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY25-20PU
 D PDIP8, 2k Flash, 128B SRAM, 128B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY25-20SSU
 D SO8, 2k Flash, 128B SRAM, 128B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY25-20SU
 D SO8 Wide, 2k Flash, 128B SRAM, 128B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY26-16MU
 D QFN/MLF32, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc1477.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1477.pdf
 $ENDCMP
 #
 $CMP ATTINY26-16PU
 D PDIP20, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc1477.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1477.pdf
 $ENDCMP
 #
 $CMP ATTINY26-16SU
 D SO20, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc1477.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1477.pdf
 $ENDCMP
 #
 $CMP ATTINY261-20MU
 D QFN/MLF32, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY261-20PU
 D PDIP20, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY261-20SU
 D PDIP20, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY261A-MU
 D QFN/MLF32, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8197.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8197.pdf
 $ENDCMP
 #
 $CMP ATTINY261A-PU
 D PDIP20, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8197.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8197.pdf
 $ENDCMP
 #
 $CMP ATTINY261A-SU
 D SO20, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8197.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8197.pdf
 $ENDCMP
 #
 $CMP ATTINY261A-XU
 D TSSOP20, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8197.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8197.pdf
 $ENDCMP
 #
 $CMP ATTINY28-AU
 D TQFP32, 2k Flash, No SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR IR
-F http://www.atmel.com/Images/doc1062.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1062.pdf
 $ENDCMP
 #
 $CMP ATTINY28-MU
 D MLF/QFN32, 2k Flash, No SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR IR
-F http://www.atmel.com/Images/doc1062.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1062.pdf
 $ENDCMP
 #
 $CMP ATTINY28-PU
 D PDIP28 Narrow, 2k Flash, No SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR IR
-F http://www.atmel.com/Images/doc1062.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1062.pdf
 $ENDCMP
 #
 $CMP ATTINY4-TS
 D SOT-23-6, 512B Flash, 32B SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-8127-avr-8-bit-microcontroller-attiny4-attiny5-attiny9-attiny10_datasheet-summary.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8127-avr-8-bit-microcontroller-attiny4-attiny5-attiny9-attiny10_datasheet-summary.pdf
 $ENDCMP
 #
 $CMP ATTINY40-MMH
 D MLF/VQFN20, 4k Flash, 256B SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-8263-8-bit-avr-microcontroller-tinyavr-attiny40_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8263-8-bit-avr-microcontroller-tinyavr-attiny40_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY40-SU
 D S020 Wide, 4k Flash, 256B SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-8263-8-bit-avr-microcontroller-tinyavr-attiny40_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8263-8-bit-avr-microcontroller-tinyavr-attiny40_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY40-XU
 D TSS0P20, 4k Flash, 256B SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-8263-8-bit-avr-microcontroller-tinyavr-attiny40_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8263-8-bit-avr-microcontroller-tinyavr-attiny40_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY4313-PU
 D PDIP20, 4k Flash, 256B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8246.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8246.pdf
 $ENDCMP
 #
 $CMP ATTINY4313-SU
 D SO20, 4k Flash, 256B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8246.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8246.pdf
 $ENDCMP
 #
 $CMP ATTINY43U-MU
 D MLF/QFN20, 4k Flash, 256B SRAM, 64B EEPROM
 K AVR 8bit Microcontroller tinyAVR Battery Boost
-F http://www.atmel.com/Images/doc8048.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8048.pdf
 $ENDCMP
 #
 $CMP ATTINY43U-SU
 D SO20, 4k Flash, 256B SRAM, 64B EEPROM
 K AVR 8bit Microcontroller tinyAVR Battery Boost
-F http://www.atmel.com/Images/doc8048.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8048.pdf
 $ENDCMP
 #
 $CMP ATTINY44-20MU
 D QFN/MLF20, 4k Flash, 256B SRAM, 256B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8006.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8006.pdf
 $ENDCMP
 #
 $CMP ATTINY44-20PU
 D PDIP14, 4k Flash, 256B SRAM, 256B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8006.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8006.pdf
 $ENDCMP
 #
 $CMP ATTINY44-20SSU
 D SO14, 4k Flash, 256B SRAM, 128B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8006.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8006.pdf
 $ENDCMP
 #
 $CMP ATTINY441-MMH
 D WQFN20, 4k Flash, 256B SRAM, 256B EEPROM, ADC, ACI, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/Atmel-8495-8-bit-AVR-Microcontrollers-ATtiny441-ATtiny841_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8495-8-bit-AVR-Microcontrollers-ATtiny441-ATtiny841_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY441-MU
 D MLF/QFN20, 4k Flash, 256B SRAM, 256B EEPROM, ADC, ACI, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/Atmel-8495-8-bit-AVR-Microcontrollers-ATtiny441-ATtiny841_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8495-8-bit-AVR-Microcontrollers-ATtiny441-ATtiny841_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY441-SSU
 D SO14, 4k Flash, 256B SRAM, 256B EEPROM, ADC, ACI, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/Atmel-8495-8-bit-AVR-Microcontrollers-ATtiny441-ATtiny841_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8495-8-bit-AVR-Microcontrollers-ATtiny441-ATtiny841_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY44A-MMH
 D VQFN20, 4k Flash, 256B SRAM, 256B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8183.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8183.pdf
 $ENDCMP
 #
 $CMP ATTINY44A-MU
 D QFN/MLF20, 4k Flash, 256B SRAM, 256B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8183.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8183.pdf
 $ENDCMP
 #
 $CMP ATTINY44A-PU
 D PDIP14, 4k Flash, 256B SRAM, 256B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8183.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8183.pdf
 $ENDCMP
 #
 $CMP ATTINY44A-SSU
 D SO14, 4k Flash, 256B SRAM, 256B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8183.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8183.pdf
 $ENDCMP
 #
 $CMP ATTINY45-20MU
 D ATTINY25, QFN/MLF20, 4k Flash, 256B SRAM, 256B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY45-20PU
 D PDIP8, 4k Flash, 256B SRAM, 256B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY45-20SU
 D SO8 Wide, 4k Flash, 256B SRAM, 256B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY461-20MU
 D QFN/MLF32, 4k Flash, 256B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY461-20PU
 D PDIP20, 4k Flash, 256B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY461-20SU
 D PDIP20, 4k Flash, 256B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY461A-MU
 D QFN/MLF32, 4k Flash, 256B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8197.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8197.pdf
 $ENDCMP
 #
 $CMP ATTINY461A-PU
 D PDIP20, 4k Flash, 256B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8197.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8197.pdf
 $ENDCMP
 #
 $CMP ATTINY461A-SU
 D SO20, 4k Flash, 256B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8197.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8197.pdf
 $ENDCMP
 #
 $CMP ATTINY461A-XU
 D TSSOP20, 4k Flash, 256B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8197.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8197.pdf
 $ENDCMP
 #
 $CMP ATTINY48-AU
 D TQFP32, 4k Flash, 256B SRAM, 64B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8008.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8008.pdf
 $ENDCMP
 #
 $CMP ATTINY48-MMH
 D QFN/MLF28, 4k Flash, 256B SRAM, 64B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8008.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8008.pdf
 $ENDCMP
 #
 $CMP ATTINY48-MU
 D QFN/MLF32, 4k Flash, 256B SRAM, 64B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8008.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8008.pdf
 $ENDCMP
 #
 $CMP ATTINY48-PU
 D PDIP28 Narrow, 4k Flash, 256B SRAM, 64B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8008.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8008.pdf
 $ENDCMP
 #
 $CMP ATTINY5-TS
 D SOT-23-6, 512B Flash, 32B SRAM, No EEPROM, ADC
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-8127-avr-8-bit-microcontroller-attiny4-attiny5-attiny9-attiny10_datasheet-summary.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8127-avr-8-bit-microcontroller-attiny4-attiny5-attiny9-attiny10_datasheet-summary.pdf
 $ENDCMP
 #
 $CMP ATTINY84-20MU
 D QFN/MLF20, 8k Flash, 512B SRAM, 512B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8006.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8006.pdf
 $ENDCMP
 #
 $CMP ATTINY84-20PU
 D PDIP14, 8k Flash, 512B SRAM, 512B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8006.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8006.pdf
 $ENDCMP
 #
 $CMP ATTINY84-20SSU
 D SO14, 8k Flash, 512B SRAM, 128B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8006.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8006.pdf
 $ENDCMP
 #
 $CMP ATTINY841-MMH
 D WQFN20, 8k Flash, 512B SRAM, 512B EEPROM, ADC, ACI, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/Atmel-8495-8-bit-AVR-Microcontrollers-ATtiny441-ATtiny841_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8495-8-bit-AVR-Microcontrollers-ATtiny441-ATtiny841_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY841-MU
 D MLF/QFN20, 8k Flash, 512B SRAM, 512B EEPROM, ADC, ACI, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/Atmel-8495-8-bit-AVR-Microcontrollers-ATtiny441-ATtiny841_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8495-8-bit-AVR-Microcontrollers-ATtiny441-ATtiny841_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY841-SSU
 D SO14, 8k Flash, 512B SRAM, 512B EEPROM, ADC, ACI, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/Atmel-8495-8-bit-AVR-Microcontrollers-ATtiny441-ATtiny841_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8495-8-bit-AVR-Microcontrollers-ATtiny441-ATtiny841_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY84A-MMH
 D VQFN20, 8k Flash, 512B SRAM, 512B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8183.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8183.pdf
 $ENDCMP
 #
 $CMP ATTINY84A-MU
 D QFN/MLF20, 8k Flash, 512B SRAM, 512B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8183.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8183.pdf
 $ENDCMP
 #
 $CMP ATTINY84A-PU
 D PDIP14, 8k Flash, 512B SRAM, 512B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8183.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8183.pdf
 $ENDCMP
 #
 $CMP ATTINY84A-SSU
 D SO14, 8k Flash, 512B SRAM, 512B EEPROM, dW
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8183.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8183.pdf
 $ENDCMP
 #
 $CMP ATTINY85-20MU
 D ATTINY25, QFN/MLF20, 8k Flash, 512B SRAM, 512B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY85-20PU
 D ATTINY85, PDIP8, 8k Flash, 512B SRAM, 512B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY85-20SU
 D ATTINY85, SO8 Wide, 8k Flash, 512B SRAM, 512B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY861-20MU
 D QFN/MLF32, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY861-20PU
 D PDIP20, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY861-20SU
 D PDIP20, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2588-8-bit-avr-microcontrollers-tinyavr-attiny261-attiny461-attiny861_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY861A-MU
 D QFN/MLF32, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8197.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8197.pdf
 $ENDCMP
 #
 $CMP ATTINY861A-PU
 D PDIP20, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8197.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8197.pdf
 $ENDCMP
 #
 $CMP ATTINY861A-SU
 D SO20, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8197.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8197.pdf
 $ENDCMP
 #
 $CMP ATTINY861A-XU
 D TSSOP20, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8197.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8197.pdf
 $ENDCMP
 #
 $CMP ATTINY87-MU
 D MLF32, 8k Flash, 512B SRAM, 512B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR Automotive
-F http://www.atmel.com/Images/Atmel-8265-8-bit-AVR-Microcontroller-tinyAVR-ATtiny87-ATtiny167_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8265-8-bit-AVR-Microcontroller-tinyAVR-ATtiny87-ATtiny167_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY87-SU
 D S020, 8k Flash, 512B SRAM, 512B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR Automotive
-F http://www.atmel.com/Images/Atmel-8265-8-bit-AVR-Microcontroller-tinyAVR-ATtiny87-ATtiny167_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8265-8-bit-AVR-Microcontroller-tinyAVR-ATtiny87-ATtiny167_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY87-XU
 D TSSOP20, 8k Flash, 512B SRAM, 512B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR Automotive
-F http://www.atmel.com/Images/Atmel-8265-8-bit-AVR-Microcontroller-tinyAVR-ATtiny87-ATtiny167_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8265-8-bit-AVR-Microcontroller-tinyAVR-ATtiny87-ATtiny167_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY88-AU
 D TQFP32, 8k Flash, 512B SRAM, 64B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8008.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8008.pdf
 $ENDCMP
 #
 $CMP ATTINY88-MMH
 D QFN/MLF28, 8k Flash, 512B SRAM, 64B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8008.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8008.pdf
 $ENDCMP
 #
 $CMP ATTINY88-MU
 D QFN/MLF32, 8k Flash, 512B SRAM, 64B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8008.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8008.pdf
 $ENDCMP
 #
 $CMP ATTINY88-PU
 D PDIP28 Narrow, 8k Flash, 512B SRAM, 64B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/Images/doc8008.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8008.pdf
 $ENDCMP
 #
 $CMP ATTINY9-TS
 D SOT-23-6, 1024B Flash, 32B SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://www.atmel.com/images/atmel-8127-avr-8-bit-microcontroller-attiny4-attiny5-attiny9-attiny10_datasheet-summary.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8127-avr-8-bit-microcontroller-attiny4-attiny5-attiny9-attiny10_datasheet-summary.pdf
 $ENDCMP
 #
 #End Doc Library

--- a/MCU_Atmel_AVR.dcm
+++ b/MCU_Atmel_AVR.dcm
@@ -3,217 +3,217 @@ EESchema-DOCLIB  Version 2.0
 $CMP AT90CAN128-16AU
 D 128k Flash, 4k SRAM, 4k EEPROM, JTAG, CAN, TQFP64
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc7679.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc7679.pdf
 $ENDCMP
 #
 $CMP AT90CAN128-16MU
 D 128k Flash, 4k SRAM, 4k EEPROM, JTAG, CAN, QFN64
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc7679.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc7679.pdf
 $ENDCMP
 #
 $CMP AT90CAN32-16AU
 D 32k Flash, 2k SRAM, 1k EEPROM, JTAG, CAN, TQFP64
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc7679.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc7679.pdf
 $ENDCMP
 #
 $CMP AT90CAN32-16MU
 D 32k Flash, 2k SRAM, 1k EEPROM, JTAG, CAN, QFN64
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc7679.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc7679.pdf
 $ENDCMP
 #
 $CMP AT90CAN64-16AU
 D 64k Flash, 4k SRAM, 2k EEPROM, JTAG, CAN, TQFP64
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc7679.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc7679.pdf
 $ENDCMP
 #
 $CMP AT90CAN64-16MU
 D 64k Flash, 4k SRAM, 2k EEPROM, JTAG, CAN, QFN64
 K AVR 8bit Microcontroller MegaAVR
-F http://www.atmel.com/Images/doc7679.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc7679.pdf
 $ENDCMP
 #
 $CMP AT90PWM1-16MU
 D QFN/MLF32, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller LightingAVR PWM
-F http://www.atmel.com/Images/doc4378.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc4378.pdf
 $ENDCMP
 #
 $CMP AT90PWM1-16SU
 D SO24, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller LightingAVR PWM
-F http://www.atmel.com/Images/doc4378.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc4378.pdf
 $ENDCMP
 #
 $CMP AT90S1200-4PC
 D PDIP20, 1k Flash, No SRAM, 64B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc0838.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0838.pdf
 $ENDCMP
 #
 $CMP AT90S1200-4SC
 D SO20, 1k Flash, No SRAM, 64B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc0838.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0838.pdf
 $ENDCMP
 #
 $CMP AT90S1200-4YC
 D SSOP20, 1k Flash, No SRAM, 64B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc0838.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0838.pdf
 $ENDCMP
 #
 $CMP AT90S2313-4PC
 D PDIP20, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc0839.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0839.pdf
 $ENDCMP
 #
 $CMP AT90S2313-4SC
 D SO20, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc0839.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0839.pdf
 $ENDCMP
 #
 $CMP AT90S2323-4PC
 D AT90S/LS2323, PDIP8, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc1004.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1004.pdf
 $ENDCMP
 #
 $CMP AT90S2323-4SC
 D AT90S/LS2323, SO8 Wide, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc1004.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1004.pdf
 $ENDCMP
 #
 $CMP AT90S2333-4AC
 D AT90S4433, TQFP32, 2k Flash, 128B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc1042.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1042.pdf
 $ENDCMP
 #
 $CMP AT90S2333-4PC
 D PDIP28 Narrow, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc1042.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1042.pdf
 $ENDCMP
 #
 $CMP AT90S2343-4PC
 D AT90S/LS2343, PDIP8, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc1004.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1004.pdf
 $ENDCMP
 #
 $CMP AT90S2343-4SC
 D AT90S/LS2343, SO8 Wide, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc1004.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1004.pdf
 $ENDCMP
 #
 $CMP AT90S4414-4AC
 D TQFP44, 4k Flash, 256B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc0841.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0841.pdf
 $ENDCMP
 #
 $CMP AT90S4414-4JC
 D PLCC44, 4k Flash, 256B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc0841.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0841.pdf
 $ENDCMP
 #
 $CMP AT90S4414-4PC
 D PDIP40, 4k Flash, 256B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc0841.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0841.pdf
 $ENDCMP
 #
 $CMP AT90S4433-8AC
 D TQFP32, 4k Flash, 128B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc1042.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1042.pdf
 $ENDCMP
 #
 $CMP AT90S4433-8PC
 D PDIP28 Narrow, 4k Flash, 128B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc1042.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1042.pdf
 $ENDCMP
 #
 $CMP AT90S4434-4AC
 D TQFP44, 4k Flash, 256B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc1041.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1041.pdf
 $ENDCMP
 #
 $CMP AT90S4434-4JC
 D PLCC44, 4k Flash, 256B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc1041.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1041.pdf
 $ENDCMP
 #
 $CMP AT90S4434-4PC
 D PDIP40, 4k Flash, 256B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc1041.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1041.pdf
 $ENDCMP
 #
 $CMP AT90S8515-4AC
 D TQFP44, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc0841.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0841.pdf
 $ENDCMP
 #
 $CMP AT90S8515-4JC
 D PLCC44, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc0841.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0841.pdf
 $ENDCMP
 #
 $CMP AT90S8515-4PC
 D PDIP40, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc0841.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0841.pdf
 $ENDCMP
 #
 $CMP AT90S8535-8AC
 D TQFP44, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc1041.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1041.pdf
 $ENDCMP
 #
 $CMP AT90S8535-8JC
 D PLCC44, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc1041.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1041.pdf
 $ENDCMP
 #
 $CMP AT90S8535-8PC
 D PDIP40, 8k Flash, 512B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
-F http://www.atmel.com/Images/doc1041.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1041.pdf
 $ENDCMP
 #
 $CMP AT90USB162-16AU
 D TQFP32, 16k Flash, 512B SRAM, 512B EEPROM, USB 2.0
 K AVR 8bit Microcontroller USB
-F http://www.atmel.com/Images/doc7707.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc7707.pdf
 $ENDCMP
 #
 $CMP AT90USB162-16MU
 D QFN/MLF32, 16k Flash, 512B SRAM, 512B EEPROM, USB 2.0
 K AVR 8bit Microcontroller USB
-F http://www.atmel.com/Images/doc7707.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc7707.pdf
 $ENDCMP
 #
 $CMP AT90USB82-16MU
 D QFN/MLF32, 8k Flash, 512B SRAM, 512B EEPROM, USB 2.0
 K AVR 8bit Microcontroller USB
-F http://www.atmel.com/Images/doc7707.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc7707.pdf
 $ENDCMP
 #
 #End Doc Library

--- a/Memory_EEPROM.dcm
+++ b/Memory_EEPROM.dcm
@@ -198,163 +198,163 @@ $ENDCMP
 $CMP AT24CS01-MAHM
 D 1Kb (128x8) Serial EEPROM with Unique Serial Number, UDFN8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS01-SSHM
 D 1Kb (128x8) Serial EEPROM with Unique Serial Number, SO8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS01-STUM
 D 1Kb (128x8) Serial EEPROM with Unique Serial Number, SOT-23-5
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS01-XHM
 D 1Kb (128x8) Serial EEPROM with Unique Serial Number, TSSOP8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS02-MAHM
 D 2Kb (256x8) Serial EEPROM with Unique Serial Number, UDFN8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS02-SSHM
 D 2Kb (256x8) Serial EEPROM with Unique Serial Number, SO8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS02-STUM
 D 2Kb (256x8) Serial EEPROM with Unique Serial Number, SOT-23-5
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS02-XHM
 D 2Kb (256x8) Serial EEPROM with Unique Serial Number, TSSOP8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8815-SEEPROM-AT24CS01-02-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS04-MAHM
 D 4Kb (512x8) Serial EEPROM with Unique Serial Number, UDFN8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8766-SEEPROM-AT24CS04-08-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8766-SEEPROM-AT24CS04-08-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS04-SSHM
 D 4Kb (512x8) Serial EEPROM with Unique Serial Number, SO8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8766-SEEPROM-AT24CS04-08-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8766-SEEPROM-AT24CS04-08-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS04-STUM
 D 4Kb (512x8) Serial EEPROM with Unique Serial Number, SOT-23-5
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8766-SEEPROM-AT24CS04-08-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8766-SEEPROM-AT24CS04-08-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS04-XHM
 D 4Kb (512x8) Serial EEPROM with Unique Serial Number, TSSOP8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8766-SEEPROM-AT24CS04-08-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8766-SEEPROM-AT24CS04-08-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS08-MAHM
 D 8Kb (1024x8) Serial EEPROM with Unique Serial Number, UDFN8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8766-SEEPROM-AT24CS04-08-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8766-SEEPROM-AT24CS04-08-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS08-SSHM
 D 8Kb (1024x8) Serial EEPROM with Unique Serial Number, SO8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8766-SEEPROM-AT24CS04-08-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8766-SEEPROM-AT24CS04-08-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS08-STUM
 D 8Kb (1024x8) Serial EEPROM with Unique Serial Number, SOT-23-5
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8766-SEEPROM-AT24CS04-08-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8766-SEEPROM-AT24CS04-08-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS08-XHM
 D 8Kb (1024x8) Serial EEPROM with Unique Serial Number, TSSOP8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8766-SEEPROM-AT24CS04-08-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8766-SEEPROM-AT24CS04-08-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS16-MAHM
 D 16Kb (2048x8) Serial EEPROM with Unique Serial Number, UDFN8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8859-SEEPROM-AT24CS16-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8859-SEEPROM-AT24CS16-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS16-SSHM
 D 16Kb (2048x8) Serial EEPROM with Unique Serial Number, SO8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8859-SEEPROM-AT24CS16-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8859-SEEPROM-AT24CS16-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS16-STUM
 D 16Kb (2048x8) Serial EEPROM with Unique Serial Number, SOT-23-5
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8859-SEEPROM-AT24CS16-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8859-SEEPROM-AT24CS16-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS16-XHM
 D 16Kb (2048x8) Serial EEPROM with Unique Serial Number, TSSOP8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8859-SEEPROM-AT24CS16-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8859-SEEPROM-AT24CS16-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS32-MAHM
 D 32Kb (4096x8) Serial EEPROM with Unique Serial Number, UDFN8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8869-SEEPROM-AT24CS32-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8869-SEEPROM-AT24CS32-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS32-SSHM
 D 32Kb (4096x8) Serial EEPROM with Unique Serial Number, SO8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8869-SEEPROM-AT24CS32-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8869-SEEPROM-AT24CS32-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS32-STUM
 D 32Kb (4096x8) Serial EEPROM with Unique Serial Number, SOT-23-5
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8869-SEEPROM-AT24CS32-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8869-SEEPROM-AT24CS32-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS32-XHM
 D 32Kb (4096x8) Serial EEPROM with Unique Serial Number, TSSOP8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8869-SEEPROM-AT24CS32-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8869-SEEPROM-AT24CS32-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS64-MAHM
 D 64Kb (8192x8) Serial EEPROM with Unique Serial Number, UDFN8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8870-SEEPROM-AT24CS64-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8870-SEEPROM-AT24CS64-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS64-SSHM
 D 64Kb (8192x8) Serial EEPROM with Unique Serial Number, SO8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8870-SEEPROM-AT24CS64-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8870-SEEPROM-AT24CS64-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT24CS64-XHM
 D 64Kb (8192x8) Serial EEPROM with Unique Serial Number, TSSOP8
 K I2C Serial EEPROM Nonvolatile Memory
-F http://www.atmel.com/Images/Atmel-8870-SEEPROM-AT24CS64-Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8870-SEEPROM-AT24CS64-Datasheet.pdf
 $ENDCMP
 #
 $CMP AT25_EEPROM

--- a/Memory_Flash.dcm
+++ b/Memory_Flash.dcm
@@ -23,43 +23,43 @@ $ENDCMP
 $CMP AT45DB161-JC
 D 16Mb Serial DataFlash, PLCC32, Vcc=2.7V
 K Atmel DataFlash
-F http://www.atmel.com/Images/doc0807.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0807.pdf
 $ENDCMP
 #
 $CMP AT45DB161-RC
 D 16Mb Serial DataFlash, SOIC28, Vcc=2.7V
 K Atmel DataFlash
-F http://www.atmel.com/Images/doc0807.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0807.pdf
 $ENDCMP
 #
 $CMP AT45DB161-TC
 D 16Mb Serial DataFlash, TSSOP28, Vcc=2.7V
 K Atmel DataFlash
-F http://www.atmel.com/Images/doc0807.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0807.pdf
 $ENDCMP
 #
 $CMP AT45DB161B-RC
 D 16Mb Serial DataFlash, SOIC28, Vcc=2.7V
 K Atmel DataFlash
-F http://www.atmel.com/Images/doc2224.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2224.pdf
 $ENDCMP
 #
 $CMP AT45DB161B-RC-2.5
 D 16Mb Serial DataFlash, SOIC28, Vcc=2.5V
 K Atmel DataFlash
-F http://www.atmel.com/Images/doc2224.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2224.pdf
 $ENDCMP
 #
 $CMP AT45DB161B-TC
 D 16Mb Serial DataFlash, TSSOP28, Vcc=2.7V
 K Atmel DataFlash
-F http://www.atmel.com/Images/doc2224.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2224.pdf
 $ENDCMP
 #
 $CMP AT45DB161B-TC-2.5
 D 16Mb Serial DataFlash, TSSOP28, Vcc=2.5V
 K Atmel DataFlash
-F http://www.atmel.com/Images/doc2224.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2224.pdf
 $ENDCMP
 #
 $CMP M25PX32-VMP

--- a/Sensor_Touch.dcm
+++ b/Sensor_Touch.dcm
@@ -3,13 +3,13 @@ EESchema-DOCLIB  Version 2.0
 $CMP AT42QT1010-TSHR
 D Single-key Touch Sensor, SOT-23-6
 K Touch QTouch Sensor Key
-F http://www.atmel.com/Images/Atmel-9541-AT42-QTouch-BSW-AT42QT1010_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-9541-AT42-QTouch-BSW-AT42QT1010_Datasheet.pdf
 $ENDCMP
 #
 $CMP AT42QT1011-TSHR
 D Single-key Touch Sensor, SOT-23-6
 K Touch QTouch Sensor Key
-F http://www.atmel.com/Images/Atmel-9542-AT42-QTouch-BSW-AT42QT1011_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-9542-AT42-QTouch-BSW-AT42QT1011_Datasheet.pdf
 $ENDCMP
 #
 $CMP CY8CMBR3002


### PR DESCRIPTION
all atmel documentation has been moved to microchip. The old links just point to the microchip main page, instead the documentation is now availabe on the microchip page. All links were translated from
`http://www.atmel.com/[iI]mages` to `http://ww1.microchip.com/downloads/en/DeviceDoc`.
I have tested some random datasheets from different series and they all appear to work.