### PR TITLE
Added 1x18650 and 2x18650 cell battery holder

### DIFF
--- a/Battery_Holder.dcm
+++ b/Battery_Holder.dcm
@@ -1,0 +1,15 @@
+EESchema-DOCLIB  Version 2.0
+#
+$CMP BatteryHolder_1x18650
+D Battery holder 1x18650 cells
+K Battery holder 1x18650 cells
+F ~
+$ENDCMP
+#
+$CMP BatteryHolder_2x18650
+D Battery holder 2x18650 cells
+K Battery holder 2x18650 cells
+F ~
+$ENDCMP
+#
+#End Doc Library

--- a/Battery_Holder.lib
+++ b/Battery_Holder.lib
@@ -1,0 +1,40 @@
+EESchema-LIBRARY Version 2.4
+#encoding utf-8
+#
+# BatteryHolder_1x18650
+#
+DEF BatteryHolder_1x18650 U 0 40 Y Y 1 F N
+F0 "U" 100 250 50 H V C CNN
+F1 "BatteryHolder_1x18650" 50 -250 50 H V L CNN
+F2 "" 0 0 50 H I C CNN
+F3 "" 0 0 50 H I C CNN
+$FPLIST
+ BatteryHolder*1x18650*
+$ENDFPLIST
+DRAW
+S -100 200 100 -200 0 1 10 f
+X + 1 0 300 100 D 50 50 1 1 w
+X - 2 0 -300 100 U 50 50 1 1 w
+ENDDRAW
+ENDDEF
+#
+# BatteryHolder_2x18650
+#
+DEF BatteryHolder_2x18650 U 0 20 Y Y 1 F N
+F0 "U" 100 250 50 H V C CNN
+F1 "BatteryHolder_2x18650" 50 -250 50 H V L CNN
+F2 "" 0 0 50 H I C CNN
+F3 "" 0 0 50 H I C CNN
+$FPLIST
+ BatteryHolder*2x18650*
+$ENDFPLIST
+DRAW
+S -200 200 200 -200 0 1 10 f
+X + 1 -100 300 100 D 50 50 1 1 w
+X - 2 -100 -300 100 U 50 50 1 1 w
+X + 3 0 300 100 D 50 50 1 1 w
+X - 4 0 -300 100 U 50 50 1 1 w
+ENDDRAW
+ENDDEF
+#
+#End Library

--- a/sym-lib-table
+++ b/sym-lib-table
@@ -17,6 +17,7 @@
   (lib (name Analog_Switch)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/Analog_Switch.lib)(options "")(descr "Analog switches"))
   (lib (name Audio)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/Audio.lib)(options "")(descr "Audio devices"))
   (lib (name Battery_Management)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/Battery_Management.lib)(options "")(descr "Battery management ICs"))
+  (lib (name Battery_Holder)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/Battery_Holder.lib)(options "")(descr "Battery holder"))
   (lib (name Comparator)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/Comparator.lib)(options "")(descr "Comparator symbols"))
   (lib (name Connector)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/Connector.lib)(options "")(descr "Connector symbols (Examples: Terminal Block, D-SUB, DIN, USB...)"))
   (lib (name Connector_Generic)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/Connector_Generic.lib)(options "")(descr "Generic connector symbols"))


### PR DESCRIPTION
Suggestion for symbols for battery holder

What are your thoughts about making symbols for battery holders?
I deliberately added the battery type as a suffix it in the scheme so it is visible what type of battery it is.


![bild](https://user-images.githubusercontent.com/25547797/41205033-f293a8d8-6cec-11e8-892b-6b869fbdcd0c.png)

![bild](https://user-images.githubusercontent.com/25547797/41205036-f7b96a00-6cec-11e8-944b-f236452eeb36.png)

![bild](https://user-images.githubusercontent.com/25547797/41205038-fc632e88-6cec-11e8-99b5-6e50cbb6a2d9.png)

![bild](https://user-images.githubusercontent.com/25547797/41205042-03904056-6ced-11e8-878b-6f881d3492f9.png)

![bild](https://user-images.githubusercontent.com/25547797/41205048-0c5e284c-6ced-11e8-87ca-1994f56375a9.png)

![bild](https://user-images.githubusercontent.com/25547797/41205050-138fec72-6ced-11e8-9ab9-4cec2536c87a.png)







------------
Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the symbol(s) you are contributing
- [ ] An example screenshot image is very helpful
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
