### PR TITLE
Consistent descriptions and keywords for power flag symbols

### DIFF
--- a/power.dcm
+++ b/power.dcm
@@ -1,482 +1,482 @@
 EESchema-DOCLIB  Version 2.0
 #
 $CMP +10V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +10V
+K power-flag
 $ENDCMP
 #
 $CMP +12C
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +12C
+K power-flag
 $ENDCMP
 #
 $CMP +12L
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +12L
+K power-flag
 $ENDCMP
 #
 $CMP +12LF
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +12LF
+K power-flag
 $ENDCMP
 #
 $CMP +12P
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +12P
+K power-flag
 $ENDCMP
 #
 $CMP +12V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +12V
+K power-flag
 $ENDCMP
 #
 $CMP +12VA
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +12VA
+K power-flag
 $ENDCMP
 #
 $CMP +15V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +15V
+K power-flag
 $ENDCMP
 #
 $CMP +1V0
-D power-flag symbol +1.0V
-K Power Flag Symbol
+D Power flag, +1.0V
+K power-flag
 $ENDCMP
 #
 $CMP +1V1
-D power-flag symbol +1.1V
-K Power Flag Symbol
+D Power flag, +1.1V
+K power-flag
 $ENDCMP
 #
 $CMP +1V2
-D power-flag symbol +1.2V
-K Power Flag Symbol
+D Power flag, +1.2V
+K power-flag
 $ENDCMP
 #
 $CMP +1V35
-D power-flag symbol +1.35V
-K Power Flag Symbol
+D Power flag, +1.35V
+K power-flag
 $ENDCMP
 #
 $CMP +1V5
-D power-flag symbol +1.5V
-K Power Flag Symbol
+D Power flag, +1.5V
+K power-flag
 $ENDCMP
 #
 $CMP +1V8
-D power-flag symbol +1.8V
-K Power Flag Symbol
+D Power flag, +1.8V
+K power-flag
 $ENDCMP
 #
 $CMP +24V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +24V
+K power-flag
 $ENDCMP
 #
 $CMP +28V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +28V
+K power-flag
 $ENDCMP
 #
 $CMP +2V5
-D power-flag symbol +2.5V
-K Power Flag Symbol
+D Power flag, +2.5V
+K power-flag
 $ENDCMP
 #
 $CMP +2V8
-D power-flag symbol +2.8V
-K Power Flag Symbol
+D Power flag, +2.8V
+K power-flag
 $ENDCMP
 #
 $CMP +3.3V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +3.3V
+K power-flag
 $ENDCMP
 #
 $CMP +3.3VA
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +3.3VA
+K power-flag
 $ENDCMP
 #
 $CMP +3.3VADC
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +3.3VADC
+K power-flag
 $ENDCMP
 #
 $CMP +3.3VDAC
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +3.3VDAC
+K power-flag
 $ENDCMP
 #
 $CMP +3.3VP
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +3.3VP
+K power-flag
 $ENDCMP
 #
 $CMP +36V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +36V
+K power-flag
 $ENDCMP
 #
 $CMP +3V3
-D power-flag symbol +3.3V
-K Power Flag Symbol
+D Power flag, +3.3V
+K power-flag
 $ENDCMP
 #
 $CMP +3V8
-D power-flag symbol +3.8V
-K Power Flag Symbol
+D Power flag, +3.8V
+K power-flag
 $ENDCMP
 #
 $CMP +48V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +48V
+K power-flag
 $ENDCMP
 #
 $CMP +4V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +4V
+K power-flag
 $ENDCMP
 #
 $CMP +5C
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +5C
+K power-flag
 $ENDCMP
 #
 $CMP +5F
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +5F
+K power-flag
 $ENDCMP
 #
 $CMP +5P
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +5P
+K power-flag
 $ENDCMP
 #
 $CMP +5V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +5V
+K power-flag
 $ENDCMP
 #
 $CMP +5VA
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +5VA
+K power-flag
 $ENDCMP
 #
 $CMP +5VD
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +5VD
+K power-flag
 $ENDCMP
 #
 $CMP +5VL
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +5VL
+K power-flag
 $ENDCMP
 #
 $CMP +5VP
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +5VP
+K power-flag
 $ENDCMP
 #
 $CMP +6V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +6V
