### PR TITLE
Better descriptions and keywords for Device lib

### DIFF
--- a/Device.dcm
+++ b/Device.dcm
@@ -73,13 +73,13 @@ F ~
 $ENDCMP
 #
 $CMP CP1
-D Polarized capacitor, alternative symbol
+D Polarized capacitor, curved cathode
 K cap capacitor
 F ~
 $ENDCMP
 #
 $CMP CP1_Small
-D Polarized capacitor, small symbol, alternative symbol
+D Polarized capacitor, curved cathode, small symbol
 K cap capacitor
 F ~
 $ENDCMP
@@ -193,13 +193,13 @@ F ~
 $ENDCMP
 #
 $CMP DIAC_ALT
-D Diode for alternating current, alternative symbol
+D Diode for alternating current, filled shape
 K AC diode DIAC
 F ~
 $ENDCMP
 #
 $CMP D_ALT
-D Diode, alternative symbol
+D Diode, filled shape
 K diode
 F ~
 $ENDCMP
@@ -241,7 +241,7 @@ F ~
 $ENDCMP
 #
 $CMP D_Capacitance_ALT
-D Variable capacitance diode, alternative symbol
+D Variable capacitance diode, filled shape
 K capacitance diode varicap varactor
 F ~
 $ENDCMP
@@ -253,7 +253,7 @@ F ~
 $ENDCMP
 #
 $CMP D_Photo_ALT
-D Photodiode, alternative symbol
+D Photodiode, filled shape
 K photodiode diode opto
 F ~
 $ENDCMP
@@ -265,7 +265,7 @@ F ~
 $ENDCMP
 #
 $CMP D_Radiation_ALT
-D Semiconductor radiation detector, alternative symbol
+D Semiconductor radiation detector, filled shape
 K radiation detector diode
 F ~
 $ENDCMP
@@ -295,7 +295,7 @@ F ~
 $ENDCMP
 #
 $CMP D_Schottky_ALT
-D Schottky diode, alternative symbol
+D Schottky diode, filled shape
 K diode Schottky
 F ~
 $ENDCMP
@@ -325,7 +325,7 @@ F ~
 $ENDCMP
 #
 $CMP D_Schottky_Small_ALT
-D Schottky diode, small symbol, alternative symbol
+D Schottky diode, small symbol, filled shape
 K diode Schottky
 F ~
 $ENDCMP
@@ -421,7 +421,7 @@ F ~
 $ENDCMP
 #
 $CMP D_Small_ALT
-D Diode, small symbol, alternative symbol
+D Diode, small symbol, filled shape
 K diode
 F ~
 $ENDCMP
@@ -433,7 +433,7 @@ F ~
 $ENDCMP
 #
 $CMP D_TVS_ALT
-D Bidirectional transient-voltage-suppression diode, alternative symbol
+D Bidirectional transient-voltage-suppression diode, filled shape
 K diode TVS thyrector
 F ~
 $ENDCMP
@@ -463,7 +463,7 @@ F ~
 $ENDCMP
 #
 $CMP D_Temperature_Dependent_ALT
-D Temperature dependent diode, alternative symbol
+D Temperature dependent diode, filled shape
 K temperature sensor diode
 F ~
 $ENDCMP
@@ -475,7 +475,7 @@ F ~
 $ENDCMP
 #
 $CMP D_Tunnel_ALT
-D Tunnel diode (Esaki diode), alternative symbol
+D Tunnel diode (Esaki diode), filled shape
 K tunnel diode
 F ~
 $ENDCMP
@@ -487,7 +487,7 @@ F ~
 $ENDCMP
 #
 $CMP D_Unitunnel_ALT
-D Unitunnel diode, alternative symbol
+D Unitunnel diode, filled shape
 K unitunnel diode
 F ~
 $ENDCMP
@@ -499,7 +499,7 @@ F ~
 $ENDCMP
 #
 $CMP D_Zener_ALT
-D Zener diode, alternative symbol
+D Zener diode, filled shape
 K diode
 F ~
 $ENDCMP
@@ -511,7 +511,7 @@ F ~
 $ENDCMP
 #
 $CMP D_Zener_Small_ALT
-D Zener diode, small symbol, alternative symbol
+D Zener diode, small symbol, filled shape
 K diode
 F ~
 $ENDCMP
@@ -733,7 +733,7 @@ F ~
 $ENDCMP
 #
 $CMP LED_ALT
-D Light emitting diode, alternative symbol
+D Light emitting diode, filled shape
 K LED diode
 F ~
 $ENDCMP
@@ -859,7 +859,7 @@ F ~
 $ENDCMP
 #
 $CMP LED_Small_ALT
-D Light emitting diode, small symbol, alternative symbol
+D Light emitting diode, small symbol, filled shape
 K LED diode light-emitting-diode
 F ~
 $ENDCMP

--- a/Device.dcm
+++ b/Device.dcm
@@ -1,61 +1,61 @@
 EESchema-DOCLIB  Version 2.0
 #
 $CMP Amperemeter_AC
-D AC amperemeter
-K amperemeter AC
+D AC ammeter
+K ammeter AC
 F ~
 $ENDCMP
 #
 $CMP Amperemeter_DC
-D DC amperemeter
-K amperemeter DC
+D DC ammeter
+K ammeter DC
 F ~
 $ENDCMP
 #
 $CMP Antenna
-D Antenna symbol
+D Antenna
 K antenna
 F ~
 $ENDCMP
 #
 $CMP Antenna_Chip
-D Ceramic chip antenna symbol with pin for PCB trace
+D Ceramic chip antenna with pin for PCB trace
 K antenna
 F ~
 $ENDCMP
 #
 $CMP Antenna_Dipole
-D Dipole antenna symbol
+D Dipole antenna
 K dipole antenna
 F ~
 $ENDCMP
 #
 $CMP Antenna_Loop
-D Loop antenna symbol
+D Loop antenna
 K loop antenna
 F ~
 $ENDCMP
 #
 $CMP Antenna_Shield
-D Antenna symbol with extra pin for shielding
+D Antenna with extra pin for shielding
 K antenna
 F ~
 $ENDCMP
 #
 $CMP Battery
-D Battery (multiple cells)
+D Multiple-cell battery
 K batt voltage-source cell
 F ~
 $ENDCMP
 #
 $CMP Battery_Cell
-D Single battery cell
+D Single-cell battery
 K battery cell
 F ~
 $ENDCMP
 #
 $CMP Buzzer
-D Buzzer, polar
+D Buzzer, polarized
 K quartz resonator ceramic
 F ~
 $ENDCMP
@@ -67,25 +67,25 @@ F ~
 $ENDCMP
 #
 $CMP CP
-D Polarised capacitor
+D Polarized capacitor
 K cap capacitor
 F ~
 $ENDCMP
 #
 $CMP CP1
-D Polarised capacitor
+D Polarized capacitor
 K cap capacitor
 F ~
 $ENDCMP
 #
 $CMP CP1_Small
-D Polarised capacitor
+D Polarized capacitor
 K cap capacitor
 F ~
 $ENDCMP
 #
 $CMP CP_Small
-D Polarised capacitor
+D Polarized capacitor
 K cap capacitor
 F ~
 $ENDCMP
@@ -109,7 +109,7 @@ F ~
 $ENDCMP
 #
 $CMP C_Small
-D Unpolarized capacitor
+D Unpolarized capacitor, small symbol
 K capacitor cap
 F ~
 $ENDCMP
@@ -127,49 +127,49 @@ F ~
 $ENDCMP
 #
 $CMP Crystal_GND2
-D Three pin crystal (GND on pin 2), e.g. in SMD package
+D Three pin crystal, GND on pin 2
 K quartz ceramic resonator oscillator
 F ~
 $ENDCMP
 #
 $CMP Crystal_GND23
-D Four pin crystal (GND on pins 2 and 3), e.g. in SMD package
+D Four pin crystal, GND on pins 2 and 3
 K quartz ceramic resonator oscillator
 F ~
 $ENDCMP
 #
 $CMP Crystal_GND23_Small
-D Four pin crystal, two ground/package pins (pin2 and 3) small symbol
+D Four pin crystal, GND on pins 2 and 3, small symbol
 K quartz ceramic resonator oscillator
 F ~
 $ENDCMP
 #
 $CMP Crystal_GND24
-D Four pin crystal (GND on pins 2 and 4), e.g. in SMD package
+D Four pin crystal, GND on pins 2 and 4
 K quartz ceramic resonator oscillator
 F ~
 $ENDCMP
 #
 $CMP Crystal_GND24_Small
-D Four pin crystal, two ground/package pins (pin2 and 4) small symbol
+D Four pin crystal, GND on pins 2 and 4, small symbol
 K quartz ceramic resonator oscillator
 F ~
 $ENDCMP
 #
 $CMP Crystal_GND2_Small
-D Three pin crystal, one ground/package pins (pin2) small symbol
+D Three pin crystal, GND on pin 2, small symbol
 K quartz ceramic resonator oscillator
 F ~
 $ENDCMP
 #
 $CMP Crystal_GND3
-D Three pin crystal (GND on pin 3), e.g. in SMD package
+D Three pin crystal, GND on pin 3
 K quartz ceramic resonator oscillator
 F ~
 $ENDCMP
 #
 $CMP Crystal_GND3_Small
-D Three pin crystal, one ground/package pins (pin3) small symbol
+D Three pin crystal, GND on pin 3, small symbol
 K quartz ceramic resonator oscillator
 F ~
 $ENDCMP
@@ -193,55 +193,55 @@ F ~
 $ENDCMP
 #
 $CMP DIAC_ALT
-D Diode for alternating current, alternativ symbol
+D Diode for alternating current, alternative symbol
 K AC diode DIAC
 F ~
 $ENDCMP
 #
 $CMP D_ALT
-D Diode, alternativ symbol
+D Diode, alternative symbol
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Bridge_+-AA
-D Diode bridge (pins: 1=+, 2=-, 3=AC, 4=AC)
+D Diode bridge, +ve/-ve/AC/AC
 K rectifier ACDC
 F ~
 $ENDCMP
 #
 $CMP D_Bridge_+A-A
-D Diode bridge (pins: 1=+, 2=AC, 3=-, 4=AC)
+D Diode bridge, +ve/AC/-ve/AC
 K rectifier ACDC
 F ~
 $ENDCMP
 #
 $CMP D_Bridge_+AA-
-D Diode bridge (pins: 1=+, 2=AC, 3=AC, 4=-)
+D Diode bridge, +ve/AC/AC/-ve
 K rectifier ACDC
 F ~
 $ENDCMP
 #
 $CMP D_Bridge_-A+A
-D Diode bridge (pins: 1=-, 2=AC, 3=+, 4=AC)
+D Diode bridge, -ve/AC/+ve/AC
 K rectifier ACDC
 F ~
 $ENDCMP
 #
 $CMP D_Bridge_-AA+
-D Diode bridge (pins: 1=-, 2=AC, 3=AC, 4=+)
+D Diode bridge, -ve/AC/AC/+ve
 K rectifier ACDC
 F ~
 $ENDCMP
 #
 $CMP D_Capacitance
-D Variable capacitance diode (varicap, varactor)
+D Variable capacitance diode
 K capacitance diode varicap varactor
 F ~
 $ENDCMP
 #
 $CMP D_Capacitance_ALT
-D Variable capacitance diode (varicap, varactor), alternativ symbol
+D Variable capacitance diode, alternative symbol
 K capacitance diode varicap varactor
 F ~
 $ENDCMP
@@ -265,7 +265,7 @@ F ~
 $ENDCMP
 #
 $CMP D_Radiation_ALT
-D Semiconductor radiation detector, alternativ symbol
+D Semiconductor radiation detector, alternative symbol
 K radiation detector diode
 F ~
 $ENDCMP
@@ -277,43 +277,43 @@ F ~
 $ENDCMP
 #
 $CMP D_Schottky_AAK
-D Schottky diode, two anode pins
+D Schottky diode, anode on pins 1 and 2
 K diode Schottky SCHDPAK
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_AKA
-D Schottky diode, two anode pins
+D Schottky diode, anode on pins 1 and 3
 K diode Schottky SCHDPAK
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_AKK
-D Schottky diode, two cathode pins
+D Schottky diode, cathode on pins 2 and 3
 K diode Schottky SCHDPAK
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_ALT
-D Schottky diode, alternativ symbol
+D Schottky diode, alternative symbol
 K diode Schottky
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_KAA
-D Schottky diode, two anode pins
+D Schottky diode, anode on pins 2 and 3
 K diode Schottky SCHDPAK
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_KAK
-D Schottky diode, two cathode pins
+D Schottky diode, cathode on pins 1 and 3
 K diode Schottky SCHDPAK
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_KKA
-D Schottky diode, two cathode pins
+D Schottky diode, cathode on pins 1 and 2
 K diode Schottky SCHDPAK
 F ~
 $ENDCMP
@@ -325,92 +325,92 @@ F ~
 $ENDCMP
 #
 $CMP D_Schottky_Small_ALT
-D Schottky diode, small symbol, alternativ symbol
+D Schottky diode, small symbol, alternative symbol
 K diode Schottky
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_ACom_AKK
-D Dual Schottky diode, common anode
+D Dual Schottky diode, common anode on pin 1
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_ACom_KAK
-D Dual Schottky diode, common anode
+D Dual Schottky diode, common anode on pin 2
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_ACom_KKA
-D Dual Schottky diode, common anode
+D Dual Schottky diode, common anode on pin 3
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_KCom_AAK
-D Dual Schottky diode, common cathode
+D Dual Schottky diode, common cathode on pin 3
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_KCom_AKA
-D Dual Schottky diode, common cathode
+D Dual Schottky diode, common cathode on pin 2
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_KCom_KAA
-D Dual Schottky diode, common cathode
+D Dual Schottky diode, common cathode on pin 1
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_ACK
-D Dual Schottky diode
+D Dual Schottky diode, anode/center/cathode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_AKC
-D Dual Schottky diode
+D Dual Schottky diode, anode/cathode/center
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_CAK
-D Dual Schottky diode
+D Dual Schottky diode, center/anode/cathode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_CKA
-D Dual Schottky diode
+D Dual Schottky diode, center/cathode/anode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_KAC
-D Dual Schottky diode
+D Dual Schottky diode, cathode/anode/center
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_KCA
-D Dual Schottky diode
+D Dual Schottky diode, cathode/center/anode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Shockley
-D Shockley diode (PNPN diode)
-K Shockley diode
+D Shockley (PNPN) diode
+K Shockley diode PNPN
 F ~
 $ENDCMP
 #
 $CMP D_SiPM
-D Silicon photomultiplier for counting of individual photons
-K SiPM MPPC SPAD
+D Silicon photomultiplier
+K SiPM MPPC SPAD photon counting
 F ~
 $ENDCMP
 #
@@ -421,37 +421,37 @@ F ~
 $ENDCMP
 #
 $CMP D_Small_ALT
-D Diode, small symbol, alternativ symbol
+D Diode, small symbol, alternative symbol
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_TVS
-D Bidirectional transient-voltage-suppression (TVS) diode
+D Bidirectional transient-voltage-suppression diode
 K diode TVS thyrector
 F ~
 $ENDCMP
 #
 $CMP D_TVS_ALT
-D Bidirectional transient-voltage-suppression (TVS) diode, alternative symbol
+D Bidirectional transient-voltage-suppression diode, alternative symbol
 K diode TVS thyrector
 F ~
 $ENDCMP
 #
 $CMP D_TVS_x2_AAC
-D Bidirectional dual transient-voltage-suppression (TVS) diode (center=pin3)
+D Bidirectional dual transient-voltage-suppression diode, center on pin 3
 K diode TVS thyrector
 F ~
 $ENDCMP
 #
 $CMP D_TVS_x2_ACA
-D Bidirectional dual transient-voltage-suppression (TVS) diode (center=pin2)
+D Bidirectional dual transient-voltage-suppression diode, center on pin 2
 K diode TVS thyrector
 F ~
 $ENDCMP
 #
 $CMP D_TVS_x2_CAA
