### PR TITLE
Fix Atmel MCU DCMs

### DIFF
--- a/MCU_Atmel_ATMEGA.dcm
+++ b/MCU_Atmel_ATMEGA.dcm
@@ -69,13 +69,13 @@ $ENDCMP
 $CMP ATMEGA128A-AU
 D TQFP64, 128k Flash, 4k SRAM, 4k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8151.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8151-8-bit-AVR-ATmega128A_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA128A-MU
 D MLF/QFN64, 128k Flash, 4k SRAM, 4k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8151.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8151-8-bit-AVR-ATmega128A_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA16-16AU
@@ -111,19 +111,19 @@ $ENDCMP
 $CMP ATMEGA162-16AU
 D TQFP44, 16k Flash, 1K SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2513-8-bit-avr-microntroller-atmega162_datasheet-summary.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2513-8-bit-AVR-Microntroller-ATmega162_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA162-16MU
 D QFN/MLF44, 16k Flash, 1K SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2513-8-bit-avr-microntroller-atmega162_datasheet-summary.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2513-8-bit-AVR-Microntroller-ATmega162_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA162-16PU
 D PDIP40, 16k Flash, 1K SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2513-8-bit-avr-microntroller-atmega162_datasheet-summary.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2513-8-bit-AVR-Microntroller-ATmega162_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA163-4AC
@@ -159,19 +159,19 @@ $ENDCMP
 $CMP ATMEGA164P-20AU
 D TQFP44, 16k Flash, 1k SRAM, 512k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-42742-ATmega164P_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA164P-20MU
 D MLF/QFN44, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-42742-ATmega164P_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA164P-20PU
 D PDIP40, 16k Flash, 1k SRAM, 512k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-42742-ATmega164P_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA164PA-AU
@@ -243,19 +243,19 @@ $ENDCMP
 $CMP ATMEGA168-20AU
 D TQFP32, 16k Flash, 512B SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2545-8-bit-AVR-Microcontroller-ATmega48-88-168_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA168-20MU
 D QFN/MLF32, 16k Flash, 512B SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2545-8-bit-AVR-Microcontroller-ATmega48-88-168_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA168-20PU
 D PDIP28 Narrow, 16k Flash, 512B SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2545-8-bit-AVR-Microcontroller-ATmega48-88-168_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA168A-AU
@@ -357,31 +357,31 @@ $ENDCMP
 $CMP ATMEGA16A-AU
 D TQFP44, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8154.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8154-8-bit-AVR-ATmega16A_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA16A-MU
 D QFN/MLF44, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8154.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8154-8-bit-AVR-ATmega16A_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA16A-PU
 D PDIP40, 16k Flash, 1k SRAM, 512B EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8154.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8154-8-bit-AVR-ATmega16A_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA16M1-AU
 D TQFP32, 16k Flash, 1k SRAM, 512B EEPROM, CAN
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8209.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8209-8-bit%20AVR%20ATmega16M1-32M1-64M1_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA16M1-MU
 D QFN32, 16k Flash, 1k SRAM, 512B EEPROM, CAN
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8209.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8209-8-bit%20AVR%20ATmega16M1-32M1-64M1_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA16U2-AU
@@ -393,25 +393,25 @@ $ENDCMP
 $CMP ATMEGA16U4-AU
 D TQFP44, 16K Flash, 1.25K SRAM, 512B EEPROM, USB2.0
 K AVR 8bit Microcontroller MegaAVR USB
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7766-8-bit-AVR-ATmega16U4-32U4_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA16U4-MU
 D QFN44, 16K Flash, 1.25K SRAM, 512B EEPROM, USB2.0
 K AVR 8bit Microcontroller MegaAVR USB
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7766-8-bit-AVR-ATmega16U4-32U4_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA16U4RC-AU
 D TQFP44, 16K Flash, 1.25K SRAM, 512B EEPROM, USB2.0, RC Osc
 K AVR 8bit Microcontroller MegaAVR USB
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7766-8-bit-AVR-ATmega16U4-32U4_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA16U4RC-MU
 D QFN44, 16K Flash, 1.25K SRAM, 512B EEPROM, USB2.0, RC Osc
 K AVR 8bit Microcontroller MegaAVR USB
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7766-8-bit-AVR-ATmega16U4-32U4_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA2560-16AU
@@ -483,19 +483,19 @@ $ENDCMP
 $CMP ATMEGA324P-20AU
 D TQFP44, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-42743-ATmega324P_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA324P-20MU
 D MLF/QFN44, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-42743-ATmega324P_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA324P-20PU
 D PDIP40, 32k Flash, 2k SRAM, 1k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-42743-ATmega324P_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA324PA-AU