+K power-flag
 $ENDCMP
 #
 $CMP +7.5V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +7.5V
+K power-flag
 $ENDCMP
 #
 $CMP +8V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +8V
+K power-flag
 $ENDCMP
 #
 $CMP +9V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +9V
+K power-flag
 $ENDCMP
 #
 $CMP +9VA
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +9VA
+K power-flag
 $ENDCMP
 #
 $CMP +BATT
-D power-flag symbol (positive battery voltage)
-K Power Flag Symbol battery
+D Power flag, positive battery voltage
+K power-flag battery
 $ENDCMP
 #
 $CMP +VDC
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +VDC
+K power-flag
 $ENDCMP
 #
 $CMP +VSW
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, +VSW
+K power-flag
 $ENDCMP
 #
 $CMP -10V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, -10V
+K power-flag
 $ENDCMP
 #
 $CMP -12V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, -12V
+K power-flag
 $ENDCMP
 #
 $CMP -12VA
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, -12VA
+K power-flag
 $ENDCMP
 #
 $CMP -15V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, -15V
+K power-flag
 $ENDCMP
 #
 $CMP -24V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, -24V
+K power-flag
 $ENDCMP
 #
 $CMP -2V5
-D power-flag symbol -2.5V
-K Power Flag Symbol
+D Power flag, -2.5V
+K power-flag
 $ENDCMP
 #
 $CMP -36V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, -36V
+K power-flag
 $ENDCMP
 #
 $CMP -3V3
-D power-flag symbol -3.3V
-K Power Flag Symbol
+D Power flag, -3.3V
+K power-flag
 $ENDCMP
 #
 $CMP -48V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, -48V
+K power-flag
 $ENDCMP
 #
 $CMP -5V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, -5V
+K power-flag
 $ENDCMP
 #
 $CMP -5VA
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, -5VA
+K power-flag
 $ENDCMP
 #
 $CMP -6V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, -6V
+K power-flag
 $ENDCMP
 #
 $CMP -8V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, -8V
+K power-flag
 $ENDCMP
 #
 $CMP -9V
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, -9V
+K power-flag
 $ENDCMP
 #
 $CMP -9VA
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, -9VA
+K power-flag
 $ENDCMP
 #
 $CMP -BATT
-D power-flag symbol (negative battery voltage)
-K Power Flag Symbol battery
+D Power flag, negative battery voltage
+K power-flag battery
 $ENDCMP
 #
 $CMP -VDC
-D power-flag symbol (negative direct current)
-K Power Flag Symbol
+D Power flag, negative direct current
+K power-flag
 $ENDCMP
 #
 $CMP -VSW
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, -VSW
+K power-flag
 $ENDCMP
 #
 $CMP AC
-D power-flag symbol (alternating current)
-K Power Flag Symbol
+D Power flag, alternating current
+K power-flag
 $ENDCMP
 #
 $CMP Earth
-D Ground power flag symbol
-K power pwr gnd ground
+D Power flag, earth
+K power-flag ground gnd
 F ~
 $ENDCMP
 #
 $CMP Earth_Clean
-D Clean Earth power flag symbol
-K power pwr gnd ground clean signal
+D Power flag, clean earth
+K power-flag ground gnd clean signal
 F ~
 $ENDCMP
 #
 $CMP Earth_Protective
-D Protective Earth power flag symbol
-K power pwr earth protective gnd ground clean
+D Power flag, protective earth
+K power-flag ground gnd clean
 F ~
 $ENDCMP
 #
 $CMP GND
-D GROUND power-flag symbol
-K Power Flag Symbol
+D Power flag, ground
+K power-flag
 $ENDCMP
 #
 $CMP GNDA
-D (analog) ground power-flag symbol
-K Power Flag Symbol
+D Power flag, analog ground
+K power-flag
 $ENDCMP
 #
 $CMP GNDD
-D (digital) ground power-flag symbol
-K Power Flag Symbol
+D Power flag, digital ground
+K power-flag
 $ENDCMP
 #
 $CMP GNDPWR
-D (power) ground power-flag symbol
-K Power Flag Symbol
+D Power flag, power ground
+K power-flag
 $ENDCMP
 #
 $CMP GNDREF