-D Bidirectional dual transient-voltage-suppression (TVS) diode (center=pin1)
+D Bidirectional dual transient-voltage-suppression diode, center on pin 1
 K diode TVS thyrector
 F ~
 $ENDCMP
@@ -463,7 +463,7 @@ F ~
 $ENDCMP
 #
 $CMP D_Temperature_Dependent_ALT
-D Temperature dependent diode, alternativ symbol
+D Temperature dependent diode, alternative symbol
 K temperature sensor diode
 F ~
 $ENDCMP
@@ -475,7 +475,7 @@ F ~
 $ENDCMP
 #
 $CMP D_Tunnel_ALT
-D Tunnel diode (Esaki diode), alternativ symbol
+D Tunnel diode (Esaki diode), alternative symbol
 K tunnel diode
 F ~
 $ENDCMP
@@ -487,7 +487,7 @@ F ~
 $ENDCMP
 #
 $CMP D_Unitunnel_ALT
-D Unitunnel diode, alternativ symbol
+D Unitunnel diode, alternative symbol
 K unitunnel diode
 F ~
 $ENDCMP
@@ -499,7 +499,7 @@ F ~
 $ENDCMP
 #
 $CMP D_Zener_ALT
-D Zener diode, alternativ symbol
+D Zener diode, alternative symbol
 K diode
 F ~
 $ENDCMP
@@ -511,86 +511,86 @@ F ~
 $ENDCMP
 #
 $CMP D_Zener_Small_ALT
-D Zener diode, small symbol, alternativ symbol
+D Zener diode, small symbol, alternative symbol
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_x2_ACom_AKK
-D Dual diode, common anode
+D Dual diode, common anode on pin 1
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_x2_ACom_KAK
-D Dual diode, common anode
+D Dual diode, common anode on pin 2
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_x2_ACom_KKA
-D Dual diode, common anode
+D Dual diode, common anode on pin 3
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_x2_KCom_AAK
-D Dual diode, common cathode
+D Dual diode, common cathode on pin 3
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_x2_KCom_AKA
-D Dual diode, common cathode
+D Dual diode, common cathode on pin 2
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_x2_KCom_KAA
-D Dual diode, common cathode
+D Dual diode, common cathode on pin 1
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_x2_Serial_ACK
-D Dual diode
+D Dual diode, anode/center/cathode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_x2_Serial_AKC
-D Dual diode
+D Dual diode, anode/cathode/center
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_x2_Serial_CAK
-D Dual diode
+D Dual diode, center/anode/cathode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_x2_Serial_CKA
-D Dual diode
+D Dual diode, center/cathode/anode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_x2_Serial_KAC
-D Dual diode
+D Dual diode, cathode/anode/center
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_x2_Serial_KCA
-D Dual diode
+D Dual diode, cathode/center/anode
 K diode
 F ~
 $ENDCMP
 #
 $CMP Delay_Line
 D Delay line
-K delay propogation retard impedance
+K delay propagation retard impedance
 F ~
 $ENDCMP
 #
@@ -625,7 +625,7 @@ F http://www.murata.com/~/media/webrenewal/support/library/catalog/products/emc/
 $ENDCMP
 #
 $CMP Earphone
-D Earphone, polar
+D Earphone, polarized
 K earphone speaker headphone
 F ~
 $ENDCMP
@@ -655,19 +655,19 @@ F ~
 $ENDCMP
 #
 $CMP Fuse
-D Fuse, generic
+D Fuse
 K fuse
 F ~
 $ENDCMP
 #
 $CMP Fuse_Polarized
-D Fuse, generic
+D Polarized fuse
 K fuse
 F ~
 $ENDCMP
 #
 $CMP Fuse_Polarized_Small
-D Fuse, polarised
+D Polarized fuse, small symbol
 K fuse
 F ~
 $ENDCMP
@@ -685,7 +685,7 @@ F ~
 $ENDCMP
 #
 $CMP Hall_Generator
-D Hall generator
+D Hall effect generator
 K Hall generator magnet
 F ~
 $ENDCMP
@@ -697,7 +697,7 @@ F ~
 $ENDCMP
 #
 $CMP Jumper
-D Jumper, generic, normally closed
+D Jumper, normally closed
 K jumper bridge link NC
 F ~
 $ENDCMP
@@ -709,14 +709,14 @@ F ~
 $ENDCMP
 #
 $CMP Jumper_NC_Small
-D Jumper, normally closed
-K jumper link bridge
+D Jumper, normally closed, small symbol
+K jumper link bridge NC
 F ~
 $ENDCMP
 #
 $CMP Jumper_NO_Small
-D Jumper, normally open
-K jumper link bridge
+D Jumper, normally open, small symbol
+K jumper link bridge NO
 F ~
 $ENDCMP
 #
@@ -727,115 +727,115 @@ F ~
 $ENDCMP
 #
 $CMP LED
-D LED generic
+D Light emitting diode
 K LED diode
 F ~
 $ENDCMP
 #
 $CMP LED_ALT
-D LED generic, alternativ symbol
+D Light emitting diode, alternative symbol
 K LED diode
 F ~
 $ENDCMP
 #
 $CMP LED_ARGB
-D LED RGB, common anode (pin 1)
+D RGB LED, anode/red/green/blue
 K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_BGRA
-D LED RGB, common anode
+D RGB LED, blue/green/red/anode
 K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_CRGB
-D LED RGB, common cathode
+D RGB LED, cathode/red/green/blue
 K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_Dual_2pin
-D LED dual, 2pin version
+D Dual LED, bidirectional
 K LED diode bicolor dual
 F ~
 $ENDCMP
 #
 $CMP LED_Dual_AAC
-D LED dual, common cathode
+D Dual LED, common cathode on pin 3
 K LED diode bicolor dual
 F ~
 $ENDCMP
 #
 $CMP LED_Dual_AACC
-D LED dual, 4-pin
+D Dual LED, cathodes on pins 3 and 4
 K LED diode bicolor dual
 F ~
 $ENDCMP
 #
 $CMP LED_Dual_ACA
-D LED dual, common cathode
+D Dual LED, common cathode on pin 2
 K LED diode bicolor dual
 F ~
 $ENDCMP
 #
 $CMP LED_Dual_ACAC
-D LED dual, 4-pin
+D Dual LED, cathodes on pins 2 and 4
 K LED diode bicolor dual
 F ~
 $ENDCMP
 #
 $CMP LED_Dual_CAC
-D LED dual, common anode
+D Dual LED, common anode on pin 2
 K LED diode bicolor dual
 F ~
 $ENDCMP
 #
 $CMP LED_Dual_CCA
-D LED dual, common anode
+D Dual LED, common anode on pin 3
 K LED diode bicolor dual
 F ~
 $ENDCMP
 #
 $CMP LED_PAD
-D LED with pad
+D Light emitting diode with pad
 K LED diode pad
 F ~
 $ENDCMP
 #
 $CMP LED_RABG
-D LED RGB, common anode
+D RGB LED, red/anode/blue/green
 K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_RAGB
-D LED RGB, common anode
+D RGB LED, red/anode/green/blue
 K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_RCBG
-D LED RGB, common cathode
+D RGB LED, red/cathode/blue/green
 K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_RCGB
-D LED RGB, common cathode
+D RGB LED, red/cathode/green/blue
 K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_RGB
-D LED RGB 6 pins
+D RGB LED, 6 pin package
 K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_RGB_EP
-D LED RGB 6 pins, exposed pad
+D RGB LED, 6 pin package with exposed pad
 K LED RGB diode
 F ~
 $ENDCMP
@@ -847,19 +847,19 @@ F ~
 $ENDCMP
 #
 $CMP LED_Series_PAD
-D LED with pad
+D Several LEDs in series with exposed pad
 K LED diode pad
 F ~
 $ENDCMP
 #
 $CMP LED_Small
-D LED, small symbol
+D Light emitting diode, small symbol
 K LED diode light-emitting-diode
 F ~
 $ENDCMP
 #
 $CMP LED_Small_ALT
-D LED, small symbol, alternativ symbol
+D Light emitting diode, small symbol, alternative symbol
 K LED diode light-emitting-diode
 F ~
 $ENDCMP
@@ -955,31 +955,31 @@ F ~
 $ENDCMP
 #
 $CMP Laserdiode_1A3C
-D Laser diode in a 2-pin package
+D Laser diode, cathode on pin 3, anode on pin 1
 K opto laserdiode
 F ~
 $ENDCMP
 #
 $CMP Laserdiode_1C2A
-D Laser diode in a 2-pin package
+D Laser diode, cathode on pin 1, anode on pin 2
 K opto laserdiode
 F ~
 $ENDCMP
 #
 $CMP Laserdiode_M_TYPE
-D Laser diode in a 3-pin package with photodiode (1=LD-A, 2=LD-C/PD-C, 3=PD-A)
+D Laser diode with photodiode, common cathode on pin 2
 K opto laserdiode photodiode
 F http://www.egismos.disonhu.com/laser/diode-package.htm
 $ENDCMP
 #
 $CMP Laserdiode_N_TYPE
-D Laser diode in a 3-pin package with photodiode (1=LD-C, 2=LD-A/PD-C, 3=PD-A)
+D Laser diode with photodiode, center on pin 2, LD cathode on pin 1
 K opto laserdiode photodiode
 F http://www.egismos.disonhu.com/laser/diode-package.htm
 $ENDCMP
 #
 $CMP Laserdiode_P_TYPE
-D Laser diode in a 3-pin package with photodiode (1=LD-A, 2=LD-C/PD-A, 3=PD-C)
+D Laser diode with photodiode, center on pin 2, PD cathode on pin 3
 K opto laserdiode photodiode
 F http://www.egismos.disonhu.com/laser/diode-package.htm
 $ENDCMP
@@ -1045,19 +1045,19 @@ F ~
 $ENDCMP
 #
 $CMP Ohmmeter
-D Ohmmeter, measures resistance
-K ohmmeter
+D Ohmmeter
+K ohmmeter resistance
 F ~
 $ENDCMP
 #
 $CMP Opamp_Dual_Generic
-D Dual opamp, SOIC-8/DIP-8/SSOP-8/TO-99
+D Dual operational amplifier, SOIC-8/DIP-8/SSOP-8/TO-99
 K dual opamp
 F ~
 $ENDCMP
 #
 $CMP Opamp_Quad_Generic
-D Quad opamp, SOIC-14/DIP-14/SSOP-14
+D Quad operational amplifier, SOIC-14/DIP-14/SSOP-14
 K quad opamp
 F ~
 $ENDCMP
@@ -1069,590 +1069,590 @@ F ~
 $ENDCMP
 #
 $CMP Peltier_Element
-D Peltier element, thermoelectric cooler (TEC)
+D Peltier element, thermoelectric cooler
 K Peltier TEC
 F ~
 $ENDCMP
 #
 $CMP Polyfuse
-D Resettable fuse, polymeric positive temperature coefficient (PPTC)
+D Resettable fuse, polymeric positive temperature coefficient
 K resettable fuse PTC PPTC polyfuse polyswitch
 F ~
 $ENDCMP
 #
 $CMP Polyfuse_Small
-D Resettable fuse, polymeric positive temperature coefficient (PPTC), small symbol
+D Resettable fuse, polymeric positive temperature coefficient, small symbol
 K resettable fuse PTC PPTC polyfuse polyswitch
 F ~
 $ENDCMP
 #
 $CMP Q_DUAL_NMOS_G1S2G2D2S1D1
-D Dual NMOS/NMOS transistor, 6-pin package
-K dual NMOSFET NMOS/NMOS
+D Dual NMOS transistor, 6 pin package
+K transistor NMOS N-MOS N-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_DUAL_NPN_C2C1E1E2
 D Double NPN transistors, current mirror configuration
-K transistor double NPN
+K transistor NPN
 F ~
 $ENDCMP
 #
 $CMP Q_DUAL_NPN_NPN_E1B1C2E2B2C1
-D Dual NPN/NPN transistor, 6-pin package
-K NPN/NPN transistor
+D Dual NPN transistor, 6 pin package
+K transistor NPN
 F ~
 $ENDCMP
 #
 $CMP Q_DUAL_NPN_PNP_E1B1C2E2B2C1
-D Dual NPN/PNP transistor, 6-pin package
-K NPN/PNP transistor
+D Dual NPN/PNP transistor, 6 pin package
+K transistor NPN PNP
 F ~
 $ENDCMP
 #
 $CMP Q_DUAL_PMOS_G1S2G2D2S1D1
-D Dual PMOS/PMOS transistor, 6-pin package
-K dual PMOS/PMOS MOSFET
+D Dual PMOS transistor, 6 pin package
+K transistor PMOS P-MOS P-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_DUAL_PNP_C2C1E1E2
 D Double PNP transistors, current mirror configuration
-K transistor double PNP
+K transistor PNP
 F ~
 $ENDCMP
 #
 $CMP Q_DUAL_PNP_PNP_C1B1B2C2E2E1
-D Dual PNP/PNP transistor, 6-pin package
-K PNP/PNP transistor
+D Dual PNP transistor, 6 pin package
+K transistor PNP
 F https://www.diodes.com/assets/Datasheets/ds30437.pdf
 $ENDCMP
 #
 $CMP Q_DUAL_PNP_PNP_E1B1C2E2B2C1
-D Dual PNP/PNP transistor, 6-pin package
-K PNP/PNP transistor
+D Dual PNP transistor, 6 pin package
+K transistor PNP
 F ~
 $ENDCMP
 #
 $CMP Q_NIGBT_CEG
-D Transistor N-IGBT (general)
-K IGBT N-IGBT transistor
+D N-IGBT transistor, collector/emitter/gate
+K transistor IGBT N-IGBT
 F ~
 $ENDCMP
 #
 $CMP Q_NIGBT_CGE
-D Transistor N-IGBT (general)
-K IGBT N-IGBT transistor
+D N-IGBT transistor, collector/gate/emitter
+K transistor IGBT N-IGBT
 F ~
 $ENDCMP
 #
 $CMP Q_NIGBT_ECG
-D Transistor N-IGBT (general)
-K IGBT N-IGBT transistor
+D N-IGBT transistor, emitter/collector/gate
+K transistor IGBT N-IGBT
 F ~
 $ENDCMP
 #
 $CMP Q_NIGBT_ECGC
-D Transistor N-IGBT, collector connected to mounting plane (general)
-K IGBT N-IGBT transistor
+D N-IGBT transistor, emitter/collector/gate, collector connected to mounting plane
+K transistor IGBT N-IGBT
 F ~
 $ENDCMP
 #
 $CMP Q_NIGBT_EGC
-D Transistor N-IGBT (general)
-K IGBT N-IGBT transistor
+D N-IGBT transistor, emitter/gate/collector
+K transistor IGBT N-IGBT
 F ~
 $ENDCMP
 #
 $CMP Q_NIGBT_GCE
-D Transistor N-IGBT (general)
-K IGBT N-IGBT transistor
+D N-IGBT transistor, gate/collector/emitter
+K transistor IGBT N-IGBT
 F ~
 $ENDCMP
 #
 $CMP Q_NIGBT_GCEC
-D Transistor N-IGBT, collector connected to mounting plane (general)
-K IGBT N-IGBT transistor
+D N-IGBT transistor, gate/collector/emitter, collector connected to mounting plane
+K transistor IGBT N-IGBT
 F ~
 $ENDCMP
 #
 $CMP Q_NIGBT_GEC
-D Transistor N-IGBT (general)
-K IGBT N-IGBT transistor
+D N-IGBT transistor, gate/emitter/collector
+K transistor IGBT N-IGBT
 F ~
 $ENDCMP
 #
 $CMP Q_NJFET_DGS
-D Transistor N-JFET (general)
-K NJFET N-JFET transistor
+D N-JFET transistor, drain/gate/source
+K transistor NJFET N-JFET
 F ~
 $ENDCMP
 #
 $CMP Q_NJFET_DSG
-D Transistor N-JFET (general)
-K NJFET N-JFET transistor
+D N-JFET transistor, drain/source/gate
+K transistor NJFET N-JFET
 F ~
 $ENDCMP
 #
 $CMP Q_NJFET_GDS