@@ -609,13 +609,13 @@ $ENDCMP
 $CMP ATMEGA328PB-AU
 D TQFP32, 32k Flash, 2kB SRAM, 1K EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-42397-8-bit-avr-microcontroller-atmega328pb_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/40001906C.pdf
 $ENDCMP
 #
 $CMP ATMEGA328PB-MU
 D VQFN32, Exposed Pad, 32k Flash, 2kB SRAM, 1K EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-42397-8-bit-avr-microcontroller-atmega328pb_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/40001906C.pdf
 $ENDCMP
 #
 $CMP ATMEGA329-16AU
@@ -681,13 +681,13 @@ $ENDCMP
 $CMP ATMEGA32M1-AU
 D TQFP32, 32k Flash, 2k SRAM, 1kB EEPROM, CAN
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8209.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8209-8-bit%20AVR%20ATmega16M1-32M1-64M1_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA32M1-MU
 D QFN32, 32k Flash, 2k SRAM, 1kB EEPROM, CAN
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8209.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8209-8-bit%20AVR%20ATmega16M1-32M1-64M1_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA32U2-AU
@@ -699,43 +699,43 @@ $ENDCMP
 $CMP ATMEGA32U4-AU
 D TQFP44, 32K Flash, 2.5K SRAM, 1K EEPROM, USB2.0
 K AVR 8bit Microcontroller MegaAVR USB
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7766-8-bit-AVR-ATmega16U4-32U4_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA32U4-MU
 D QFN44, 32K Flash, 2.5K SRAM, 1K EEPROM, USB2.0
 K AVR 8bit Microcontroller MegaAVR USB
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7766-8-bit-AVR-ATmega16U4-32U4_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA32U4RC-AU
 D TQFP44, 32K Flash, 2.5K SRAM, 1K EEPROM, USB2.0
 K AVR 8bit Microcontroller MegaAVR USB
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7766-8-bit-AVR-ATmega16U4-32U4_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA32U4RC-MU
 D QFN44, 32K Flash, 2.5K SRAM, 1K EEPROM, USB2.0
 K AVR 8bit Microcontroller MegaAVR USB
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-7766-8-bit-avr-atmega16u4-32u4_%20datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7766-8-bit-AVR-ATmega16U4-32U4_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA48-20AU
 D TQFP32, 4k Flash, 256B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2545-8-bit-AVR-Microcontroller-ATmega48-88-168_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA48-20MU
 D QFN/MLF32, 4k Flash, 256B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2545-8-bit-AVR-Microcontroller-ATmega48-88-168_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA48-20PU
 D PDIP28 Narrow, 4k Flash, 256B SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2545-8-bit-AVR-Microcontroller-ATmega48-88-168_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA48A-AU
@@ -843,19 +843,19 @@ $ENDCMP
 $CMP ATMEGA644P-20AU
 D TQFP44, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-42744-ATmega644P_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA644P-20MU
 D MLF/QFN44, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-42744-ATmega644P_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA644P-20PU
 D PDIP40, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR PicoPower
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8011-8-bit-avr-microcontroller-atmega164p-324p-644p_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-42744-ATmega644P_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA644PA-AU
@@ -975,13 +975,13 @@ $ENDCMP
 $CMP ATMEGA64M1-AU
 D TQFP32, 64k Flash, 4k SRAM, 2kB EEPROM, CAN
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8209.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8209-8-bit%20AVR%20ATmega16M1-32M1-64M1_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA64M1-MU
 D QFN32, 64k Flash, 4k SRAM, 2kB EEPROM, CAN
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8209.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8209-8-bit%20AVR%20ATmega16M1-32M1-64M1_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA8-16AU
@@ -1053,19 +1053,19 @@ $ENDCMP
 $CMP ATMEGA88-20AU
 D TQFP32, 8k Flash, 512B SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2545-8-bit-AVR-Microcontroller-ATmega48-88-168_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA88-20MU
 D QFN/MLF32, 8k Flash, 512B SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2545-8-bit-AVR-Microcontroller-ATmega48-88-168_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA88-20PU
 D PDIP28 Narrow, 8k Flash, 512B SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2545.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2545-8-bit-AVR-Microcontroller-ATmega48-88-168_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATMEGA88A-AU
