### PR TITLE
Revert lib version updates for some libs. Again.

### DIFF
--- a/Amplifier_Operational.lib
+++ b/Amplifier_Operational.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # ADA4807-1

--- a/Battery_Management.lib
+++ b/Battery_Management.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # AS8506C

--- a/Connector_Specialized.lib
+++ b/Connector_Specialized.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # 4P4C

--- a/Device.lib
+++ b/Device.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # Amperemeter_AC

--- a/Diode_Bridge.lib
+++ b/Diode_Bridge.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # ABS2

--- a/Driver_Motor.lib
+++ b/Driver_Motor.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # A4950E

--- a/Interface.lib
+++ b/Interface.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # 8237

--- a/Interface_UART.lib
+++ b/Interface_UART.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # 16450

--- a/Jumper.lib
+++ b/Jumper.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # Jumper_2_Bridged

--- a/MCU_Intel.lib
+++ b/MCU_Intel.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # 8035

--- a/MCU_Module.lib
+++ b/MCU_Module.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # Adafruit_HUZZAH_ESP8266_breakout

--- a/Memory_NVRAM.lib
+++ b/Memory_NVRAM.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # FM16W08-SG

--- a/Memory_RAM.lib
+++ b/Memory_RAM.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # 2130

--- a/Power_Protection.lib
+++ b/Power_Protection.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # CM1213A-01SO

--- a/RF.lib
+++ b/RF.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # CC1000

--- a/RF_AM_FM.lib
+++ b/RF_AM_FM.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # RFM69HW

--- a/RF_Bluetooth.lib
+++ b/RF_Bluetooth.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # BL652

--- a/RF_GPS.lib
+++ b/RF_GPS.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # RXM-GPS-RM

--- a/RF_RFID.lib
+++ b/RF_RFID.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # HTRC11001T

--- a/RF_WiFi.lib
+++ b/RF_WiFi.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # ESP-12E

--- a/RF_ZigBee.lib
+++ b/RF_ZigBee.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # CC2520

--- a/Regulator_Linear.lib
+++ b/Regulator_Linear.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # ADP7142AUZJ

--- a/Relay.lib
+++ b/Relay.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # AZ850-x

--- a/Sensor.lib
+++ b/Sensor.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # ADE7758

--- a/Sensor_Optical.lib
+++ b/Sensor_Optical.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # A1050

--- a/Sensor_Proximity.lib
+++ b/Sensor_Proximity.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # BPR-205

--- a/Timer.lib
+++ b/Timer.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # 8284

--- a/Transistor_BJT.lib
+++ b/Transistor_BJT.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # 2N2219

--- a/Transistor_FET.lib
+++ b/Transistor_FET.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # 2N7000

--- a/Transistor_IGBT.lib
+++ b/Transistor_IGBT.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # IRG4PF50W

--- a/Video.lib
+++ b/Video.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # AD725

--- a/legacy/maxim.lib
+++ b/legacy/maxim.lib
@@ -1,4 +1,4 @@
-EESchema-LIBRARY Version 2.4
+EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
 # DS1621


### PR DESCRIPTION
Some libs have again been stored using a recent nightly. This creates problems for everyone using older versions. (dcm file content gets invisible for some reason.)

I reverted the lib version header for all libs that had problems.