-D Transistor N-JFET (general)
-K NJFET N-JFET transistor
+D N-JFET transistor, gate/drain/source
+K transistor NJFET N-JFET
 F ~
 $ENDCMP
 #
 $CMP Q_NJFET_GSD
-D Transistor N-JFET (general)
-K NJFET N-JFET transistor
+D N-JFET transistor, gate/source/drain
+K transistor NJFET N-JFET
 F ~
 $ENDCMP
 #
 $CMP Q_NJFET_SDG
-D Transistor N-JFET (general)
-K NJFET N-JFET transistor
+D N-JFET transistor, source/drain/gate
+K transistor NJFET N-JFET
 F ~
 $ENDCMP
 #
 $CMP Q_NJFET_SGD
-D Transistor N-JFET (general)
-K NJFET N-JFET transistor
+D N-JFET transistor, source/gate/drain
+K transistor NJFET N-JFET
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_DGS
-D Transistor N-MOSFET (general)
-K NMOS N-MOS N-MOSFET transistor
+D N-MOSFET transistor, drain/gate/source
+K transistor NMOS N-MOS N-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_DSG
-D Transistor N-MOSFET with substrate diode (general)
-K NMOS N-MOS N-MOSFET transistor
+D N-MOSFET transistor, drain/source/gate
+K transistor NMOS N-MOS N-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_GDS
-D Transistor N-MOSFET with substrate diode (general)
-K NMOS N-MOS N-MOSFET transistor
+D N-MOSFET transistor, gate/drain/source
+K transistor NMOS N-MOS N-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_GDSD
-D Transistor N-MOSFET with substrate diode, drain connected to mounting plane (general)
-K NMOS N-MOS N-MOSFET transistor
+D N-MOSFET transistor, gate/drain/source, drain connected to mounting plane
+K transistor NMOS N-MOS N-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_GSD
-D Transistor N-MOSFET with substrate diode (general)
-K NMOS N-MOS N-MOSFET transistor
+D N-MOSFET transistor, gate/source/drain
+K transistor NMOS N-MOS N-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_SDG
-D Transistor N-MOSFET with substrate diode (general)
-K NMOS N-MOS N-MOSFET transistor
+D N-MOSFET transistor, source/drain/gate
+K transistor NMOS N-MOS N-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_SDGD
-D Transistor N-MOSFET with substrate diode, drain connected to mounting plane (general)
-K NMOS N-MOS N-MOSFET transistor
+D N-MOSFET transistor, source/drain/gate, drain connected to mounting plane
+K transistor NMOS N-MOS N-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_SGD
-D Transistor N-MOSFET with substrate diode (general)
-K NMOS N-MOS N-MOSFET transistor
+D N-MOSFET transistor, source/gate/drain
+K transistor NMOS N-MOS N-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_BCE
-D Transistor NPN (general)
-K NPN transistor
+D NPN transistor, base/collector/emitter
+K transistor NPN
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_BCEC
-D Transistor NPN, collector connected to mounting plane (general)
-K NPN transistor
+D NPN transistor, base/collector/emitter, collector connected to mounting plane
+K transistor NPN
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_BEC
-D Transistor NPN (general)
-K NPN transistor
+D NPN transistor, base/emitter/collector
+K transistor NPN
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_CBE
-D Transistor NPN (general)
-K NPN transistor
+D NPN transistor, collector/base/emitter
+K transistor NPN
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_CEB
-D Transistor NPN (general)
-K NPN transistor
+D NPN transistor, collector/emitter/base
+K transistor NPN
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_BCE
-D Darlington transistor NPN (general)
-K NPN transistor Darlington
+D NPN Darlington transistor, base/collector/emitter
+K transistor NPN Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_BCEC
-D Darlington transistor NPN (general)
-K NPN transistor Darlington
+D NPN Darlington transistor, base/collector/emitter, collector connected to mounting plane
+K transistor NPN Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_BEC
-D Darlington transistor NPN (general)
-K NPN transistor Darlington
+D NPN Darlington transistor, base/emitter/collector
+K transistor NPN Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_CBE
-D Darlington transistor NPN (general)
-K NPN transistor Darlington
+D NPN Darlington transistor, collector/base/emitter
+K transistor NPN Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_CEB
-D Darlington transistor NPN (general)
-K NPN transistor Darlington
+D NPN Darlington transistor, collector/emitter/base
+K transistor NPN Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_EBC
-D Darlington transistor NPN (general)
-K NPN transistor Darlington
+D NPN Darlington transistor, emitter/base/collector
+K transistor NPN Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_ECB
-D Darlington transistor NPN (general)
-K NPN transistor Darlington
+D NPN Darlington transistor, emitter/collector/base
+K transistor NPN Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_ECBC
-D Darlington transistor NPN (general)
-K NPN transistor Darlington
+D NPN Darlington transistor, emitter/collector/base, collector connected to mounting plane
+K transistor NPN Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_EBC
-D Transistor NPN (general)
-K NPN transistor
+D NPN transistor, emitter/base/collector
+K transistor NPN
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_ECB
-D Transistor NPN (general)
-K NPN transistor
+D NPN transistor, emitter/collector/base
+K transistor NPN
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_ECBC
-D Transistor NPN, collector connected to mounting plane (general)
-K NPN transistor
+D NPN transistor, emitter/collector/base, collector connected to mounting plane
+K transistor NPN
 F ~
 $ENDCMP
 #
 $CMP Q_NUJT_BEB
-D Transistor N-Type unijunction (UJT, general)
-K UJT transistor
+D N-Type unijunction transistor
+K transistor UJT
 F ~
 $ENDCMP
 #
 $CMP Q_PJFET_DGS
-D Transistor P-JFET (general)
-K PJFET P-JFET transistor
+D P-JFET transistor, drain/gate/source
+K transistor PJFET P-JFET
 F ~
 $ENDCMP
 #
 $CMP Q_PJFET_DSG
-D Transistor P-JFET (general)
-K PJFET P-JFET transistor
+D P-JFET transistor, drain/source/gate
+K transistor PJFET P-JFET
 F ~
 $ENDCMP
 #
 $CMP Q_PJFET_GDS
-D Transistor P-JFET (general)
-K PJFET P-JFET transistor
+D P-JFET transistor, gate/drain/source
+K transistor PJFET P-JFET
 F ~
 $ENDCMP
 #
 $CMP Q_PJFET_GSD
-D Transistor P-JFET (general)
-K PJFET P-JFET transistor
+D P-JFET transistor, gate/source/drain
+K transistor PJFET P-JFET
 F ~
 $ENDCMP
 #
 $CMP Q_PJFET_SDG
-D Transistor P-JFET (general)
-K PJFET P-JFET transistor
+D P-JFET transistor, source/drain/gate
+K transistor PJFET P-JFET
 F ~
 $ENDCMP
 #
 $CMP Q_PJFET_SGD
-D Transistor P-JFET (general)
-K PJFET P-JFET transistor
+D P-JFET transistor, source/gate/drain
+K transistor PJFET P-JFET
 F ~
 $ENDCMP
 #
 $CMP Q_PMOS_DGS
-D Transistor P-MOSFET with substrate diode (general)
-K PMOS P-MOS P-MOSFET transistor
+D P-MOSFET transistor, drain/gate/source
+K transistor PMOS P-MOS P-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_PMOS_DSG
-D Transistor P-MOSFET with substrate diode (general)
-K PMOS P-MOS P-MOSFET transistor
+D P-MOSFET transistor, drain/source/gate
+K transistor PMOS P-MOS P-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_PMOS_GDS
-D Transistor P-MOSFET with substrate diode (general)
-K PMOS P-MOS P-MOSFET transistor
+D P-MOSFET transistor, gate/drain/source
+K transistor PMOS P-MOS P-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_PMOS_GDSD
-D Transistor P-MOSFET with substrate diode, drain connected to mounting plane (general)
-K PMOS P-MOS P-MOSFET transistor
+D P-MOSFET transistor, gate/drain/source, drain connected to mounting plane
+K transistor PMOS P-MOS P-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_PMOS_GSD
-D Transistor P-MOSFET with substrate diode (general)
-K PMOS P-MOS P-MOSFET transistor
+D P-MOSFET transistor, gate/source/drain
+K transistor PMOS P-MOS P-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_PMOS_SDG
-D Transistor P-MOSFET with substrate diode (general)
-K PMOS P-MOS P-MOSFET transistor
+D P-MOSFET transistor, source/drain/gate
+K transistor PMOS P-MOS P-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_PMOS_SDGD
-D Transistor P-MOSFET with substrate diode, drain connected to mounting plane (general)
-K PMOS P-MOS P-MOSFET transistor
+D P-MOSFET transistor, source/drain/gate, drain connected to mounting plane
+K transistor PMOS P-MOS P-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_PMOS_SGD
-D Transistor P-MOSFET with substrate diode (general)
-K PMOS P-MOS P-MOSFET transistor
+D P-MOSFET transistor, source/gate/drain
+K transistor PMOS P-MOS P-MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_BCE
-D Transistor PNP (general)
-K PNP transistor
+D PNP transistor, base/collector/emitter
+K transistor PNP
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_BCEC
-D Transistor PNP, collector connected to mounting plane (general)
-K PNP transistor
+D PNP transistor, base/collector/emitter, collector connected to mounting plane
+K transistor PNP
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_BEC
-D Transistor PNP (general)
-K PNP transistor
+D PNP transistor, base/emitter/collector
+K transistor PNP
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_CBE
-D Transistor PNP (general)
-K PNP transistor
+D PNP transistor, collector/base/emitter
+K transistor PNP
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_CEB
-D Transistor PNP (general)
-K PNP transistor
+D PNP transistor, collector/emitter/base
+K transistor PNP
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_BCE
-D Darlington transistor PNP (general)
-K PNP transistor Darlington
+D PNP Darlington transistor, base/collector/emitter
+K transistor PNP Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_BCEC
-D Darlington transistor PNP, collector connected to mounting plane (general)
-K PNP transistor Darlington
+D PNP Darlington transistor, base/collector/emitter, collector connected to mounting plane
+K transistor PNP Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_BEC
-D Darlington transistor PNP (general)
-K PNP transistor Darlington
+D PNP Darlington transistor, base/emitter/collector
+K transistor PNP Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_CBE
-D Darlington transistor PNP (general)
-K PNP transistor Darlington
+D PNP Darlington transistor, collector/base/emitter
+K transistor PNP Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_CEB
-D Darlington transistor PNP (general)
-K PNP transistor Darlington
+D PNP Darlington transistor, collector/emitter/base
+K transistor PNP Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_EBC
-D Darlington transistor PNP (general)
-K PNP transistor Darlington
+D PNP Darlington transistor, emitter/base/collector
+K transistor PNP Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_ECB
-D Darlington transistor PNP (general)
-K PNP transistor Darlington
+D PNP Darlington transistor, emitter/collector/base
+K transistor PNP Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_ECBC
-D Darlington transistor PNP, collector connected to mounting plane (general)
-K PNP transistor Darlington
+D PNP Darlington transistor, emitter/collector/base, collector connected to mounting plane
+K transistor PNP Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_EBC
-D Transistor PNP (general)
-K PNP transistor
+D PNP transistor, emitter/base/collector
+K transistor PNP
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_ECB
-D Transistor PNP (general)
-K PNP transistor
+D PNP transistor, emitter/collector/base
+K transistor PNP
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_ECBC
-D Transistor PNP, collector connected to mounting plane (general)
-K PNP transistor
+D PNP transistor, emitter/collector/base, collector connected to mounting plane
+K transistor PNP
 F ~
 $ENDCMP
 #
 $CMP Q_PUJT_BEB
-D Transistor P-Type unijunction (UJT, general)
-K UJT transistor
+D P-Type unijunction transistor
+K transistor UJT
 F ~
 $ENDCMP
 #
 $CMP Q_Photo_NPN
-D Phototransistor NPN, 2-pin (C=1, E=2)
-K NPN phototransistor
+D NPN phototransistor, collector/emitter
+K phototransistor NPN
 F ~
 $ENDCMP
 #
 $CMP Q_Photo_NPN_CBE
-D Phototransistor NPN, 3-pin with base pin (C=1, B=2, E=3)
-K NPN phototransistor
+D NPN phototransistor, collector/base/emitter
+K phototransistor NPN
 F ~
 $ENDCMP
 #
 $CMP Q_Photo_NPN_CE
-D Phototransistor NPN, 2-pin (C=1, E=2)
-K NPN phototransistor
+D NPN phototransistor, collector/emitter
+K phototransistor NPN
 F ~
 $ENDCMP
 #
 $CMP Q_Photo_NPN_EBC
-D Phototransistor NPN, 3-pin with base pin (E=1, B=2, C=3)
-K NPN phototransistor
+D NPN phototransistor, emitter/base/collector
+K phototransistor NPN
 F ~
 $ENDCMP
 #
 $CMP Q_Photo_NPN_EC
-D Phototransistor NPN, 2-pin (E=1, C=2)
-K NPN phototransistor
+D NPN phototransistor, emitter/collector
+K phototransistor NPN
 F ~
 $ENDCMP
 #
 $CMP Q_SCR_AGK
-D Silicon controlled rectifier (SCR, Thyristor)
-K thyristor silicon controlled rectifier
+D Silicon controlled rectifier, anode/gate/cathode
+K SCR thyristor
 F ~
 $ENDCMP
 #
 $CMP Q_SCR_AKG
-D Silicon controlled rectifier (SCR, Thyristor)
-K thyristor silicon controlled rectifier
+D Silicon controlled rectifier, anode/cathode/gate
+K SCR thyristor
 F ~
 $ENDCMP
 #
 $CMP Q_SCR_GAK
-D Silicon controlled rectifier (SCR, Thyristor)
-K thyristor silicon controlled rectifier
+D Silicon controlled rectifier, gate/anode/cathode
+K SCR thyristor
 F ~
 $ENDCMP
 #
 $CMP Q_SCR_GKA
-D Silicon controlled rectifier (SCR, Thyristor)
-K thyristor silicon controlled rectifier
+D Silicon controlled rectifier, gate/cathode/anode
+K SCR thyristor
 F ~
 $ENDCMP
 #
 $CMP Q_SCR_KAG
-D Silicon controlled rectifier (SCR, Thyristor)
-K thyristor silicon controlled rectifier
+D Silicon controlled rectifier, cathode/anode/gate
+K SCR thyristor
 F ~
 $ENDCMP
 #
 $CMP Q_SCR_KGA
-D Silicon controlled rectifier (SCR, Thyristor)
-K thyristor silicon controlled rectifier
+D Silicon controlled rectifier, cathode/gate/anode
+K SCR thyristor
 F ~
 $ENDCMP
 #
 $CMP Q_TRIAC_A1A2G
-D Triode for alternating current (TRIAC), pinordering A1=1, A2=2, G=3
-K triode for alternating current TRIAC
+D Triode for alternating current, anode1/anode2/gate
+K TRIAC
 F ~
 $ENDCMP
 #
 $CMP Q_TRIAC_A1GA2
-D Triode for alternating current (TRIAC), pinordering A1=1, A2=3, G=2
-K triode for alternating current TRIAC
+D Triode for alternating current, anode1/gate/anode2
+K TRIAC
 F ~
 $ENDCMP
 #
 $CMP Q_TRIAC_A2A1G
-D Triode for alternating current (TRIAC), pinordering A1=2, A2=1, G=3
-K triode for alternating current TRIAC
+D Triode for alternating current, anode2/anode1/gate
+K TRIAC
 F ~
 $ENDCMP
 #
 $CMP Q_TRIAC_A2GA1
-D Triode for alternating current (TRIAC), pinordering A1=3, A2=1, G=2
-K triode for alternating current TRIAC
+D Triode for alternating current, anode2/gate/anode1
+K TRIAC
 F ~
 $ENDCMP
 #
 $CMP Q_TRIAC_GA1A2