@@ -1119,19 +1119,19 @@ $ENDCMP
 $CMP ATMEGA8A-AU
 D TQFP32, 8k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8159-8-bit-avr-microcontroller-atmega8a_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Microchip%208bit%20mcu%20AVR%20ATmega8A%20data%20sheet%2040001974A.pdf
 $ENDCMP
 #
 $CMP ATMEGA8A-MU
 D QFN/MLF32, 8k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8159-8-bit-avr-microcontroller-atmega8a_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Microchip%208bit%20mcu%20AVR%20ATmega8A%20data%20sheet%2040001974A.pdf
 $ENDCMP
 #
 $CMP ATMEGA8A-PU
 D PDIP28 Narrow, 8k Flash, 1k SRAM, 512B EEPROM
 K AVR 8bit Microcontroller MegaAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8159-8-bit-avr-microcontroller-atmega8a_datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Microchip%208bit%20mcu%20AVR%20ATmega8A%20data%20sheet%2040001974A.pdf
 $ENDCMP
 #
 $CMP ATMEGA8U2-AU

--- a/MCU_Atmel_ATMEGA.dcm
+++ b/MCU_Atmel_ATMEGA.dcm
@@ -18,6 +18,12 @@ K AVR 8bit Microcontroller MegaAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
 $ENDCMP
 #
+$CMP ATMEGA1280-8AU
+D TQFP100, 128k Flash, 8k SRAM, 4k EEPROM, JTAG
+K AVR 8bit Microcontroller MegaAVR
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
+$ENDCMP
+#
 $CMP ATMEGA1281-16AU
 D TQFP64, 128k Flash, 8k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
@@ -25,6 +31,18 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcont
 $ENDCMP
 #
 $CMP ATMEGA1281-16MU
+D MLF/QFN64, 128k Flash, 8k SRAM, 4k EEPROM, JTAG
+K AVR 8bit Microcontroller MegaAVR
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
+$ENDCMP
+#
+$CMP ATMEGA1281-8AU
+D TQFP64, 128k Flash, 8k SRAM, 4k EEPROM, JTAG
+K AVR 8bit Microcontroller MegaAVR
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
+$ENDCMP
+#
+$CMP ATMEGA1281-8MU
 D MLF/QFN64, 128k Flash, 8k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
@@ -420,6 +438,12 @@ K AVR 8bit Microcontroller MegaAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
 $ENDCMP
 #
+$CMP ATMEGA2560-8AU
+D TQFP100, 256k Flash, 8k SRAM, 4k EEPROM, JTAG
+K AVR 8bit Microcontroller MegaAVR
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
+$ENDCMP
+#
 $CMP ATMEGA2561-16AU
 D TQFP64, 256k Flash, 8k SRAM, 4k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
@@ -565,7 +589,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcont
 $ENDCMP
 #
 $CMP ATMEGA328-MMH
-D ATMEGA328A, QFN/MLF28, 32k Flash, 2kB SRAM, 1k EEPROM
+D QFN/MLF28, 32k Flash, 2kB SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8271-8-bit-avr-microcontroller-atmega48a-48pa-88a-88pa-168a-168pa-328-328p_datasheet.pdf
 $ENDCMP
@@ -643,7 +667,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8284-8-bit-avr-microcont
 $ENDCMP
 #
 $CMP ATMEGA329A-MU
-D ATMEGA329PA, QFN/MLF64, 32k Flash, 2k SRAM, 1k EEPROM
+D QFN/MLF64, 32k Flash, 2k SRAM, 1k EEPROM
 K AVR 8bit Microcontroller MegaAVR LCD PicoPower
 F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8284-8-bit-avr-microcontroller-atmega169a_pa_329a_pa_3290a_pa_649a_p_6490a_p_datasheet.pdf
 $ENDCMP
@@ -804,6 +828,12 @@ K AVR 8bit Microcontroller MegaAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
 $ENDCMP
 #
+$CMP ATMEGA640-8AU
+D TQFP100, 64k Flash, 8k SRAM, 4k EEPROM, JTAG
+K AVR 8bit Microcontroller MegaAVR
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2549-8-bit-AVR-Microcontroller-ATmega640-1280-1281-2560-2561_datasheet.pdf
+$ENDCMP
+#
 $CMP ATMEGA644-20AU
 D TQFP44, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
@@ -811,7 +841,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2593.pdf
 $ENDCMP
 #
 $CMP ATMEGA644-20MU
-D ATMEGA644A, QFN/MLF44, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
+D QFN/MLF44, 64k Flash, 4k SRAM, 2k EEPROM, JTAG
 K AVR 8bit Microcontroller MegaAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2593.pdf
 $ENDCMP
