### PR TITLE
Update audio connector schematic symbols

### DIFF
--- a/Audio_connectors
+++ b/Audio_connectors
@@ -1,0 +1,1 @@
+Uncer "Connector" all "AudioJack..." should use the IEC 60617 symbols that are shown in IEEE Std 315A-1986, Clause 5.3.5.1 or Clause 5.3.5.3.


### PR DESCRIPTION
Change audio connectors to IEC 60617/IEEE 315A symbols.

------------
Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the symbol(s) you are contributing
- [/home/larry/Pictures/Screenshot from 2018-08-27 21-16-43.png
![image](https://user-images.githubusercontent.com/18520951/44695175-e6676f00-aa3f-11e8-8d7a-bef4358ac9c3.png)
 ] An example screenshot image is very helpful
![image](https://user-images.githubusercontent.com/18520951/44695220-29c1dd80-aa40-11e8-9d1b-7074b1f95e60.png)
![screenshot from 2018-08-27 21-16-43](https://user-images.githubusercontent.com/18520951/44695282-74435a00-aa40-11e8-9d82-7d523f2556cf.png)
![screenshot from 2018-08-27 21-16-43](https://user-images.githubusercontent.com/18520951/44695299-8a511a80-aa40-11e8-877a-9828ffad5820.png)
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