-D Triode for alternating current (TRIAC), pinordering A1=2, A2=3, G=1
-K triode for alternating current TRIAC
+D Triode for alternating current, gate/anode1/anode2
+K TRIAC
 F ~
 $ENDCMP
 #
 $CMP Q_TRIAC_GA2A1
-D Triode for alternating current (TRIAC), pinordering A1=3, A2=2, G=1
-K triode for alternating current TRIAC
+D Triode for alternating current, gate/anode2/anode1
+K TRIAC
 F ~
 $ENDCMP
 #
@@ -1813,68 +1813,68 @@ F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x02_SIP
-D 2 voltage dividers network, dual terminator, SIP package
+D 2 voltage divider network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x03_SIP
-D 3 voltage dividers network, dual terminator, SIP package
+D 3 voltage divider network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x04_SIP
-D 4 voltage dividers network, dual terminator, SIP package
+D 4 voltage divider network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x05_SIP
-D 5 voltage dividers network, dual terminator, SIP package
+D 5 voltage divider network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x06_SIP
-D 6 voltage dividers network, dual terminator, SIP package
+D 6 voltage divider network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x07_SIP
-D 7 voltage dividers network, dual terminator, SIP package
+D 7 voltage divider network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x08_SIP
-D 8 voltage dividers network, dual terminator, SIP package
+D 8 voltage divider network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x09_SIP
-D 9 voltage dividers network, dual terminator, SIP package
+D 9 voltage divider network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x10_SIP
-D 10 voltage dividers network, dual terminator, SIP package
+D 10 voltage divider network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x11_SIP
-D 11 voltage dividers network, dual terminator, SIP package
+D 11 voltage divider network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_PHOTO
-D Photoresistor, light sensitive resistor, LDR
-K resistor variable light opto LDR
+D Photoresistor
+K resistor variable light sensitive opto LDR
 F ~
 $ENDCMP
 #
@@ -1903,13 +1903,13 @@ F ~
 $ENDCMP
 #
 $CMP R_POT_TRIM_US
-D Trim-potentiometer US symbol
+D Trim-potentiometer, US symbol
 K resistor variable trimpot trimmer
 F ~
 $ENDCMP
 #
 $CMP R_POT_US
-D Potentiometer US symbol
+D Potentiometer, US symbol
 K resistor variable
 F ~
 $ENDCMP
@@ -2017,7 +2017,7 @@ F ~
 $ENDCMP
 #
 $CMP R_Shunt_US
-D Shunt resistor US symbol
+D Shunt resistor, US symbol
 K R res shunt resistor
 F ~
 $ENDCMP
@@ -2029,20 +2029,20 @@ F ~
 $ENDCMP
 #
 $CMP R_US
-D Resistor US symbol
+D Resistor, US symbol
 K R res resistor
 F ~
 $ENDCMP
 #
 $CMP R_Variable
-D Variable resistor (rheostat)
-K R res resistor variable potentiometer
+D Variable resistor
+K R res resistor variable potentiometer rheostat
 F ~
 $ENDCMP
 #
 $CMP R_Variable_US
-D Variable resistor (rheostat) US symbol
-K R res resistor variable potentiometer
+D Variable resistor, US symbol
+K R res resistor variable potentiometer rheostat
 F ~
 $ENDCMP
 #
@@ -2053,7 +2053,7 @@ F ~
 $ENDCMP
 #
 $CMP Resonator_Small
-D Three pin ceramic resonator
+D Three pin ceramic resonator, small symbol
 K ceramic resonator
 F ~
 $ENDCMP
@@ -2107,61 +2107,61 @@ F ~
 $ENDCMP
 #
 $CMP Thermistor
-D Thermistor, temperature dependent resistor
+D Temperature dependent resistor
 K R res thermistor
 F ~
 $ENDCMP
 #
 $CMP Thermistor_NTC
-D Temperature dependent resistor, negative temperature coefficient (NTC)
+D Temperature dependent resistor, negative temperature coefficient
 K thermistor NTC resistor sensor RTD
 F ~
 $ENDCMP
 #
 $CMP Thermistor_NTC_3wire
-D Temperature dependent resistor, negative temperature coefficient (NTC), 3-wire interface
+D Temperature dependent resistor, negative temperature coefficient, 3-wire interface
 K thermistor NTC resistor sensor RTD
 F ~
 $ENDCMP
 #
 $CMP Thermistor_NTC_4wire
-D Temperature dependent resistor, negative temperature coefficient (NTC), 4-wire interface
+D Temperature dependent resistor, negative temperature coefficient, 4-wire interface
 K thermistor NTC resistor sensor RTD
 F ~
 $ENDCMP
 #
 $CMP Thermistor_NTC_US
-D Temperature dependent resistor, negative temperature coefficient (NTC) US symbol
+D Temperature dependent resistor, negative temperature coefficient, US symbol
 K thermistor NTC resistor sensor RTD
 F ~
 $ENDCMP
 #
 $CMP Thermistor_PTC
-D Temperature dependent resistor, positive temperature coefficient (PTC)
+D Temperature dependent resistor, positive temperature coefficient
 K resistor PTC thermistor sensor RTD
 F ~
 $ENDCMP
 #
 $CMP Thermistor_PTC_3wire
-D Temperature dependent resistor, positive temperature coefficient (PTC), 3-wire interface
+D Temperature dependent resistor, positive temperature coefficient, 3-wire interface
 K resistor PTC thermistor sensor RTD
 F ~
 $ENDCMP
 #
 $CMP Thermistor_PTC_4wire
-D Temperature dependent resistor, positive temperature coefficient (PTC), 3-wire interface
+D Temperature dependent resistor, positive temperature coefficient, 3-wire interface
 K resistor PTC thermistor sensor RTD
 F ~
 $ENDCMP
 #
 $CMP Thermistor_PTC_US
-D Temperature dependent resistor, positive temperature coefficient (PTC) US symbol
+D Temperature dependent resistor, positive temperature coefficient, US symbol
 K resistor PTC thermistor sensor RTD
 F ~
 $ENDCMP
 #
 $CMP Thermistor_US
-D Thermistor, temperature dependent resistor US symbol
+D Thermistor, temperature dependent resistor, US symbol
 K R res thermistor
 F ~
 $ENDCMP
@@ -2233,25 +2233,25 @@ F ~
 $ENDCMP
 #
 $CMP Varistor_US
-D Voltage dependent resistor US symbol
+D Voltage dependent resistor, US symbol
 K VDR resistance
 F ~
 $ENDCMP
 #
 $CMP Voltage_Divider
-D Voltage divider in a single package
+D Voltage divider
 K R network voltage divider
 F ~
 $ENDCMP
 #
 $CMP Voltage_Divider_CenterPin1
-D Voltage divider (center=pin1)
+D Voltage divider, center on pin 1
 K R network voltage divider
 F ~
 $ENDCMP
 #
 $CMP Voltage_Divider_CenterPin3
-D Voltage divider (center=pin3)
+D Voltage divider, center on pin 3
 K R network voltage divider
 F ~
 $ENDCMP

--- a/Device.dcm
+++ b/Device.dcm
@@ -1051,13 +1051,13 @@ F ~
 $ENDCMP
 #
 $CMP Opamp_Dual_Generic
-D Dual operational amplifier, SOIC-8/DIP-8/SSOP-8/TO-99
+D Dual operational amplifier
 K dual opamp
 F ~
 $ENDCMP
 #
 $CMP Opamp_Quad_Generic
-D Quad operational amplifier, SOIC-14/DIP-14/SSOP-14
+D Quad operational amplifier
 K quad opamp
 F ~
 $ENDCMP

--- a/Device.dcm
+++ b/Device.dcm
@@ -2,13 +2,13 @@ EESchema-DOCLIB  Version 2.0
 #
 $CMP Amperemeter_AC
 D AC Amperemeter
-K Amperemeter AC
+K amperemeter AC
 F ~
 $ENDCMP
 #
 $CMP Amperemeter_DC
 D DC Amperemeter
-K Amperemeter DC
+K amperemeter DC
 F ~
 $ENDCMP
 #
@@ -56,7 +56,7 @@ $ENDCMP
 #
 $CMP Buzzer
 D Buzzer, polar
-K Quartz Resonator Ceramic
+K quartz resonator ceramic
 F ~
 $ENDCMP
 #
@@ -206,31 +206,31 @@ $ENDCMP
 #
 $CMP D_Bridge_+-AA
 D Diode bridge (pins: 1=+, 2=-, 3=AC, 4=AC)
-K rectifier acdc
+K rectifier ACDC
 F ~
 $ENDCMP
 #
 $CMP D_Bridge_+A-A
 D Diode bridge (pins: 1=+, 2=AC, 3=-, 4=AC)
-K rectifier acdc
+K rectifier ACDC
 F ~
 $ENDCMP
 #
 $CMP D_Bridge_+AA-
 D Diode bridge (pins: 1=+, 2=AC, 3=AC, 4=-)
-K rectifier acdc
+K rectifier ACDC
 F ~
 $ENDCMP
 #
 $CMP D_Bridge_-A+A
 D Diode bridge (pins: 1=-, 2=AC, 3=+, 4=AC)
-K rectifier acdc
+K rectifier ACDC
 F ~
 $ENDCMP
 #
 $CMP D_Bridge_-AA+
 D Diode bridge (pins: 1=-, 2=AC, 3=AC, 4=+)
-K rectifier acdc
+K rectifier ACDC
 F ~
 $ENDCMP
 #
@@ -278,55 +278,55 @@ $ENDCMP
 #
 $CMP D_Schottky_AAK
 D Schottky diode, two anode pins
-K diode schotty SCHDPAK
+K diode Schottky SCHDPAK
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_AKA
 D Schottky diode, two anode pins
-K diode schotty SCHDPAK
+K diode Schottky SCHDPAK
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_AKK
 D Schottky diode, two cathode pins
-K diode schotty SCHDPAK
+K diode Schottky SCHDPAK
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_ALT
 D Schottky diode, alternativ symbol
-K diode schotty
+K diode Schottky
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_KAA
 D Schottky diode, two anode pins
-K diode schotty SCHDPAK
+K diode Schottky SCHDPAK
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_KAK
 D Schottky diode, two cathode pins
-K diode schotty SCHDPAK
+K diode Schottky SCHDPAK
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_KKA
 D Schottky diode, two cathode pins
-K diode schotty SCHDPAK
+K diode Schottky SCHDPAK
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_Small
 D Schottky diode, small symbol
-K diode schottky
+K diode Schottky
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_Small_ALT
 D Schottky diode, small symbol, alternativ symbol
-K diode schottky
+K diode Schottky
 F ~
 $ENDCMP
 #
@@ -638,31 +638,31 @@ $ENDCMP
 #
 $CMP Ferrite_Bead
 D Ferrite bead
-K L ferite bead inductor filter
+K L ferrite bead inductor filter
 F ~
 $ENDCMP
 #
 $CMP Ferrite_Bead_Small
 D Ferrite bead, small symbol
-K L ferite bead inductor filter
+K L ferrite bead inductor filter
 F ~
 $ENDCMP
 #
 $CMP Frequency_Counter
 D Frequency Counter
-K Frequency Counter
+K frequency counter
 F ~
 $ENDCMP
 #
 $CMP Fuse
 D Fuse, generic
-K Fuse
+K fuse
 F ~
 $ENDCMP
 #
 $CMP Fuse_Polarized
 D Fuse, generic
-K Fuse
+K fuse
 F ~
 $ENDCMP
 #
@@ -680,7 +680,7 @@ $ENDCMP
 #
 $CMP Galvanometer
 D Galvanometer
-K Galvanometer
+K galvanometer
 F ~
 $ENDCMP
 #
@@ -698,13 +698,13 @@ $ENDCMP
 #
 $CMP Jumper
 D Jumper, generic, normally closed
-K jumper bridge link nc
+K jumper bridge link NC
 F ~
 $ENDCMP
 #
 $CMP Jumper_NC_Dual
 D Dual Jumper, normally closed
-K jumper bridge link nc
+K jumper bridge link NC
 F ~
 $ENDCMP
 #
@@ -728,139 +728,139 @@ $ENDCMP
 #
 $CMP LED
 D LED generic
-K led diode
+K LED diode
 F ~
 $ENDCMP
 #
 $CMP LED_ALT
 D LED generic, alternativ symbol
-K led diode
+K LED diode
 F ~
 $ENDCMP
 #
 $CMP LED_ARGB
 D LED RGB, common anode (pin 1)
-K led rgb diode
+K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_BGRA
 D LED RGB, common anode
-K led rgb diode
+K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_CRGB
 D LED RGB, Common Cathode
-K led rgb diode
+K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_Dual_2pin
 D LED dual, 2pin version
-K led diode bicolor dual
+K LED diode bicolor dual
 F ~
 $ENDCMP
 #
 $CMP LED_Dual_AAC
 D LED dual, common cathode
-K led diode bicolor dual
+K LED diode bicolor dual
 F ~
 $ENDCMP
 #
 $CMP LED_Dual_AACC
 D LED dual, 4-pin
-K led diode bicolor dual
+K LED diode bicolor dual
 F ~
 $ENDCMP
 #
 $CMP LED_Dual_ACA
 D LED dual, common cathode
-K led diode bicolor dual
+K LED diode bicolor dual
 F ~
 $ENDCMP
 #
 $CMP LED_Dual_ACAC
 D LED dual, 4-pin
-K led diode bicolor dual
+K LED diode bicolor dual
 F ~
 $ENDCMP
 #
 $CMP LED_Dual_CAC
 D LED dual, common anode
-K led diode bicolor dual
+K LED diode bicolor dual
 F ~
 $ENDCMP
 #
 $CMP LED_Dual_CCA
 D LED dual, common anode
-K led diode bicolor dual
+K LED diode bicolor dual
 F ~
 $ENDCMP
 #
 $CMP LED_PAD
 D LED with pad
-K led diode pad
+K LED diode pad
 F ~
 $ENDCMP
 #
 $CMP LED_RABG
 D LED RGB, common anode
-K led rgb diode
+K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_RAGB
 D LED RGB, common anode
-K led rgb diode
+K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_RCBG
 D LED RGB, Common Cathode
-K led rgb diode
+K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_RCGB
 D LED RGB, Common Cathode
-K led rgb diode
+K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_RGB
 D LED RGB 6 pins
-K led rgb diode
+K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_RGB_EP
 D LED RGB 6 pins, exposed pad
-K led rgb diode
+K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_Series
 D several LEDs in series
-K led diode
+K LED diode
 F ~
 $ENDCMP
 #
 $CMP LED_Series_PAD
 D LED with pad
-K led diode pad
+K LED diode pad
 F ~
 $ENDCMP
 #
 $CMP LED_Small
 D LED, small symbol
-K led diode light-emitting-diode
+K LED diode light-emitting-diode
 F ~
 $ENDCMP
 #
 $CMP LED_Small_ALT
 D LED, small symbol, alternativ symbol
-K led diode light-emitting-diode
+K LED diode light-emitting-diode
 F ~
 $ENDCMP
 #
@@ -986,19 +986,19 @@ $ENDCMP
 #
 $CMP MEMRISTOR
 D Memristor
-K Memristor
+K memristor
 F ~
 $ENDCMP
 #
 $CMP Microphone
 D Microphone
-K Microphone
+K microphone
 F ~
 $ENDCMP
 #
 $CMP Microphone_Condenser
 D Condenser Microspcope
-K Capacitance condenser Microphone
+K capacitance condenser microphone
 F ~
 $ENDCMP
 #
@@ -1010,7 +1010,7 @@ $ENDCMP
 #
 $CMP Microphone_Ultrasound
 D Ultrasound receiver
-K Microphone Ultrasound crystal
+K microphone ultrasound crystal
 F ~
 $ENDCMP
 #
@@ -1046,7 +1046,7 @@ $ENDCMP
 #
 $CMP Ohmmeter
 D Ohmmeter, measures resistance
-K Ohmmeter
+K ohmmeter
 F ~
 $ENDCMP
 #
@@ -1064,7 +1064,7 @@ $ENDCMP
 #
 $CMP Oscilloscope
 D Oscilloscope
-K Oscilloscope
+K oscilloscope
 F ~
 $ENDCMP
 #
