### PR TITLE
Fixed broken install prefix setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,11 @@ cmake_minimum_required( VERSION 2.6.1 FATAL_ERROR )
 # Locations for install targets.
 #================================================
 if( APPLE )
-    # Like all variables, CMAKE_INSTALL_PREFIX can be over-ridden on the command line.
-    set( CMAKE_INSTALL_PREFIX "/Library/Application Support/kicad/" CACHE PATH "" )
+    # The project command has already set CMAKE_INSTALL_PREFIX, so FORCE must be used.
+    # This check makes sure CMAKE_INSTALL_PREFIX can still be overridden from the command line.
+   if( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
+       set( CMAKE_INSTALL_PREFIX "/Library/Application Support/kicad/" CACHE PATH "" FORCE )
+   endif()
 
     # Everything without leading / is relative to CMAKE_INSTALL_PREFIX.
     set( KICAD_LIBRARY library )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,9 @@ cmake_minimum_required( VERSION 2.6.1 FATAL_ERROR )
 if( APPLE )
     # The project command has already set CMAKE_INSTALL_PREFIX, so FORCE must be used.
     # This check makes sure CMAKE_INSTALL_PREFIX can still be overridden from the command line.
-   if( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
-       set( CMAKE_INSTALL_PREFIX "/Library/Application Support/kicad/" CACHE PATH "" FORCE )
-   endif()
+    if( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
+        set( CMAKE_INSTALL_PREFIX "/Library/Application Support/kicad/" CACHE PATH "" FORCE )
+    endif()
 
     # Everything without leading / is relative to CMAKE_INSTALL_PREFIX.
     set( KICAD_LIBRARY library )


### PR DESCRIPTION
This does not work for macOS users.  It will try to install to /usr/local/share/kicad (which does not exist) and fails without installing anything.

This is caused by how CMAKE_INSTALL_PREFIX is being handled.  Without using FORCE because the project ( ) command, whose job is to setup the basic variables needed, will have already set CMAKE_INSTALL_PREFIX.  Some older versions of cmake with an incomplete implementation of project don't set the install prefix, allowing this to accidentally work.  That is not the intended behavior however, nor does it work with recent versions of cmake.

This commit fixes the problem by using the canonical way to handle the CMAKE_INSTALL_PREFIX according to the cmake developers: https://public.kitware.com/pipermail/cmake/2010-December/041135.html