### PR TITLE
Consistent descriptions and keywords for graphical/warning symbols

### DIFF
--- a/Graphic.dcm
+++ b/Graphic.dcm
@@ -1,175 +1,175 @@
 EESchema-DOCLIB  Version 2.0
 #
 $CMP Logo_Open_Hardware_Large
-D Large Open hardware Logo
+D Open Hardware logo, large
 K Logo
 F ~
 $ENDCMP
 #
 $CMP Logo_Open_Hardware_Small
-D small Open Hardware Logo
+D Open Hardware logo, small
 K Logo
 F ~
 $ENDCMP
 #
 $CMP SYM_Arrow45_Large
-D 300mil filled 45° arrow symbol
+D Filled 45° arrow, 300mil
 K symbol arrow angled 45°
 F ~
 $ENDCMP
 #
 $CMP SYM_Arrow45_Normal
-D 200mil filled 45° arrow symbol
+D Filled 45° arrow, 200mil
 K symbol arrow angled 45°
 F ~
 $ENDCMP
 #
 $CMP SYM_Arrow45_Small
-D small (160mil) filled 45° arrow symbol
+D Filled 45° arrow, 160mil
 K symbol arrow angled 45°
 F ~
 $ENDCMP
 #
 $CMP SYM_Arrow45_Tiny
-D small (100mil) filled 45° arrow symbol
+D Filled 45° arrow, 100mil
 K symbol arrow angled 45°
 F ~
 $ENDCMP
 #
 $CMP SYM_Arrow45_XLarge
-D 400mil filled 45° arrow symbol
+D Filled 45° arrow, 400mil
 K symbol arrow 45° angled
 F ~
 $ENDCMP
 #
 $CMP SYM_Arrow_Large
-D 300mil filled arrow symbol
+D Filled arrow, 300mil
 K symbol arrow
 F ~
 $ENDCMP
 #
 $CMP SYM_Arrow_Normal
-D 200mil filled arrow symbol
+D Filled arrow, 200mil
 K symbol arrow
 F ~
 $ENDCMP
 #
 $CMP SYM_Arrow_Small
-D small (160mil) filled arrow symbol
+D Filled arrow, 160mil
 K symbol arrow
 F ~
 $ENDCMP
 #
 $CMP SYM_Arrow_Tiny
-D small (100mil) filled arrow symbol
+D Filled arrow, 100mil
 K symbol arrow
 F ~
 $ENDCMP
 #
 $CMP SYM_Arrow_XLarge
-D 400mil filled arrow symbol
+D Filled arrow, 400mil
 K symbol arrow
 F ~
 $ENDCMP
 #
 $CMP SYM_ESD_Large
-D large ESD warning symbol / "Do not touch"
+D ESD warning/"Do not touch" symbol, large
 K symbol ESD
 F ~
 $ENDCMP
 #
 $CMP SYM_ESD_Small
-D small ESD warning symbol / "Do not touch"
+D ESD warning/"Do not touch" symbol, small
 K symbol ESD
 F ~
 $ENDCMP
 #
 $CMP SYM_Earth_Protective_Large
-D large protective earth symbol
+D Protective earth symbol, large
 K graphical symbol earth protective
 F ~
 $ENDCMP
 #
 $CMP SYM_Earth_Protective_Small
-D small protective earth symbol
+D Protective earth symbol, small
 K graphical symbol earth protective
 F ~
 $ENDCMP
 #
 $CMP SYM_Flash_Large
-D large flash symbol
+D Flash symbol, large
 K graphic symbol flash VAC 220VAC 110VAC power
 F ~
 $ENDCMP
 #
 $CMP SYM_Flash_Small
-D small flash symbol
+D Flash symbol, small
 K graphic symbol flash VAC 220VAC 110VAC power
 F ~
 $ENDCMP
 #
 $CMP SYM_Flash_XLarge
-D extra large flash symbol
+D Flash symbol, extra large
 K graphic symbol flash VAC 220VAC 110VAC power
 F ~
 $ENDCMP
 #
 $CMP SYM_Hot_Large
-D large hot surface warning sign
+D Hot surface warning symbol, large
 K symbol logo hot surface warning heat
 F ~
 $ENDCMP
 #
 $CMP SYM_Hot_Small
-D small hot surface warning sign
+D Hot surface warning symbol, small
 K symbol logo hot surface warning heat
 F ~
 $ENDCMP
 #
 $CMP SYM_LASER_Large
-D large LASER radiation warning sign
+D Laser radiation warning symbol, large
 K symbol logo laser warning
 F ~
 $ENDCMP
 #
 $CMP SYM_LASER_Small
-D small LASER radiation warning sign
+D Laser radiation warning symbol, small
 K symbol logo laser warning
 F ~
 $ENDCMP
 #
 $CMP SYM_Magnet_Large
-D large magnetic field warning sign
+D Magnetic field warning symbol, large
 K symbol logo magnetic field warning
 F ~
 $ENDCMP
 #
 $CMP SYM_Magnet_Small
-D small magnetic field warning sign
+D Magnetic field warning symbol, small
 K symbol logo magnetic field warning
 F ~
 $ENDCMP
 #
 $CMP SYM_Radio_Waves_Large
-D large radio waves warning sign
+D Radio waves warning symbol, large
 K symbol logo radio waves warning radiation
 F ~
 $ENDCMP
 #
 $CMP SYM_Radio_Waves_Small
-D small radio waves warning sign
+D Radio waves warning symbol, small
 K symbol logo radio waves warning radiation
 F ~
 $ENDCMP
 #
 $CMP SYM_Radioactive_Large
-D large radioactive radiation warning sign
+D Radioactive/radiation warning symbol, large
 K symbol logo radioactive radiation warning heat
 F ~
 $ENDCMP
 #
 $CMP SYM_Radioactive_Radiation_Small
-D small radioactive radiation warning sign
+D Radioactive/radiation warning symbol, small
 K symbol logo radioactive radiation warning
 F ~
 $ENDCMP


### PR DESCRIPTION
Again, just making the descriptions and keywords better.
![sym](https://user-images.githubusercontent.com/4781841/44315841-32784980-a46b-11e8-8378-cb54e3dbdcda.png)

------------
Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [x] Provide a URL to a datasheet for the symbol(s) you are contributing
- [x] An example screenshot image is very helpful
- [x] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
- [x] If there are matching footprint PRs, provide link(s) as appropriate
- [x] Check the output of the Travis automated check scripts - fix any errors as required