@@ -1088,277 +1088,277 @@ $ENDCMP
 #
 $CMP Q_DUAL_NMOS_G1S2G2D2S1D1
 D Dual NMOS/NMOS transistor, 6-pin package
-K dual nmosfet nmos/nmos
+K dual NMOSFET NMOS/NMOS
 F ~
 $ENDCMP
 #
 $CMP Q_DUAL_NPN_C2C1E1E2
 D Double NPN Transistors, Current mirror configuration
-K Transistor Double NPN
+K transistor double NPN
 F ~
 $ENDCMP
 #
 $CMP Q_DUAL_NPN_NPN_E1B1C2E2B2C1
 D Dual NPN/NPN Transistor, 6-pin package
-K NPN/NPN Transistor
+K NPN/NPN transistor
 F ~
 $ENDCMP
 #
 $CMP Q_DUAL_NPN_PNP_E1B1C2E2B2C1
 D Dual NPN/PNP Transistor, 6-pin package
-K NPN/PNP Transistor
+K NPN/PNP transistor
 F ~
 $ENDCMP
 #
 $CMP Q_DUAL_PMOS_G1S2G2D2S1D1
 D Dual PMOS/PMOS transistor, 6-pin package
-K dual pmos/pmos mosfet
+K dual PMOS/PMOS MOSFET
 F ~
 $ENDCMP
 #
 $CMP Q_DUAL_PNP_C2C1E1E2
 D Double PNP Transistors, Current mirror configuration
-K Transistor Double PNP
+K transistor double PNP
 F ~
 $ENDCMP
 #
 $CMP Q_DUAL_PNP_PNP_C1B1B2C2E2E1
 D Dual PNP/PNP Transistor, 6-pin package
-K PNP/PNP Transistor
+K PNP/PNP transistor
 F https://www.diodes.com/assets/Datasheets/ds30437.pdf
 $ENDCMP
 #
 $CMP Q_DUAL_PNP_PNP_E1B1C2E2B2C1
 D Dual PNP/PNP Transistor, 6-pin package
-K PNP/PNP Transistor
+K PNP/PNP transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NIGBT_CEG
 D Transistor N-IGBT (general)
-K igbt n-igbt transistor
+K IGBT N-IGBT transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NIGBT_CGE
 D Transistor N-IGBT (general)
-K igbt n-igbt transistor
+K IGBT N-IGBT transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NIGBT_ECG
 D Transistor N-IGBT (general)
-K igbt n-igbt transistor
+K IGBT N-IGBT transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NIGBT_ECGC
 D Transistor N-IGBT, collector connected to mounting plane (general)
-K igbt n-igbt transistor
+K IGBT N-IGBT transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NIGBT_EGC
 D Transistor N-IGBT (general)
-K igbt n-igbt transistor
+K IGBT N-IGBT transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NIGBT_GCE
 D Transistor N-IGBT (general)
-K igbt n-igbt transistor
+K IGBT N-IGBT transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NIGBT_GCEC
 D Transistor N-IGBT, collector connected to mounting plane (general)
-K igbt n-igbt transistor
+K IGBT N-IGBT transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NIGBT_GEC
 D Transistor N-IGBT (general)
-K igbt n-igbt transistor
+K IGBT N-IGBT transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NJFET_DGS
 D Transistor N-JFET (general)
-K njfet n-jfet transistor
+K NJFET N-JFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NJFET_DSG
 D Transistor N-JFET (general)
-K njfet n-jfet transistor
+K NJFET N-JFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NJFET_GDS
 D Transistor N-JFET (general)
-K njfet n-jfet transistor
+K NJFET N-JFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NJFET_GSD
 D Transistor N-JFET (general)
-K njfet n-jfet transistor
+K NJFET N-JFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NJFET_SDG
 D Transistor N-JFET (general)
-K njfet n-jfet transistor
+K NJFET N-JFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NJFET_SGD
 D Transistor N-JFET (general)
-K njfet n-jfet transistor
+K NJFET N-JFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_DGS
 D Transistor N-MOSFET (general)
-K nmos n-mos n-mosfet transistor
+K NMOS N-MOS N-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_DSG
 D Transistor N-MOSFET with substrate diode (general)
-K NMOS n-mos n-mosfet transistor
+K NMOS N-MOS N-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_GDS
 D Transistor N-MOSFET with substrate diode (general)
-K nmos n-mos n-mosfet transistor
+K NMOS N-MOS N-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_GDSD
 D Transistor N-MOSFETwith substrate diode, drain connected to mounting plane (general)
-K NMOS n-mos n-mosfet transistor
+K NMOS N-MOS N-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_GSD
 D Transistor N-MOSFETwith substrate diode (general)
-K NMOS n-mos n-mosfet transistor
+K NMOS N-MOS N-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_SDG
 D Transistor N-MOSFETwith substrate diode (general)
-K NMOS n-mos n-mosfet transistor
+K NMOS N-MOS N-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_SDGD
 D Transistor N-MOSFETwith substrate diode, drain connected to mounting plane (general)
-K NMOS n-mos n-mosfet transistor
+K NMOS N-MOS N-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_SGD
 D Transistor N-MOSFETwith substrate diode (general)
-K NMOS n-mos n-mosfet transistor
+K NMOS N-MOS N-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_BCE
 D Transistor NPN (general)
-K npn transistor
+K NPN transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_BCEC
 D Transistor NPN, collector connected to mounting plane (general)
-K npn transistor
+K NPN transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_BEC
 D Transistor NPN (general)
-K npn transistor
+K NPN transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_CBE
 D Transistor NPN (general)
-K npn transistor
+K NPN transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_CEB
 D Transistor NPN (general)
-K npn transistor
+K NPN transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_BCE
 D Darlington Transistor NPN (general)
-K npn transistor darlington
+K NPN transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_BCEC
 D Darlington Transistor NPN (general)
-K npn transistor darlington
+K NPN transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_BEC
 D Darlington Transistor NPN (general)
-K npn transistor darlington
+K NPN transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_CBE
 D Darlington Transistor NPN (general)
-K npn transistor darlington
+K NPN transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_CEB
 D Darlington Transistor NPN (general)
-K npn transistor darlington
+K NPN transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_EBC
 D Darlington Transistor NPN (general)
-K npn transistor darlington
+K NPN transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_ECB
 D Darlington Transistor NPN (general)
-K npn transistor darlington
+K NPN transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_ECBC
 D Darlington Transistor NPN (general)
-K npn transistor darlington
+K NPN transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_EBC
 D Transistor NPN (general)
-K npn transistor
+K NPN transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_ECB
 D Transistor NPN (general)
-K npn transistor
+K NPN transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_ECBC
 D Transistor NPN, collector connected to mounting plane (general)
-K npn transistor
+K NPN transistor
 F ~
 $ENDCMP
 #
@@ -1370,181 +1370,181 @@ $ENDCMP
 #
 $CMP Q_PJFET_DGS
 D Transistor P-JFET (general)
-K pjfet p-jfet transistor
+K PJFET P-JFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PJFET_DSG
 D Transistor P-JFET (general)
-K pjfet p-jfet transistor
+K PJFET P-JFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PJFET_GDS
 D Transistor P-JFET (general)
-K pjfet p-jfet transistor
+K PJFET P-JFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PJFET_GSD
 D Transistor P-JFET (general)
-K pjfet p-jfet transistor
+K PJFET P-JFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PJFET_SDG
 D Transistor P-JFET (general)
-K pjfet p-jfet transistor
+K PJFET P-JFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PJFET_SGD
 D Transistor P-JFET (general)
-K pjfet p-jfet transistor
+K PJFET P-JFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PMOS_DGS
 D Transistor P-MOSFET with substrate diode (general)
-K pmos p-mos p-mosfet transistor
+K PMOS P-MOS P-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PMOS_DSG
 D Transistor P-MOSFET with substrate diode (general)
-K pmos p-mos p-mosfet transistor
+K PMOS P-MOS P-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PMOS_GDS
 D Transistor P-MOSFET with substrate diode (general)
-K pmos p-mos p-mosfet transistor
+K PMOS P-MOS P-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PMOS_GDSD
 D Transistor P-MOSFET with substrate diode, drain connected to mounting plane (general)
-K pmos p-mos p-mosfet transistor
+K PMOS P-MOS P-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PMOS_GSD
 D Transistor P-MOSFET with substrate diode (general)
-K pmos p-mos p-mosfet transistor
+K PMOS P-MOS P-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PMOS_SDG
 D Transistor P-MOSFET with substrate diode (general)
-K pmos p-mos p-mosfet transistor
+K PMOS P-MOS P-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PMOS_SDGD
 D Transistor P-MOSFET with substrate diode, drain connected to mounting plane (general)
-K pmos p-mos p-mosfet transistor
+K PMOS P-MOS P-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PMOS_SGD
 D Transistor P-MOSFET with substrate diode (general)
-K pmos p-mos p-mosfet transistor
+K PMOS P-MOS P-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_BCE
 D Transistor PNP (general)
-K pnp transistor
+K PNP transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_BCEC
 D Transistor PNP, collector connected to mounting plane (general)
-K pnp transistor
+K PNP transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_BEC
 D Transistor PNP (general)
-K pnp transistor
+K PNP transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_CBE
 D Transistor PNP (general)
-K pnp transistor
+K PNP transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_CEB
 D Transistor PNP (general)
-K pnp transistor
+K PNP transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_BCE
 D Darlington Transistor PNP (general)
-K PNP transistor darlington
+K PNP transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_BCEC
 D Darlington Transistor PNP, collector connected to mounting plane (general)
-K PNP transistor darlington
+K PNP transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_BEC
 D Darlington Transistor PNP (general)
-K PNP transistor darlington
+K PNP transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_CBE
 D Darlington Transistor PNP (general)
-K PNP transistor darlington
+K PNP transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_CEB
 D Darlington Transistor PNP (general)
-K PNP transistor darlington
+K PNP transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_EBC
 D Darlington Transistor PNP (general)
-K PNP transistor darlington
+K PNP transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_ECB
 D Darlington Transistor PNP (general)
-K PNP transistor darlington
+K PNP transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_ECBC
 D Darlington Transistor PNP, collector connected to mounting plane (general)
-K PNP transistor darlington
+K PNP transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_EBC
 D Transistor PNP (general)
-K pnp transistor
+K PNP transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_ECB
 D Transistor PNP (general)
-K pnp transistor
+K PNP transistor
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_ECBC
 D Transistor PNP, collector connected to mounting plane (general)
-K pnp transistor
+K PNP transistor
 F ~
 $ENDCMP
 #
@@ -1556,25 +1556,25 @@ $ENDCMP
 #
 $CMP Q_Photo_NPN
 D Phototransistor NPN, 2-pin (C=1, E=2)
-K npn phototransistor
+K NPN phototransistor
 F ~
 $ENDCMP
 #
 $CMP Q_Photo_NPN_CBE
 D Phototransistor NPN, 3-pin with base pin (C=1, B=2, E=3)
-K npn phototransistor
+K NPN phototransistor
 F ~
 $ENDCMP
 #
 $CMP Q_Photo_NPN_CE
 D Phototransistor NPN, 2-pin (C=1, E=2)
-K npn phototransistor
+K NPN phototransistor
 F ~
 $ENDCMP
 #
 $CMP Q_Photo_NPN_EBC
 D Phototransistor NPN, 3-pin with base pin (E=1, B=2, C=3)
-K npn phototransistor
+K NPN phototransistor
 F ~
 $ENDCMP
 #
@@ -1586,37 +1586,37 @@ $ENDCMP
 #
 $CMP Q_SCR_AGK
 D silicon controlled rectifier (SCR, Thyristor)
-K Thyristor silicon controlled rectifier
+K thyristor silicon controlled rectifier
 F ~
 $ENDCMP
 #
 $CMP Q_SCR_AKG
 D silicon controlled rectifier (SCR, Thyristor)
-K Thyristor silicon controlled rectifier
+K thyristor silicon controlled rectifier
 F ~
 $ENDCMP
 #
 $CMP Q_SCR_GAK
 D silicon controlled rectifier (SCR, Thyristor)
-K Thyristor silicon controlled rectifier
+K thyristor silicon controlled rectifier
 F ~
 $ENDCMP
 #
 $CMP Q_SCR_GKA
 D silicon controlled rectifier (SCR, Thyristor)
-K Thyristor silicon controlled rectifier
+K thyristor silicon controlled rectifier
 F ~
 $ENDCMP
 #
 $CMP Q_SCR_KAG
 D silicon controlled rectifier (SCR, Thyristor)
-K Thyristor silicon controlled rectifier
+K thyristor silicon controlled rectifier
 F ~
 $ENDCMP
 #
 $CMP Q_SCR_KGA
 D silicon controlled rectifier (SCR, Thyristor)
-K Thyristor silicon controlled rectifier
+K thyristor silicon controlled rectifier
 F ~
 $ENDCMP
 #
@@ -1658,217 +1658,217 @@ $ENDCMP
 #
 $CMP R
 D Resistor
-K r res resistor
+K R res resistor
 F ~
 $ENDCMP
 #
 $CMP RF_Shield_One_Piece
 D One-Piece EMI RF Shielding Cabinet
-K RF EMI Shielding Cabinet
+K RF EMI shielding cabinet
 F ~
 $ENDCMP
 #
 $CMP RF_Shield_Two_Pieces
 D Two-Piece EMI RF Shielding Cabinet
-K RF EMI Shielding Cabinet
+K RF EMI shielding cabinet
 F ~
 $ENDCMP
 #
 $CMP RTRIM
 D trimmable Resistor (Preset resistor)
-K r res resistor variable potentiometer trimmer
+K R res resistor variable potentiometer trimmer
 F ~
 $ENDCMP
 #
 $CMP R_Network03
 D 3 Resistor network, star topology, bussed resistors, small symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network03_US
 D 3 Resistor network, star topology, bussed resistors, small US symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network04
 D 4 Resistor network, star topology, bussed resistors, small symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network04_US
 D 4 Resistor network, star topology, bussed resistors, small SU symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network05
 D 5 Resistor network, star topology, bussed resistors, small symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network05_US
 D 5 Resistor network, star topology, bussed resistors, small US symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network06
 D 6 Resistor network, star topology, bussed resistors, small symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network06_US
 D 6 Resistor network, star topology, bussed resistors, small US symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network07
 D 7 Resistor network, star topology, bussed resistors, small symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network07_US
 D 7 Resistor network, star topology, bussed resistors, small US symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network08
 D 8 Resistor network, star topology, bussed resistors, small symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network08_US
 D 8 Resistor network, star topology, bussed resistors, small US symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network09
 D 9 Resistor network, star topology, bussed resistors, small symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network09_US
 D 9 Resistor network, star topology, bussed resistors, small US symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network10
 D 10 Resistor network, star topology, bussed resistors, small symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network10_US
 D 10 Resistor network, star topology, bussed resistors, small US symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network11
 D 11 Resistor network, star topology, bussed resistors, small symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network11_US
 D 11 Resistor network, star topology, bussed resistors, small US symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network12
 D 12 Resistor network, star topology, bussed resistors, small symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network12_US
 D 12 Resistor network, star topology, bussed resistors, small US symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network13
 D 13 Resistor network, star topology, bussed resistors, small symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network13_US
 D 13 Resistor network, star topology, bussed resistors, small US symbol
-K R Network star-topology
+K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x02_SIP
 D 2 Voltage Dividers network, Dual Terminator, SIP package
-K R Network divider topology
+K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x03_SIP
 D 3 Voltage Dividers network, Dual Terminator, SIP package
-K R Network divider topology
+K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x04_SIP
 D 4 Voltage Dividers network, Dual Terminator, SIP package
-K R Network divider topology
+K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x05_SIP
 D 5 Voltage Dividers network, Dual Terminator, SIP package
-K R Network divider topology
+K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x06_SIP
 D 6 Voltage Dividers network, Dual Terminator, SIP package