@@ -1387,7 +1417,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8068-8-and16-bit-AVR-XME
 $ENDCMP
 #
 $CMP ATXMEGA256A3-MH
-D ATXMEGA128A3, QFN64, 256k Flash, 8k Boot, 16k SRAM, 4k EEPROM, JTAG
+D QFN64, 256k Flash, 8k Boot, 16k SRAM, 4k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8068-8-and16-bit-AVR-XMEGA-A3-Microcontrollers_Datasheet.pdf
 $ENDCMP
@@ -1465,7 +1495,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8069-8-and-16-bit-AVR-AM
 $ENDCMP
 #
 $CMP ATXMEGA32A4U-AU
-D ATXMEGA16A4U, TQFP44, 32k Flash, 4k Boot, 4k SRAM, 1k EEPROM, JTAG, USB
+D TQFP44, 32k Flash, 4k Boot, 4k SRAM, 1k EEPROM, JTAG, USB
 K AVR 8/16bit Microcontroller XMegaAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8387-8-and16-bit-AVR-Microcontroller-XMEGA-A4U_Datasheet.pdf
 $ENDCMP
@@ -1519,7 +1549,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8153-8-and-16-bit-AVR-Mi
 $ENDCMP
 #
 $CMP ATXMEGA384A1-AU
-D ATXMEGA128A1, TQFP100, 384k Flash, 8k Boot, 32k SRAM, 4k EEPROM, JTAG
+D TQFP100, 384k Flash, 8k Boot, 32k SRAM, 4k EEPROM, JTAG
 K AVR 8/16bit Microcontroller XMegaAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8067-8-and-16-bit-AVR-Microcontrollers-ATxmega64A1-ATxmega128A1_Datasheet.pdf
 $ENDCMP

--- a/MCU_Atmel_ATTINY.dcm
+++ b/MCU_Atmel_ATTINY.dcm
@@ -3,43 +3,43 @@ EESchema-DOCLIB  Version 2.0
 $CMP ATTINY10-P
 D DIP8, 1k OTP Flash, No SRAM, 64B EEPROM (For reference only)
 K AVR 8-bit Microcontroller tinyAVR Discontinued
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1006.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny%2011_12%20Complete.pdf
 $ENDCMP
 #
 $CMP ATTINY10-S
 D SO8, 1k OTP FLash, No SRAM, 64B EEPROM (For reference only)
 K AVR 8-bit Microcontroller tinyAVR Discontinued
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1006.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny%2011_12%20Complete.pdf
 $ENDCMP
 #
 $CMP ATTINY10-TS
 D SOT-23-6, 1k Flash, 32B SRAM, No EEPROM, ADC
 K AVR 8bit Microcontroller tinyAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8127-avr-8-bit-microcontroller-attiny4-attiny5-attiny9-attiny10_datasheet-summary.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8127-AVR-8-bit-Microcontroller-ATtiny4-ATtiny5-ATtiny9-ATtiny10_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY11-6PC
 D PDIP8, 1k Flash, No SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1006.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny%2011_12%20Complete.pdf
 $ENDCMP
 #
 $CMP ATTINY11-6SC
 D SO8 Wide, 1k Flash, No SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1006.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny%2011_12%20Complete.pdf
 $ENDCMP
 #
 $CMP ATTINY12-4PC
 D PDIP8, 1k Flash, No SRAM, 64B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1006.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny%2011_12%20Complete.pdf
 $ENDCMP
 #
 $CMP ATTINY12-4SC
 D SO8 Wide, 1k Flash, No SRAM, 64B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1006.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny%2011_12%20Complete.pdf
 $ENDCMP
 #
 $CMP ATTINY13-20MMU
@@ -171,31 +171,31 @@ $ENDCMP
 $CMP ATTINY22-8PC
 D PDIP8, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1273.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny22L.pdf
 $ENDCMP
 #
 $CMP ATTINY22-8SC
 D SO8 Wide, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1273.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny22L.pdf
 $ENDCMP
 #
 $CMP ATTINY2313-20MU
 D MLF20, 2k Flash, 128B SRAM, 128B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2543.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2543-AVR-ATtiny2313_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY2313-20PU
 D PDIP20, 2k Flash, 128B SRAM, 128B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2543.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2543-AVR-ATtiny2313_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY2313-20SU
 D SO20, 2k Flash, 128B SRAM, 128B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2543.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2543-AVR-ATtiny2313_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY2313A-PU
