### PR TITLE
Typo in the name of the Power symbols / flags library

### DIFF
--- a/sym-lib-table
+++ b/sym-lib-table
@@ -176,7 +176,7 @@
   (lib (name Triac_Thyristor)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/Triac_Thyristor.lib)(options "")(descr "TRIAC and thyristor symbols"))
   (lib (name Valve)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/Valve.lib)(options "")(descr "Valve symbols"))
   (lib (name Video)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/Video.lib)(options "")(descr "Video symbols"))
-  (lib (name power)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/power.lib)(options "")(descr "Power symbols, special power flags"))
+  (lib (name Power)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/power.lib)(options "")(descr "Power symbols, special power flags"))
   (lib (name pspice)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/pspice.lib)(options "")(descr "Legacy pspice symbol library."))
   (lib (name MCU_Microchip_SAME)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/MCU_Microchip_SAME.lib)(options "")(descr "Microchip SAME microcontrollers"))
   (lib (name MCU_Microchip_SAML)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/MCU_Microchip_SAML.lib)(options "")(descr "Microchip SAML microcontrollers"))


### PR DESCRIPTION
Unless there is a legitimate reason, I suggest the name of the power symbols library should start with a capital P (despite the file name doesn't).