-K R Network divider topology
+K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x07_SIP
 D 7 Voltage Dividers network, Dual Terminator, SIP package
-K R Network divider topology
+K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x08_SIP
 D 8 Voltage Dividers network, Dual Terminator, SIP package
-K R Network divider topology
+K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x09_SIP
 D 9 Voltage Dividers network, Dual Terminator, SIP package
-K R Network divider topology
+K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x10_SIP
 D 10 Voltage Dividers network, Dual Terminator, SIP package
-K R Network divider topology
+K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x11_SIP
 D 11 Voltage Dividers network, Dual Terminator, SIP package
-K R Network divider topology
+K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
@@ -1916,145 +1916,145 @@ $ENDCMP
 #
 $CMP R_Pack02
 D 2 Resistor network, parallel topology, DIP package
-K R Network parallel topology isolated
+K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack02_SIP
 D 2 Resistor network, parallel topology, SIP package
-K R Network parallel topology isolated
+K R network parallel topology isolated
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Pack03
 D 3 Resistor network, parallel topology, DIP package
-K R Network parallel topology isolated
+K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack03_SIP
 D 3 Resistor network, parallel topology, SIP package
-K R Network parallel topology isolated
+K R network parallel topology isolated
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Pack04
 D 4 Resistor network, parallel topology, DIP package
-K R Network parallel topology isolated
+K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack04_SIP
 D 4 Resistor network, parallel topology, SIP package
-K R Network parallel topology isolated
+K R network parallel topology isolated
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Pack05
 D 5 Resistor network, parallel topology, DIP package
-K R Network parallel topology isolated
+K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack05_SIP
 D 5 Resistor network, parallel topology, SIP package
-K R Network parallel topology isolated
+K R network parallel topology isolated
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Pack06
 D 6 Resistor network, parallel topology, DIP package
-K R Network parallel topology isolated
+K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack06_SIP
 D 6 Resistor network, parallel topology, SIP package
-K R Network parallel topology isolated
+K R network parallel topology isolated
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Pack07
 D 7 Resistor network, parallel topology, DIP package
-K R Network parallel topology isolated
+K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack07_SIP
 D 7 Resistor network, parallel topology, SIP package
-K R Network parallel topology isolated
+K R network parallel topology isolated
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Pack08
 D 8 Resistor network, parallel topology, DIP package
-K R Network parallel topology isolated
+K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack09
 D 9 Resistor network, parallel topology, DIP package
-K R Network parallel topology isolated
+K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack10
 D 10 Resistor network, parallel topology, DIP package
-K R Network parallel topology isolated
+K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack11
 D 11 Resistor network, parallel topology, DIP package
-K R Network parallel topology isolated
+K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Shunt
 D Shunt Resistor
-K r res shunt resistor
+K R res shunt resistor
 F ~
 $ENDCMP
 #
 $CMP R_Shunt_US
 D Shunt Resistor US symbol
-K r res shunt resistor
+K R res shunt resistor
 F ~
 $ENDCMP
 #
 $CMP R_Small
 D Resistor, small symbol
-K r resistor
+K R resistor
 F ~
 $ENDCMP
 #
 $CMP R_US
 D Resistor US symbol
-K r res resistor
+K R res resistor
 F ~
 $ENDCMP
 #
 $CMP R_Variable
 D variable Resistor (Rheostat)
-K r res resistor variable potentiometer
+K R res resistor variable potentiometer
 F ~
 $ENDCMP
 #
 $CMP R_Variable_US
 D variable Resistor (Rheostat) US symbol
-K r res resistor variable potentiometer
+K R res resistor variable potentiometer
 F ~
 $ENDCMP
 #
 $CMP Resonator
 D Three pin ceramic resonator
-K Ceramic Resonator
+K ceramic resonator
 F ~
 $ENDCMP
 #
 $CMP Resonator_Small
 D Three pin ceramic resonator
-K Ceramic Resonator
+K ceramic resonator
 F ~
 $ENDCMP
 #
@@ -2072,7 +2072,7 @@ $ENDCMP
 #
 $CMP SPARK_GAP
 D Spark Gap
-K spark gap esd electrostatic suppression
+K spark gap ESD electrostatic suppression
 F ~
 $ENDCMP
 #
@@ -2108,7 +2108,7 @@ $ENDCMP
 #
 $CMP Thermistor
 D Thermistor, temperature-dependent resistor
-K r res thermistor
+K R res thermistor
 F ~
 $ENDCMP
 #
@@ -2162,7 +2162,7 @@ $ENDCMP
 #
 $CMP Thermistor_US
 D Thermistor, temperature-dependent resistor US symbol
-K r res thermistor
+K R res thermistor
 F ~
 $ENDCMP
 #
@@ -2228,43 +2228,43 @@ $ENDCMP
 #
 $CMP Varistor
 D Voltage dependent resistor
-K vdr resistance
+K VDR resistance
 F ~
 $ENDCMP
 #
 $CMP Varistor_US
 D Voltage dependent resistor US symbol
-K vdr resistance
+K VDR resistance
 F ~
 $ENDCMP
 #
 $CMP Voltage_Divider
 D voltage divider in a single package
-K R Network voltage divider
+K R network voltage divider
 F ~
 $ENDCMP
 #
 $CMP Voltage_Divider_CenterPin1
 D Voltage Divider (center=pin1)
-K R Network voltage divider
+K R network voltage divider
 F ~
 $ENDCMP
 #
 $CMP Voltage_Divider_CenterPin3
 D Voltage Divider (center=pin3)
-K R Network voltage divider
+K R network voltage divider
 F ~
 $ENDCMP
 #
 $CMP Voltmeter_AC
 D AC Voltmeter
-K Voltmeter AC
+K voltmeter AC
 F ~
 $ENDCMP
 #
 $CMP Voltmeter_DC
 D DC Voltmeter
-K Voltmeter DC
+K voltmeter DC
 F ~
 $ENDCMP
 #

--- a/Device.dcm
+++ b/Device.dcm
@@ -2,13 +2,13 @@ EESchema-DOCLIB  Version 2.0
 #
 $CMP Amperemeter_AC
 D AC ammeter
-K ammeter AC
+K ammeter AC ampere meter
 F ~
 $ENDCMP
 #
 $CMP Amperemeter_DC
 D DC ammeter
-K ammeter DC
+K ammeter DC ampere meter
 F ~
 $ENDCMP
 #

--- a/Device.dcm
+++ b/Device.dcm
@@ -1,13 +1,13 @@
 EESchema-DOCLIB  Version 2.0
 #
 $CMP Amperemeter_AC
-D AC Amperemeter
+D AC amperemeter
 K amperemeter AC
 F ~
 $ENDCMP
 #
 $CMP Amperemeter_DC
-D DC Amperemeter
+D DC amperemeter
 K amperemeter DC
 F ~
 $ENDCMP
@@ -19,19 +19,19 @@ F ~
 $ENDCMP
 #
 $CMP Antenna_Chip
-D Ceramic Chip Antenna symbol with pin for PCB trace
+D Ceramic chip antenna symbol with pin for PCB trace
 K antenna
 F ~
 $ENDCMP
 #
 $CMP Antenna_Dipole
-D Dipole Antenna symbol
+D Dipole antenna symbol
 K dipole antenna
 F ~
 $ENDCMP
 #
 $CMP Antenna_Loop
-D Loop Antenna symbol
+D Loop antenna symbol
 K loop antenna
 F ~
 $ENDCMP
@@ -49,7 +49,7 @@ F ~
 $ENDCMP
 #
 $CMP Battery_Cell
-D single battery cell
+D Single battery cell
 K battery cell
 F ~
 $ENDCMP
@@ -103,7 +103,7 @@ F ~
 $ENDCMP
 #
 $CMP C_Feedthrough
-D feedthrough capacitor
+D Feedthrough capacitor
 K EMI filter feedthrough capacitor
 F ~
 $ENDCMP
@@ -187,13 +187,13 @@ F ~
 $ENDCMP
 #
 $CMP DIAC
-D diode for alternating current
+D Diode for alternating current
 K AC diode DIAC
 F ~
 $ENDCMP
 #
 $CMP DIAC_ALT
-D diode for alternating current, alternativ symbol
+D Diode for alternating current, alternativ symbol
 K AC diode DIAC
 F ~
 $ENDCMP
@@ -235,13 +235,13 @@ F ~
 $ENDCMP
 #
 $CMP D_Capacitance
-D variable capacitance diode (varicap, varactor)
+D Variable capacitance diode (varicap, varactor)
 K capacitance diode varicap varactor
 F ~
 $ENDCMP
 #
 $CMP D_Capacitance_ALT
-D variable capacitance diode (varicap, varactor), alternativ symbol
+D Variable capacitance diode (varicap, varactor), alternativ symbol
 K capacitance diode varicap varactor
 F ~
 $ENDCMP
@@ -259,13 +259,13 @@ F ~
 $ENDCMP
 #
 $CMP D_Radiation
-D semiconductor radiation detector
+D Semiconductor radiation detector
 K radiation detector diode
 F ~
 $ENDCMP
 #
 $CMP D_Radiation_ALT
-D semiconductor radiation detector, alternativ symbol
+D Semiconductor radiation detector, alternativ symbol
 K radiation detector diode
 F ~
 $ENDCMP
@@ -331,79 +331,79 @@ F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_ACom_AKK
-D Dual schottky diode, common anode
+D Dual Schottky diode, common anode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_ACom_KAK
-D Dual schottky diode, common anode
+D Dual Schottky diode, common anode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_ACom_KKA
-D Dual schottky diode, common anode
+D Dual Schottky diode, common anode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_KCom_AAK
-D Dual schottky diode, common cathode
+D Dual Schottky diode, common cathode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_KCom_AKA
-D Dual schottky diode, common cathode
+D Dual Schottky diode, common cathode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_KCom_KAA
-D Dual schottky diode, common cathode
+D Dual Schottky diode, common cathode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_ACK
-D Dual schottky diode
+D Dual Schottky diode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_AKC
-D Dual schottky diode
+D Dual Schottky diode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_CAK
-D Dual schottky diode
+D Dual Schottky diode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_CKA
-D Dual schottky diode
+D Dual Schottky diode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_KAC
-D Dual schottky diode
+D Dual Schottky diode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Schottky_x2_Serial_KCA
-D Dual schottky diode
+D Dual Schottky diode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Shockley
-D Shockley Diode (PNPN Diode)
+D Shockley diode (PNPN diode)
 K Shockley diode
 F ~
 $ENDCMP
@@ -457,61 +457,61 @@ F ~
 $ENDCMP
 #
 $CMP D_Temperature_Dependent
-D temperature dependent diode
+D Temperature dependent diode
 K temperature sensor diode
 F ~
 $ENDCMP
 #
 $CMP D_Temperature_Dependent_ALT
-D temperature dependent diode, alternativ symbol
+D Temperature dependent diode, alternativ symbol
 K temperature sensor diode
 F ~
 $ENDCMP
 #
 $CMP D_Tunnel
-D Tunnel Diode (Esaki Diode)
+D Tunnel diode (Esaki diode)
 K tunnel diode
 F ~
 $ENDCMP
 #
 $CMP D_Tunnel_ALT
-D Tunnel Diode (Esaki Diode), alternativ symbol
+D Tunnel diode (Esaki diode), alternativ symbol
 K tunnel diode
 F ~
 $ENDCMP
 #
 $CMP D_Unitunnel
-D Unitunnel Diode
+D Unitunnel diode
 K unitunnel diode
 F ~
 $ENDCMP
 #
 $CMP D_Unitunnel_ALT
-D Unitunnel Diode, alternativ symbol
+D Unitunnel diode, alternativ symbol
 K unitunnel diode
 F ~
 $ENDCMP
 #
 $CMP D_Zener
-D Zener Diode
+D Zener diode
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Zener_ALT
-D Zener Diode, alternativ symbol
+D Zener diode, alternativ symbol
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Zener_Small
-D Zener Diode, small symbol
+D Zener diode, small symbol
 K diode
 F ~
 $ENDCMP
 #
 $CMP D_Zener_Small_ALT
-D Zener Diode, small symbol, alternativ symbol
+D Zener diode, small symbol, alternativ symbol
 K diode
 F ~
 $ENDCMP
@@ -607,7 +607,7 @@ F http://www.murata.com/~/media/webrenewal/support/library/catalog/products/emc/
 $ENDCMP
 #
 $CMP EMI_Filter_CommonMode
-D EMI 2-inductor common-mode-filter
+D EMI 2-inductor common mode filter
 K EMI common mode filter
 F ~
 $ENDCMP
@@ -619,19 +619,19 @@ F http://www.murata.com/~/media/webrenewal/support/library/catalog/products/emc/
 $ENDCMP
 #
 $CMP EMI_Filter_LL
-D EMI 2-inductor-filter
+D EMI 2-inductor filter
 K EMI filter
 F http://www.murata.com/~/media/webrenewal/support/library/catalog/products/emc/emifil/c30e.ashx?la=en-gb
 $ENDCMP
 #
 $CMP Earphone
-D earphone, polar
+D Earphone, polar
 K earphone speaker headphone
 F ~
 $ENDCMP
 #
 $CMP Electromagnetic_Actor
-D electro-magnetic actor
+D Electromagnetic actor
 K electromagnet coil inductor
 F ~
 $ENDCMP
@@ -649,7 +649,7 @@ F ~
 $ENDCMP
 #
 $CMP Frequency_Counter
-D Frequency Counter
+D Frequency counter
 K frequency counter
 F ~
 $ENDCMP
@@ -691,7 +691,7 @@ F ~
 $ENDCMP
 #
 $CMP Heater
-D Resistive Heater
+D Resistive heater
 K heater R resistor
 F ~
 $ENDCMP
@@ -703,7 +703,7 @@ F ~
 $ENDCMP
 #
 $CMP Jumper_NC_Dual
-D Dual Jumper, normally closed
+D Dual jumper, normally closed
 K jumper bridge link NC
 F ~
 $ENDCMP
@@ -751,7 +751,7 @@ F ~
 $ENDCMP
 #
 $CMP LED_CRGB
-D LED RGB, Common Cathode
+D LED RGB, common cathode
 K LED RGB diode
 F ~
 $ENDCMP
@@ -817,13 +817,13 @@ F ~
 $ENDCMP
 #
 $CMP LED_RCBG
-D LED RGB, Common Cathode
+D LED RGB, common cathode
 K LED RGB diode
 F ~
 $ENDCMP
 #
 $CMP LED_RCGB
-D LED RGB, Common Cathode
+D LED RGB, common cathode
 K LED RGB diode
 F ~
 $ENDCMP
@@ -841,7 +841,7 @@ F ~
 $ENDCMP
 #
 $CMP LED_Series
-D several LEDs in series
+D Several LEDs in series
 K LED diode
 F ~
 $ENDCMP
@@ -865,25 +865,25 @@ F ~
 $ENDCMP
 #
 $CMP LTRIM
-D Variable Inductor
+D Variable inductor
 K inductor choke coil reactor magnetic
 F ~
 $ENDCMP
 #
 $CMP L_Core_Ferrite
-D Inductor with Ferrite Core
+D Inductor with ferrite core
 K inductor choke coil reactor magnetic
 F ~
 $ENDCMP
 #
 $CMP L_Core_Ferrite_Coupled
-D Coupled inductor with Ferrite Core
+D Coupled inductor with ferrite core
 K inductor choke coil reactor magnetic coupled
 F ~
 $ENDCMP
 #
 $CMP L_Core_Ferrite_Coupled_Small
-D Coupled inductor with Ferrite Core, small symbol
+D Coupled inductor with ferrite core, small symbol
 K inductor choke coil reactor magnetic coupled
 F ~
 $ENDCMP
@@ -895,19 +895,19 @@ F ~
 $ENDCMP
 #
 $CMP L_Core_Iron
-D Inductor with Iron Core
+D Inductor with iron core
 K inductor choke coil reactor magnetic
 F ~
 $ENDCMP
 #
 $CMP L_Core_Iron_Coupled
