### PR TITLE
Set Travis to use Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+branches:
+  only:
+    - master
+    - travis-python
+
 language: python
 python:
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+language: python
+python:
+  - "3.6"
+
 before_install:
 - git clone --depth 1 https://github.com/KiCad/kicad-library-utils /home/travis/build/kicad-library-utils
 - git clone --depth 1 https://github.com/KiCad/kicad-symbols /home/travis/build/kicad-library-old

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
-branches:
-  only:
-    - master
-    - travis-python
+language: python
+python:
+  - "2.7"
 
 before_install:
-- python --version
 - git clone --depth 1 https://github.com/KiCad/kicad-library-utils /home/travis/build/kicad-library-utils
 - git clone --depth 1 https://github.com/KiCad/kicad-symbols /home/travis/build/kicad-library-old
 - git clone --depth 1 https://github.com/KiCad/kicad-footprints /home/travis/build/kicad-footprints

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,8 @@ branches:
     - master
     - travis-python
 
-language: python
-python:
-  - "3.6"
-
 before_install:
+- python --version
 - git clone --depth 1 https://github.com/KiCad/kicad-library-utils /home/travis/build/kicad-library-utils
 - git clone --depth 1 https://github.com/KiCad/kicad-symbols /home/travis/build/kicad-library-old
 - git clone --depth 1 https://github.com/KiCad/kicad-footprints /home/travis/build/kicad-footprints


### PR DESCRIPTION
The default language is Ruby, which causes Travis to waste about four seconds setting up a Ruby environment we don't need every time CI is run.  This PR changes the language to the one we actually use, Python 2.7.

I suggest squash-merging this PR, as the commit history is a bit of a mess.