### PR TITLE
FET remove spaces

### DIFF
--- a/Transistor_FET.dcm
+++ b/Transistor_FET.dcm
@@ -961,7 +961,7 @@ F http://www.irf.com/product-info/datasheets/data/irf7343ipbf.pdf
 $ENDCMP
 #
 $CMP IRF740
-D MOSFET, N Channel, 10A, 400V, 0.5ohm
+D MOSFET, N Channel, 10A, 400V, 0.5ohm, TO-220AB
 K N Channel
 F http://www.vishay.com/docs/91054/91054.pdf
 $ENDCMP

--- a/Transistor_FET.dcm
+++ b/Transistor_FET.dcm
@@ -961,7 +961,7 @@ F http://www.irf.com/product-info/datasheets/data/irf7343ipbf.pdf
 $ENDCMP
 #
 $CMP IRF740
-D MOSFET, N Channel, 10A, 400V, 0.5ohm, TO-220AB
+D 10A Id, 400V Vds, N-Channel Power MOSFET, 0.5Ohm Rds, TO-220AB
 K N Channel
 F http://www.vishay.com/docs/91054/91054.pdf
 $ENDCMP

--- a/Transistor_FET.dcm
+++ b/Transistor_FET.dcm
@@ -961,7 +961,7 @@ F http://www.irf.com/product-info/datasheets/data/irf7343ipbf.pdf
 $ENDCMP
 #
 $CMP IRF740
-D MOSFET, N Channel, 10A, 400V, 0.5 ohm
+D MOSFET, N Channel, 10A, 400V, 0.5ohm
 K N Channel
 F http://www.vishay.com/docs/91054/91054.pdf
 $ENDCMP

--- a/Transistor_FET.dcm
+++ b/Transistor_FET.dcm
@@ -307,7 +307,7 @@ F https://www.infineon.com/dgdl/Infineon-BSP129-DS-v01_42-en.pdf?fileId=db3a3043
 $ENDCMP
 #
 $CMP BSS138
-D 50V Vds, 0.22 A Id, N-channel MOSFET, SOT-23
+D 50V Vds, 0.22A Id, N-channel MOSFET, SOT-23
 K N-Channel MOSFET
 F https://www.fairchildsemi.com/datasheets/BS/BSS138.pdf
 $ENDCMP
@@ -961,7 +961,7 @@ F http://www.irf.com/product-info/datasheets/data/irf7343ipbf.pdf
 $ENDCMP
 #
 $CMP IRF740
-D MOSFET, N Channel, 10 A, 400 V, 0.5 ohm
+D MOSFET, N Channel, 10A, 400V, 0.5 ohm
 K N Channel
 F http://www.vishay.com/docs/91054/91054.pdf
 $ENDCMP

--- a/Transistor_FET.dcm
+++ b/Transistor_FET.dcm
@@ -961,7 +961,7 @@ F http://www.irf.com/product-info/datasheets/data/irf7343ipbf.pdf
 $ENDCMP
 #
 $CMP IRF740
-D 10A Id, 400V Vds, N-Channel Power MOSFET, 0.5Ohm Rds, TO-220AB
+D 10A Id, 400V Vds, N-Channel Power MOSFET, 500mOhm Rds, TO-220AB
 K N Channel
 F http://www.vishay.com/docs/91054/91054.pdf
 $ENDCMP


### PR DESCRIPTION
Remove spaces before A,  V and ohm in two component descriptions and added package name.

------------
Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the symbol(s) you are contributing
- [ ] An example screenshot image is very helpful
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