-D Coupled inductor with Iron Core
+D Coupled inductor with iron core
 K inductor choke coil reactor magnetic coupled
 F ~
 $ENDCMP
 #
 $CMP L_Core_Iron_Coupled_Small
-D Coupled inductor with Iron Core, small symbol
+D Coupled inductor with iron core, small symbol
 K inductor choke coil reactor magnetic coupled
 F ~
 $ENDCMP
@@ -937,49 +937,49 @@ F ~
 $ENDCMP
 #
 $CMP Lamp
-D lamp
+D Lamp
 K lamp
 F ~
 $ENDCMP
 #
 $CMP Lamp_Flash
-D flash lamp tube
+D Flash lamp tube
 K flash lamp
 F ~
 $ENDCMP
 #
 $CMP Lamp_Neon
-D neon lamp
+D Neon lamp
 K neon lamp
 F ~
 $ENDCMP
 #
 $CMP Laserdiode_1A3C
-D Laser Diode in a 2-pin package
+D Laser diode in a 2-pin package
 K opto laserdiode
 F ~
 $ENDCMP
 #
 $CMP Laserdiode_1C2A
-D Laser Diode in a 2-pin package
+D Laser diode in a 2-pin package
 K opto laserdiode
 F ~
 $ENDCMP
 #
 $CMP Laserdiode_M_TYPE
-D Laser Diode in a 3-pin package with photodiode (1=LD-A, 2=LD-C/PD-C, 3=PD-A)
+D Laser diode in a 3-pin package with photodiode (1=LD-A, 2=LD-C/PD-C, 3=PD-A)
 K opto laserdiode photodiode
 F http://www.egismos.disonhu.com/laser/diode-package.htm
 $ENDCMP
 #
 $CMP Laserdiode_N_TYPE
-D Laser Diode in a 3-pin package with photodiode (1=LD-C, 2=LD-A/PD-C, 3=PD-A)
+D Laser diode in a 3-pin package with photodiode (1=LD-C, 2=LD-A/PD-C, 3=PD-A)
 K opto laserdiode photodiode
 F http://www.egismos.disonhu.com/laser/diode-package.htm
 $ENDCMP
 #
 $CMP Laserdiode_P_TYPE
-D Laser Diode in a 3-pin package with photodiode (1=LD-A, 2=LD-C/PD-A, 3=PD-C)
+D Laser diode in a 3-pin package with photodiode (1=LD-A, 2=LD-C/PD-A, 3=PD-C)
 K opto laserdiode photodiode
 F http://www.egismos.disonhu.com/laser/diode-package.htm
 $ENDCMP
@@ -997,13 +997,13 @@ F ~
 $ENDCMP
 #
 $CMP Microphone_Condenser
-D Condenser Microspcope
+D Condenser microphone
 K capacitance condenser microphone
 F ~
 $ENDCMP
 #
 $CMP Microphone_Crystal
-D crystal microphone
+D Crystal microphone
 K microphone crystal
 F ~
 $ENDCMP
@@ -1015,31 +1015,31 @@ F ~
 $ENDCMP
 #
 $CMP Net-Tie_2
-D Net Tie, 2 pins
+D Net tie, 2 pins
 K net tie short
 F ~
 $ENDCMP
 #
 $CMP Net-Tie_3
-D Net Tie, 3 pins
+D Net tie, 3 pins
 K net tie short
 F ~
 $ENDCMP
 #
 $CMP Net-Tie_3_Tee
-D Net Tie, 3 pins, tee
+D Net tie, 3 pins, tee
 K net tie short
 F ~
 $ENDCMP
 #
 $CMP Net-Tie_4
-D Net Tie, 4 pins
+D Net tie, 4 pins
 K net tie short
 F ~
 $ENDCMP
 #
 $CMP Net-Tie_4_Cross
-D Net Tie, 4 pins, cross
+D Net tie, 4 pins, cross
 K net tie short
 F ~
 $ENDCMP
@@ -1051,13 +1051,13 @@ F ~
 $ENDCMP
 #
 $CMP Opamp_Dual_Generic
-D Dual Opamp, SOIC-8/DIP-8/SSOP-8/TO-99
+D Dual opamp, SOIC-8/DIP-8/SSOP-8/TO-99
 K dual opamp
 F ~
 $ENDCMP
 #
 $CMP Opamp_Quad_Generic
-D Quad Opamp, SOIC-14/DIP-14/SSOP-14
+D Quad opamp, SOIC-14/DIP-14/SSOP-14
 K quad opamp
 F ~
 $ENDCMP
@@ -1069,19 +1069,19 @@ F ~
 $ENDCMP
 #
 $CMP Peltier_Element
-D Peltier Element, Thermoelectric Cooler (TEC)
+D Peltier element, thermoelectric cooler (TEC)
 K Peltier TEC
 F ~
 $ENDCMP
 #
 $CMP Polyfuse
-D resettable fuse, polymeric positive temperature coefficient (PPTC)
+D Resettable fuse, polymeric positive temperature coefficient (PPTC)
 K resettable fuse PTC PPTC polyfuse polyswitch
 F ~
 $ENDCMP
 #
 $CMP Polyfuse_Small
-D resettable fuse, polymeric positive temperature coefficient (PPTC), small symbol
+D Resettable fuse, polymeric positive temperature coefficient (PPTC), small symbol
 K resettable fuse PTC PPTC polyfuse polyswitch
 F ~
 $ENDCMP
@@ -1093,19 +1093,19 @@ F ~
 $ENDCMP
 #
 $CMP Q_DUAL_NPN_C2C1E1E2
-D Double NPN Transistors, Current mirror configuration
+D Double NPN transistors, current mirror configuration
 K transistor double NPN
 F ~
 $ENDCMP
 #
 $CMP Q_DUAL_NPN_NPN_E1B1C2E2B2C1
-D Dual NPN/NPN Transistor, 6-pin package
+D Dual NPN/NPN transistor, 6-pin package
 K NPN/NPN transistor
 F ~
 $ENDCMP
 #
 $CMP Q_DUAL_NPN_PNP_E1B1C2E2B2C1
-D Dual NPN/PNP Transistor, 6-pin package
+D Dual NPN/PNP transistor, 6-pin package
 K NPN/PNP transistor
 F ~
 $ENDCMP
@@ -1117,19 +1117,19 @@ F ~
 $ENDCMP
 #
 $CMP Q_DUAL_PNP_C2C1E1E2
-D Double PNP Transistors, Current mirror configuration
+D Double PNP transistors, current mirror configuration
 K transistor double PNP
 F ~
 $ENDCMP
 #
 $CMP Q_DUAL_PNP_PNP_C1B1B2C2E2E1
-D Dual PNP/PNP Transistor, 6-pin package
+D Dual PNP/PNP transistor, 6-pin package
 K PNP/PNP transistor
 F https://www.diodes.com/assets/Datasheets/ds30437.pdf
 $ENDCMP
 #
 $CMP Q_DUAL_PNP_PNP_E1B1C2E2B2C1
-D Dual PNP/PNP Transistor, 6-pin package
+D Dual PNP/PNP transistor, 6-pin package
 K PNP/PNP transistor
 F ~
 $ENDCMP
@@ -1237,31 +1237,31 @@ F ~
 $ENDCMP
 #
 $CMP Q_NMOS_GDSD
-D Transistor N-MOSFETwith substrate diode, drain connected to mounting plane (general)
+D Transistor N-MOSFET with substrate diode, drain connected to mounting plane (general)
 K NMOS N-MOS N-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_GSD
-D Transistor N-MOSFETwith substrate diode (general)
+D Transistor N-MOSFET with substrate diode (general)
 K NMOS N-MOS N-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_SDG
-D Transistor N-MOSFETwith substrate diode (general)
+D Transistor N-MOSFET with substrate diode (general)
 K NMOS N-MOS N-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_SDGD
-D Transistor N-MOSFETwith substrate diode, drain connected to mounting plane (general)
+D Transistor N-MOSFET with substrate diode, drain connected to mounting plane (general)
 K NMOS N-MOS N-MOSFET transistor
 F ~
 $ENDCMP
 #
 $CMP Q_NMOS_SGD
-D Transistor N-MOSFETwith substrate diode (general)
+D Transistor N-MOSFET with substrate diode (general)
 K NMOS N-MOS N-MOSFET transistor
 F ~
 $ENDCMP
@@ -1297,49 +1297,49 @@ F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_BCE
-D Darlington Transistor NPN (general)
+D Darlington transistor NPN (general)
 K NPN transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_BCEC
-D Darlington Transistor NPN (general)
+D Darlington transistor NPN (general)
 K NPN transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_BEC
-D Darlington Transistor NPN (general)
+D Darlington transistor NPN (general)
 K NPN transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_CBE
-D Darlington Transistor NPN (general)
+D Darlington transistor NPN (general)
 K NPN transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_CEB
-D Darlington Transistor NPN (general)
+D Darlington transistor NPN (general)
 K NPN transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_EBC
-D Darlington Transistor NPN (general)
+D Darlington transistor NPN (general)
 K NPN transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_ECB
-D Darlington Transistor NPN (general)
+D Darlington transistor NPN (general)
 K NPN transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_NPN_Darlington_ECBC
-D Darlington Transistor NPN (general)
+D Darlington transistor NPN (general)
 K NPN transistor Darlington
 F ~
 $ENDCMP
@@ -1363,7 +1363,7 @@ F ~
 $ENDCMP
 #
 $CMP Q_NUJT_BEB
-D Transistor N-Type Unijunction (UJT, general)
+D Transistor N-Type unijunction (UJT, general)
 K UJT transistor
 F ~
 $ENDCMP
@@ -1483,49 +1483,49 @@ F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_BCE
-D Darlington Transistor PNP (general)
+D Darlington transistor PNP (general)
 K PNP transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_BCEC
-D Darlington Transistor PNP, collector connected to mounting plane (general)
+D Darlington transistor PNP, collector connected to mounting plane (general)
 K PNP transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_BEC
-D Darlington Transistor PNP (general)
+D Darlington transistor PNP (general)
 K PNP transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_CBE
-D Darlington Transistor PNP (general)
+D Darlington transistor PNP (general)
 K PNP transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_CEB
-D Darlington Transistor PNP (general)
+D Darlington transistor PNP (general)
 K PNP transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_EBC
-D Darlington Transistor PNP (general)
+D Darlington transistor PNP (general)
 K PNP transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_ECB
-D Darlington Transistor PNP (general)
+D Darlington transistor PNP (general)
 K PNP transistor Darlington
 F ~
 $ENDCMP
 #
 $CMP Q_PNP_Darlington_ECBC
-D Darlington Transistor PNP, collector connected to mounting plane (general)
+D Darlington transistor PNP, collector connected to mounting plane (general)
 K PNP transistor Darlington
 F ~
 $ENDCMP
@@ -1549,7 +1549,7 @@ F ~
 $ENDCMP
 #
 $CMP Q_PUJT_BEB
-D Transistor P-Type Unijunction (UJT, general)
+D Transistor P-Type unijunction (UJT, general)
 K UJT transistor
 F ~
 $ENDCMP
@@ -1585,73 +1585,73 @@ F ~
 $ENDCMP
 #
 $CMP Q_SCR_AGK
-D silicon controlled rectifier (SCR, Thyristor)
+D Silicon controlled rectifier (SCR, Thyristor)
 K thyristor silicon controlled rectifier
 F ~
 $ENDCMP
 #
 $CMP Q_SCR_AKG
-D silicon controlled rectifier (SCR, Thyristor)
+D Silicon controlled rectifier (SCR, Thyristor)
 K thyristor silicon controlled rectifier
 F ~
 $ENDCMP
 #
 $CMP Q_SCR_GAK
-D silicon controlled rectifier (SCR, Thyristor)
+D Silicon controlled rectifier (SCR, Thyristor)
 K thyristor silicon controlled rectifier
 F ~
 $ENDCMP
 #
 $CMP Q_SCR_GKA
-D silicon controlled rectifier (SCR, Thyristor)
+D Silicon controlled rectifier (SCR, Thyristor)
 K thyristor silicon controlled rectifier
 F ~
 $ENDCMP
 #
 $CMP Q_SCR_KAG
-D silicon controlled rectifier (SCR, Thyristor)
+D Silicon controlled rectifier (SCR, Thyristor)
 K thyristor silicon controlled rectifier
 F ~
 $ENDCMP
 #
 $CMP Q_SCR_KGA
-D silicon controlled rectifier (SCR, Thyristor)
+D Silicon controlled rectifier (SCR, Thyristor)
 K thyristor silicon controlled rectifier
 F ~
 $ENDCMP
 #
 $CMP Q_TRIAC_A1A2G
-D triode for alternating current (TRIAC), pinordering A1=1, A2=2, G=3
+D Triode for alternating current (TRIAC), pinordering A1=1, A2=2, G=3
 K triode for alternating current TRIAC
 F ~
 $ENDCMP
 #
 $CMP Q_TRIAC_A1GA2
-D triode for alternating current (TRIAC), pinordering A1=1, A2=3, G=2
+D Triode for alternating current (TRIAC), pinordering A1=1, A2=3, G=2
 K triode for alternating current TRIAC
 F ~
 $ENDCMP
 #
 $CMP Q_TRIAC_A2A1G
-D triode for alternating current (TRIAC), pinordering A1=2, A2=1, G=3
+D Triode for alternating current (TRIAC), pinordering A1=2, A2=1, G=3
 K triode for alternating current TRIAC
 F ~
 $ENDCMP
 #
 $CMP Q_TRIAC_A2GA1
-D triode for alternating current (TRIAC), pinordering A1=3, A2=1, G=2
+D Triode for alternating current (TRIAC), pinordering A1=3, A2=1, G=2
 K triode for alternating current TRIAC
 F ~
 $ENDCMP
 #
 $CMP Q_TRIAC_GA1A2
-D triode for alternating current (TRIAC), pinordering A1=2, A2=3, G=1
+D Triode for alternating current (TRIAC), pinordering A1=2, A2=3, G=1
 K triode for alternating current TRIAC
 F ~
 $ENDCMP
 #
 $CMP Q_TRIAC_GA2A1
-D triode for alternating current (TRIAC), pinordering A1=3, A2=2, G=1
+D Triode for alternating current (TRIAC), pinordering A1=3, A2=2, G=1
 K triode for alternating current TRIAC
 F ~
 $ENDCMP
@@ -1663,211 +1663,211 @@ F ~
 $ENDCMP
 #
 $CMP RF_Shield_One_Piece
-D One-Piece EMI RF Shielding Cabinet
+D One-piece EMI RF shielding cabinet
 K RF EMI shielding cabinet
 F ~
 $ENDCMP
 #
 $CMP RF_Shield_Two_Pieces
-D Two-Piece EMI RF Shielding Cabinet
+D Two-piece EMI RF shielding cabinet
 K RF EMI shielding cabinet
 F ~
 $ENDCMP
 #
 $CMP RTRIM
-D trimmable Resistor (Preset resistor)
+D Trimmable resistor (preset resistor)
 K R res resistor variable potentiometer trimmer
 F ~
 $ENDCMP
 #
 $CMP R_Network03