-D (reference supply) ground power-flag symbol
-K Power Flag Symbol
+D Power flag, reference supply ground
+K power-flag
 $ENDCMP
 #
 $CMP GNDS
-D (signal) ground power-flag symbol
-K Power Flag Symbol
+D Power flag, signal ground
+K power-flag
 $ENDCMP
 #
 $CMP HT
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, HT
+K power-flag
 $ENDCMP
 #
 $CMP LINE
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, line
+K power-flag
 $ENDCMP
 #
 $CMP NEUT
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, neutral
+K power-flag
 $ENDCMP
 #
 $CMP PRI_HI
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, primary high
+K power-flag
 $ENDCMP
 #
 $CMP PRI_LO
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, primary low
+K power-flag
 $ENDCMP
 #
 $CMP PRI_MID
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, primary middle
+K power-flag
 $ENDCMP
 #
 $CMP PWR_FLAG
-D general power-flag symbol
-K Power Flag Symbol
+D Power flag, general
+K power-flag
 F ~
 $ENDCMP
 #
 $CMP VAA
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, VAA
+K power-flag
 $ENDCMP
 #
 $CMP VAC
-D power-flag symbol (alternating current)
-K Power Flag Symbol
+D Power flag, alternating current
+K power-flag
 $ENDCMP
 #
 $CMP VBUS
-D bus-voltage (e.g. USB) power-flag symbol
-K Power Flag Symbol
+D Power flag, bus voltage
+K power-flag USB
 $ENDCMP
 #
 $CMP VCC
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, VCC
+K power-flag
 $ENDCMP
 #
 $CMP VCCQ
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, VCCQ
+K power-flag
 $ENDCMP
 #
 $CMP VCOM
-D power-flag symbol
-K Power Flag Symbol
+D Power flag, VCOM
+K power-flag
 $ENDCMP
 #
 $CMP VD
-D power-flag symbol (direct current)
-K Power Flag Symbol
+D Power flag, direct current
+K power-flag dc
 $ENDCMP
 #
 $CMP VDC
-D power-flag symbol (direct current)
-K Power Flag Symbol
+D Power flag, direct current
+K power-flag dc
 $ENDCMP
 #
 $CMP VDD
-D positive voltage power-flag symbol
-K Power Flag Symbol
+D Power flag, positive voltage
+K power-flag
 $ENDCMP
 #
 $CMP VDDA
-D positive voltage power-flag symbol
-K Power Flag Symbol
+D Power flag, positive voltage
+K power-flag
 $ENDCMP
 #
 $CMP VDDF
-D positive voltage power-flag symbol
-K Power Flag Symbol
+D Power flag, positive voltage
+K power-flag
 $ENDCMP
 #
 $CMP VEE
-D negative voltage power-flag symbol
-K Power Flag Symbol
+D Power flag, negative voltage
+K power-flag
 $ENDCMP
 #
 $CMP VMEM
-D memory power-supply power-flag symbol
-K Power Flag Symbol
+D Power flag, memory power supply
+K power-flag
 $ENDCMP
 #
 $CMP VPP
-D programming volatge power-flag symbol
-K Power Flag Symbol
+D Power flag, programming voltage
+K power-flag
 $ENDCMP
 #
 $CMP VSS
-D negative power-supply/ground power-flag symbol
-K Power Flag Symbol
+D Power flag, negative power supply/ground
+K power-flag
 $ENDCMP
 #
 $CMP VSSA
-D negative power-supply/ground power-flag symbol
-K Power Flag Symbol
+D Power flag, negative power supply/ground
+K power-flag
 $ENDCMP
 #
 #End Doc Library


### PR DESCRIPTION
Just made these a little nicer looking. Fixed up capitalization & spelling etc.
![sym](https://user-images.githubusercontent.com/4781841/44315635-8aae4c00-a469-11e8-8399-9b673f32d39a.png)

------------
Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [x] Provide a URL to a datasheet for the symbol(s) you are contributing
- [x] An example screenshot image is very helpful
- [x] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
- [x] If there are matching footprint PRs, provide link(s) as appropriate
- [x] Check the output of the Travis automated check scripts - fix any errors as required
