### PR TITLE
Fixed broken install prefix setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,12 @@ cmake_minimum_required( VERSION 2.6.1 FATAL_ERROR )
 # Locations for install targets.
 #================================================
 if( APPLE )
-    # Like all variables, CMAKE_INSTALL_PREFIX can be over-ridden on the command line.
+    # The project call sets the CMAKE_INSTALL_PREFIX, so it cannot be changed without using FORCE.
+    # This check makes sure CMAKE_INSTALL_PREFIX can still be overridden from the command line.
+   if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+       set( CMAKE_INSTALL_PREFIX "/Library/Application Support/kicad/" CACHE PATH "" FORCE)
+   endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+ 
     set( CMAKE_INSTALL_PREFIX "/Library/Application Support/kicad/" CACHE PATH "" )
 
     # Everything without leading / is relative to CMAKE_INSTALL_PREFIX.


### PR DESCRIPTION
You cannot set the CMAKE_INSTALL_PREFIX without using FORCE because the project ( ) command, whose job is to setup the basic variables needed, will have already set CMAKE_INSTALL_PREFIX.  Some older versions of cmake with an incomplete implementation of project don't set the install prefix, allowing this to accidentally work.  That is not the intended behavior however, nor does it work with recent versions of cmake.

Also, this is the canonical way to handle changes to the CMAKE_INSTALL_PREFIX according to the cmake developers: https://public.kitware.com/pipermail/cmake/2010-December/041135.html
