### PR TITLE
Add VCCQ description

### DIFF
--- a/power.dcm
+++ b/power.dcm
@@ -418,6 +418,11 @@ D power-flag symbol
 K Power Flag Symbol
 $ENDCMP
 #
+$CMP VCCQ
+D power-flag symbol
+K Power Flag Symbol
+$ENDCMP
+#
 $CMP VCOM
 D power-flag symbol
 K Power Flag Symbol


### PR DESCRIPTION
I just realized that the VCCQ symbol didn't have a description:
![image](https://user-images.githubusercontent.com/1936989/38220681-5fe97496-3690-11e8-8f23-a2ff6ded80b5.png)

I added a basic one from VCC. Simple as that.

------------
Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the symbol(s) you are contributing
- [ ] An example screenshot image is very helpful
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