-D 3 Resistor network, star topology, bussed resistors, small symbol
+D 3 resistor network, star topology, bussed resistors, small symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network03_US
-D 3 Resistor network, star topology, bussed resistors, small US symbol
+D 3 resistor network, star topology, bussed resistors, small US symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network04
-D 4 Resistor network, star topology, bussed resistors, small symbol
+D 4 resistor network, star topology, bussed resistors, small symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network04_US
-D 4 Resistor network, star topology, bussed resistors, small SU symbol
+D 4 resistor network, star topology, bussed resistors, small US symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network05
-D 5 Resistor network, star topology, bussed resistors, small symbol
+D 5 resistor network, star topology, bussed resistors, small symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network05_US
-D 5 Resistor network, star topology, bussed resistors, small US symbol
+D 5 resistor network, star topology, bussed resistors, small US symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network06
-D 6 Resistor network, star topology, bussed resistors, small symbol
+D 6 resistor network, star topology, bussed resistors, small symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network06_US
-D 6 Resistor network, star topology, bussed resistors, small US symbol
+D 6 resistor network, star topology, bussed resistors, small US symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network07
-D 7 Resistor network, star topology, bussed resistors, small symbol
+D 7 resistor network, star topology, bussed resistors, small symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network07_US
-D 7 Resistor network, star topology, bussed resistors, small US symbol
+D 7 resistor network, star topology, bussed resistors, small US symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network08
-D 8 Resistor network, star topology, bussed resistors, small symbol
+D 8 resistor network, star topology, bussed resistors, small symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network08_US
-D 8 Resistor network, star topology, bussed resistors, small US symbol
+D 8 resistor network, star topology, bussed resistors, small US symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network09
-D 9 Resistor network, star topology, bussed resistors, small symbol
+D 9 resistor network, star topology, bussed resistors, small symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network09_US
-D 9 Resistor network, star topology, bussed resistors, small US symbol
+D 9 resistor network, star topology, bussed resistors, small US symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network10
-D 10 Resistor network, star topology, bussed resistors, small symbol
+D 10 resistor network, star topology, bussed resistors, small symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network10_US
-D 10 Resistor network, star topology, bussed resistors, small US symbol
+D 10 resistor network, star topology, bussed resistors, small US symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network11
-D 11 Resistor network, star topology, bussed resistors, small symbol
+D 11 resistor network, star topology, bussed resistors, small symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network11_US
-D 11 Resistor network, star topology, bussed resistors, small US symbol
+D 11 resistor network, star topology, bussed resistors, small US symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network12
-D 12 Resistor network, star topology, bussed resistors, small symbol
+D 12 resistor network, star topology, bussed resistors, small symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network12_US
-D 12 Resistor network, star topology, bussed resistors, small US symbol
+D 12 resistor network, star topology, bussed resistors, small US symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network13
-D 13 Resistor network, star topology, bussed resistors, small symbol
+D 13 resistor network, star topology, bussed resistors, small symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network13_US
-D 13 Resistor network, star topology, bussed resistors, small US symbol
+D 13 resistor network, star topology, bussed resistors, small US symbol
 K R network star-topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x02_SIP
-D 2 Voltage Dividers network, Dual Terminator, SIP package
+D 2 voltage dividers network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x03_SIP
-D 3 Voltage Dividers network, Dual Terminator, SIP package
+D 3 voltage dividers network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x04_SIP
-D 4 Voltage Dividers network, Dual Terminator, SIP package
+D 4 voltage dividers network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x05_SIP
-D 5 Voltage Dividers network, Dual Terminator, SIP package
+D 5 voltage dividers network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x06_SIP
-D 6 Voltage Dividers network, Dual Terminator, SIP package
+D 6 voltage dividers network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x07_SIP
-D 7 Voltage Dividers network, Dual Terminator, SIP package
+D 7 voltage dividers network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x08_SIP
-D 8 Voltage Dividers network, Dual Terminator, SIP package
+D 8 voltage dividers network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x09_SIP
-D 9 Voltage Dividers network, Dual Terminator, SIP package
+D 9 voltage dividers network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x10_SIP
-D 10 Voltage Dividers network, Dual Terminator, SIP package
+D 10 voltage dividers network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Network_Dividers_x11_SIP
-D 11 Voltage Dividers network, Dual Terminator, SIP package
+D 11 voltage dividers network, dual terminator, SIP package
 K R network divider topology
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
@@ -1885,25 +1885,25 @@ F ~
 $ENDCMP
 #
 $CMP R_POT_Dual
-D Dual Potentiometer
+D Dual potentiometer
 K resistor variable
 F ~
 $ENDCMP
 #
 $CMP R_POT_Dual_Separate
-D Dual Potentiometer, separate units
+D Dual potentiometer, separate units
 K resistor variable
 F ~
 $ENDCMP
 #
 $CMP R_POT_TRIM
-D Trim-Potentiometer
+D Trim-potentiometer
 K resistor variable trimpot trimmer
 F ~
 $ENDCMP
 #
 $CMP R_POT_TRIM_US
-D Trim-Potentiometer US symbol
+D Trim-potentiometer US symbol
 K resistor variable trimpot trimmer
 F ~
 $ENDCMP
@@ -1915,109 +1915,109 @@ F ~
 $ENDCMP
 #
 $CMP R_Pack02
-D 2 Resistor network, parallel topology, DIP package
+D 2 resistor network, parallel topology, DIP package
 K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack02_SIP
-D 2 Resistor network, parallel topology, SIP package
+D 2 resistor network, parallel topology, SIP package
 K R network parallel topology isolated
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Pack03
-D 3 Resistor network, parallel topology, DIP package
+D 3 resistor network, parallel topology, DIP package
 K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack03_SIP
-D 3 Resistor network, parallel topology, SIP package
+D 3 resistor network, parallel topology, SIP package
 K R network parallel topology isolated
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Pack04
-D 4 Resistor network, parallel topology, DIP package
+D 4 resistor network, parallel topology, DIP package
 K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack04_SIP
-D 4 Resistor network, parallel topology, SIP package
+D 4 resistor network, parallel topology, SIP package
 K R network parallel topology isolated
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Pack05
-D 5 Resistor network, parallel topology, DIP package
+D 5 resistor network, parallel topology, DIP package
 K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack05_SIP
-D 5 Resistor network, parallel topology, SIP package
+D 5 resistor network, parallel topology, SIP package
 K R network parallel topology isolated
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Pack06
-D 6 Resistor network, parallel topology, DIP package
+D 6 resistor network, parallel topology, DIP package
 K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack06_SIP
-D 6 Resistor network, parallel topology, SIP package
+D 6 resistor network, parallel topology, SIP package
 K R network parallel topology isolated
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Pack07
-D 7 Resistor network, parallel topology, DIP package
+D 7 resistor network, parallel topology, DIP package
 K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack07_SIP
-D 7 Resistor network, parallel topology, SIP package
+D 7 resistor network, parallel topology, SIP package
 K R network parallel topology isolated
 F http://www.vishay.com/docs/31509/csc.pdf
 $ENDCMP
 #
 $CMP R_Pack08
-D 8 Resistor network, parallel topology, DIP package
+D 8 resistor network, parallel topology, DIP package
 K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack09
-D 9 Resistor network, parallel topology, DIP package
+D 9 resistor network, parallel topology, DIP package
 K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack10
-D 10 Resistor network, parallel topology, DIP package
+D 10 resistor network, parallel topology, DIP package
 K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Pack11
-D 11 Resistor network, parallel topology, DIP package
+D 11 resistor network, parallel topology, DIP package
 K R network parallel topology isolated
 F ~
 $ENDCMP
 #
 $CMP R_Shunt
-D Shunt Resistor
+D Shunt resistor
 K R res shunt resistor
 F ~
 $ENDCMP
 #
 $CMP R_Shunt_US
-D Shunt Resistor US symbol
+D Shunt resistor US symbol
 K R res shunt resistor
 F ~
 $ENDCMP
@@ -2035,13 +2035,13 @@ F ~
 $ENDCMP
 #
 $CMP R_Variable
-D variable Resistor (Rheostat)
+D Variable resistor (rheostat)
 K R res resistor variable potentiometer
 F ~
 $ENDCMP
 #
 $CMP R_Variable_US
-D variable Resistor (Rheostat) US symbol
+D Variable resistor (rheostat) US symbol
 K R res resistor variable potentiometer
 F ~
 $ENDCMP
@@ -2071,115 +2071,115 @@ F ~
 $ENDCMP
 #
 $CMP SPARK_GAP
-D Spark Gap
+D Spark gap
 K spark gap ESD electrostatic suppression
 F ~
 $ENDCMP
 #
 $CMP Solar_Cell
-D single solar cell
+D Single solar cell
 K solar cell
 F ~
 $ENDCMP
 #
 $CMP Solar_Cells
-D multiple solar cells
+D Multiple solar cells
 K solar cell
 F ~
 $ENDCMP
 #
 $CMP Speaker
-D speaker
+D Speaker
 K speaker sound
 F ~
 $ENDCMP
 #
 $CMP Speaker_Crystal
-D crystal speaker/transducer
+D Crystal speaker/transducer
 K crystal speaker ultrasonic transducer
 F ~
 $ENDCMP
 #
 $CMP Speaker_Ultrasound
-D ultrasonic transducer
+D Ultrasonic transducer
 K crystal speaker ultrasonic transducer
 F ~
 $ENDCMP
 #
 $CMP Thermistor
-D Thermistor, temperature-dependent resistor
+D Thermistor, temperature dependent resistor
 K R res thermistor
 F ~
 $ENDCMP
 #
 $CMP Thermistor_NTC
-D temperature dependent resistor, negative temperature coefficient (NTC)
+D Temperature dependent resistor, negative temperature coefficient (NTC)
 K thermistor NTC resistor sensor RTD
 F ~
 $ENDCMP
 #
 $CMP Thermistor_NTC_3wire
-D temperature dependent resistor, negative temperature coefficient (NTC), 3-wire interface
+D Temperature dependent resistor, negative temperature coefficient (NTC), 3-wire interface
 K thermistor NTC resistor sensor RTD
 F ~
 $ENDCMP
 #
 $CMP Thermistor_NTC_4wire
-D temperature dependent resistor, negative temperature coefficient (NTC), 4-wire interface
+D Temperature dependent resistor, negative temperature coefficient (NTC), 4-wire interface
 K thermistor NTC resistor sensor RTD
 F ~
 $ENDCMP
 #
 $CMP Thermistor_NTC_US
-D temperature dependent resistor, negative temperature coefficient (NTC) US symbol
+D Temperature dependent resistor, negative temperature coefficient (NTC) US symbol
 K thermistor NTC resistor sensor RTD
 F ~
 $ENDCMP
 #
 $CMP Thermistor_PTC
-D temperature dependent resistor, positive temperature coefficient (PTC)
+D Temperature dependent resistor, positive temperature coefficient (PTC)
 K resistor PTC thermistor sensor RTD
 F ~
 $ENDCMP
 #
 $CMP Thermistor_PTC_3wire
-D temperature dependent resistor, positive temperature coefficient (PTC), 3-wire interface
+D Temperature dependent resistor, positive temperature coefficient (PTC), 3-wire interface
 K resistor PTC thermistor sensor RTD
 F ~
 $ENDCMP
 #
 $CMP Thermistor_PTC_4wire
-D temperature dependent resistor, positive temperature coefficient (PTC), 3-wire interface
+D Temperature dependent resistor, positive temperature coefficient (PTC), 3-wire interface
 K resistor PTC thermistor sensor RTD
 F ~
 $ENDCMP
 #
 $CMP Thermistor_PTC_US
-D temperature dependent resistor, positive temperature coefficient (PTC) US symbol
+D Temperature dependent resistor, positive temperature coefficient (PTC) US symbol
 K resistor PTC thermistor sensor RTD
 F ~
 $ENDCMP
 #
 $CMP Thermistor_US
-D Thermistor, temperature-dependent resistor US symbol
+D Thermistor, temperature dependent resistor US symbol
 K R res thermistor
 F ~
 $ENDCMP
 #
 $CMP Thermocouple
-D thermocouple
+D Thermocouple
 K thermocouple temperature sensor cold junction
 F ~
 $ENDCMP
 #
 $CMP Thermocouple_ALT
-D thermocouple with connector block
+D Thermocouple with connector block
 K thermocouple temperature sensor cold junction
 F ~
 $ENDCMP
 #
 $CMP Thermocouple_Block
-D thermocouple with isothermal block
+D Thermocouple with isothermal block
 K thermocouple temperature sensor cold junction
 F ~
 $ENDCMP
@@ -2239,31 +2239,31 @@ F ~
 $ENDCMP
 #
 $CMP Voltage_Divider
-D voltage divider in a single package
+D Voltage divider in a single package
 K R network voltage divider
 F ~
 $ENDCMP
 #
 $CMP Voltage_Divider_CenterPin1
-D Voltage Divider (center=pin1)
+D Voltage divider (center=pin1)
 K R network voltage divider
 F ~
 $ENDCMP
 #
 $CMP Voltage_Divider_CenterPin3
-D Voltage Divider (center=pin3)
+D Voltage divider (center=pin3)
 K R network voltage divider
 F ~
 $ENDCMP
 #
 $CMP Voltmeter_AC
-D AC Voltmeter
+D AC voltmeter
 K voltmeter AC
 F ~
 $ENDCMP
 #
 $CMP Voltmeter_DC
-D DC Voltmeter
+D DC voltmeter
 K voltmeter DC
 F ~
 $ENDCMP

--- a/Device.dcm
+++ b/Device.dcm
@@ -73,13 +73,13 @@ F ~
 $ENDCMP
 #
 $CMP CP1
-D Polarized capacitor, curved cathode
+D Polarized capacitor, US symbol
 K cap capacitor
 F ~
 $ENDCMP
 #
 $CMP CP1_Small
-D Polarized capacitor, curved cathode, small symbol
+D Polarized capacitor, small US symbol
 K cap capacitor
 F ~
 $ENDCMP

--- a/Device.dcm
+++ b/Device.dcm
@@ -73,19 +73,19 @@ F ~
 $ENDCMP
 #
 $CMP CP1
-D Polarized capacitor
+D Polarized capacitor, alternative symbol
 K cap capacitor
 F ~
 $ENDCMP
 #
 $CMP CP1_Small
-D Polarized capacitor
+D Polarized capacitor, small symbol, alternative symbol
 K cap capacitor
 F ~
 $ENDCMP
 #
 $CMP CP_Small
-D Polarized capacitor
+D Polarized capacitor, small symbol
 K cap capacitor
 F ~
 $ENDCMP

--- a/sym-lib-table
+++ b/sym-lib-table
@@ -30,7 +30,7 @@
   (lib (name CPU_NXP_6800)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/CPU_NXP_6800.lib)(options "")(descr "NXP (formerly Motorola) 6800 CPUs"))
   (lib (name CPU_NXP_68000)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/CPU_NXP_68000.lib)(options "")(descr "NXP (formerly Motorola) 68000 CPUs"))
   (lib (name CPU_PowerPC)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/CPU_PowerPC.lib)(options "")(descr "PowerPC-based CPUs"))
-  (lib (name Device)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/Device.lib)(options "")(descr "Generic devices, common symbols"))
+  (lib (name Device)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/Device.lib)(options "")(descr "Generic symbols for common devices"))
   (lib (name DSP_AnalogDevices)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/DSP_AnalogDevices.lib)(options "")(descr "Analog Devices DSP symbols"))
   (lib (name DSP_Freescale)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/DSP_Freescale.lib)(options "")(descr "Freescale DSP symbols"))
   (lib (name DSP_Microchip_DSPIC33)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/DSP_Microchip_DSPIC33.lib)(options "")(descr "Microchip DSPIC33 symbols"))


### PR DESCRIPTION
The generic device library has a few spelling/capitalization errors and inconsistencies. Many of the transistor, DIAC/TRIAC, SCR, dual diode symbols etc. didn't seem descriptive enough to me, so I added the pin ordering like so:

```
D_Schottky_x2_Serial_AKC
Dual Schottky diode, anode/cathode/center

Q_NMOS_SDGD
N-MOSFET transistor, source/drain/gate, drain connected to mounting plane

LED_RCBG
RGB LED, red/cathode/blue/green

Laserdiode_P_TYPE
Laser diode with photodiode, center on pin 2, PD cathode on pin 3
```

I have not modified the symbols themselves, only the DCM descriptions and keywords.

I have a question about the keywords though: is putting "transistor" in the keywords redundant when the description also contains the word, or is there some other use for the keywords field?

------------
Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [x] Provide a URL to a datasheet for the symbol(s) you are contributing
- [x] An example screenshot image is very helpful
- [x] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
- [x] If there are matching footprint PRs, provide link(s) as appropriate
- [x] Check the output of the Travis automated check scripts - fix any errors as required
