### PR TITLE
Unconfuse data sheets for LM2904 and LM358

### DIFF
--- a/Amplifier_Operational.dcm
+++ b/Amplifier_Operational.dcm
@@ -159,7 +159,7 @@ $ENDCMP
 $CMP LM2904
 D Dual Operational Amplifiers, DIP-8/SOIC-8/TSSOP-8/VSSOP-8
 K dual opamp
-F http://www.ti.com/lit/ds/symlink/lm358.pdf
+F http://www.ti.com/lit/ds/symlink/lm2904-n.pdf
 $ENDCMP
 #
 $CMP LM318H
@@ -207,7 +207,7 @@ $ENDCMP
 $CMP LM358
 D Low-Power, Dual Operational Amplifiers, DIP-8/SOIC-8/TO-99-8
 K dual opamp
-F http://www.ti.com/lit/ds/symlink/lm2904-n.pdf
+F http://www.ti.com/lit/ds/symlink/lm358.pdf
 $ENDCMP
 #
 $CMP LM358_DFN


### PR DESCRIPTION
LM2904 and LM358 currently point to each others data sheets.
http://www.ti.com/lit/ds/symlink/lm358.pdf
http://www.ti.com/lit/ds/symlink/lm2904-n.pdf