@@ -357,7 +357,7 @@ $ENDCMP
 $CMP ATTINY4-TS
 D SOT-23-6, 512B Flash, 32B SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8127-avr-8-bit-microcontroller-attiny4-attiny5-attiny9-attiny10_datasheet-summary.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8127-AVR-8-bit-Microcontroller-ATtiny4-ATtiny5-ATtiny9-ATtiny10_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY40-MMH
@@ -549,7 +549,7 @@ $ENDCMP
 $CMP ATTINY5-TS
 D SOT-23-6, 512B Flash, 32B SRAM, No EEPROM, ADC
 K AVR 8bit Microcontroller tinyAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8127-avr-8-bit-microcontroller-attiny4-attiny5-attiny9-attiny10_datasheet-summary.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8127-AVR-8-bit-Microcontroller-ATtiny4-ATtiny5-ATtiny9-ATtiny10_Datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY84-20MU
@@ -717,7 +717,7 @@ $ENDCMP
 $CMP ATTINY9-TS
 D SOT-23-6, 1024B Flash, 32B SRAM, No EEPROM
 K AVR 8bit Microcontroller tinyAVR
-F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-8127-avr-8-bit-microcontroller-attiny4-attiny5-attiny9-attiny10_datasheet-summary.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8127-AVR-8-bit-Microcontroller-ATtiny4-ATtiny5-ATtiny9-ATtiny10_Datasheet.pdf
 $ENDCMP
 #
 #End Doc Library

--- a/MCU_Atmel_ATTINY.dcm
+++ b/MCU_Atmel_ATTINY.dcm
@@ -463,7 +463,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8183.pdf
 $ENDCMP
 #
 $CMP ATTINY45-20MU
-D ATTINY25, QFN/MLF20, 4k Flash, 256B SRAM, 256B EEPROM, Debug Wire
+D QFN/MLF20, 4k Flash, 256B SRAM, 256B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
@@ -613,19 +613,19 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8183.pdf
 $ENDCMP
 #
 $CMP ATTINY85-20MU
-D ATTINY25, QFN/MLF20, 8k Flash, 512B SRAM, 512B EEPROM, Debug Wire
+D QFN/MLF20, 8k Flash, 512B SRAM, 512B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY85-20PU
-D ATTINY85, PDIP8, 8k Flash, 512B SRAM, 512B EEPROM, Debug Wire
+D PDIP8, 8k Flash, 512B SRAM, 512B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
 #
 $CMP ATTINY85-20SU
-D ATTINY85, SO8 Wide, 8k Flash, 512B SRAM, 512B EEPROM, Debug Wire
+D SO8 Wide, 8k Flash, 512B SRAM, 512B EEPROM, Debug Wire
 K AVR 8bit Microcontroller tinyAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP

--- a/MCU_Atmel_AVR.dcm
+++ b/MCU_Atmel_AVR.dcm
@@ -79,19 +79,19 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/doc0839.pdf
 $ENDCMP
 #
 $CMP AT90S2323-4PC
-D AT90S/LS2323, PDIP8, 2k Flash, 128B SRAM, 128B EEPROM
+D PDIP8, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1004.pdf
 $ENDCMP
 #
 $CMP AT90S2323-4SC
-D AT90S/LS2323, SO8 Wide, 2k Flash, 128B SRAM, 128B EEPROM
+D SO8 Wide, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1004.pdf
 $ENDCMP
 #
 $CMP AT90S2333-4AC
-D AT90S4433, TQFP32, 2k Flash, 128B SRAM, 256B EEPROM
+D TQFP32, 2k Flash, 128B SRAM, 256B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1042.pdf
 $ENDCMP
@@ -103,13 +103,13 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1042.pdf
 $ENDCMP
 #
 $CMP AT90S2343-4PC
-D AT90S/LS2343, PDIP8, 2k Flash, 128B SRAM, 128B EEPROM
+D PDIP8, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1004.pdf
 $ENDCMP
 #
 $CMP AT90S2343-4SC
-D AT90S/LS2343, SO8 Wide, 2k Flash, 128B SRAM, 128B EEPROM
+D SO8 Wide, 2k Flash, 128B SRAM, 128B EEPROM
 K AVR 8bit Microcontroller ClassicAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1004.pdf
 $ENDCMP


### PR DESCRIPTION
Some of the datasheets were 404'd or otherwise not quite right (pointing to summary, wrong device, etc).

Also filled out some missing entries. I could not find any information on the "ATmega1261" though - it is defined as an alias of the 1281 but I don't think it actually exists. Perhaps a typo that was missed when someone actually added the 1281?

------------
Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the symbol(s) you are contributing
- [ ] An example screenshot image is very helpful
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
