### PR TITLE
Add symbol R_POT_MountingPin.

### DIFF
--- a/Device.dcm
+++ b/Device.dcm
@@ -2256,6 +2256,12 @@ K resistor variable
 F ~
 $ENDCMP
 #
+$CMP R_POT_MountingPin
+D Potentiometer with a mounting pin
+K resistor variable
+F ~
+$ENDCMP
+#
 $CMP R_POT_Small
 D Potentiometer
 K resistor variable

--- a/Device.lib
+++ b/Device.lib
@@ -10877,6 +10877,29 @@ X 6 6 0 -150 50 U 50 50 2 1 P
 ENDDRAW
 ENDDEF
 #
+# R_POT_MountingPin
+#
+DEF R_POT_MountingPin RV 0 40 Y N 1 F N
+F0 "RV" -325 0 50 V V C CNN
+F1 "R_POT_MountingPin" -250 0 50 V V C CNN
+F2 "" 0 0 50 H I C CNN
+F3 "" 0 0 50 H I C CNN
+$FPLIST
+ Potentiometer*
+$ENDFPLIST
+DRAW
+S 40 100 -40 -100 0 1 10 N
+P 2 0 1 0 100 0 60 0 N
+P 3 0 1 0 45 0 90 20 90 -20 F
+T 900 -65 0 15 0 1 1 Mounting Normal 0 C C
+P 2 1 1 6 -80 40 -80 -40 N
+X 1 1 0 150 50 D 50 50 1 1 P
+X 2 2 150 0 50 L 50 50 1 1 P
+X 3 3 0 -150 50 U 50 50 1 1 P
+X MountPin MP -200 0 120 R 50 50 1 1 P
+ENDDRAW
+ENDDEF
+#
 # R_POT_Small
 #
 DEF R_POT_Small RV 0 40 Y N 1 F N


### PR DESCRIPTION
[Motivated by these slide potentiometers that have mounting pins.](https://github.com/KiCad/kicad-footprints/pull/920)

I suspect that what I have here isn't quite right, but I wasn't really sure what a potentiometer with a mounting pin should look like, so I could use some feedback.

There are a bunch of KLC warnings, but they seem to have been inherited from the original `R_POT` symbol that I based this on.

![r_pot_mountingpin](https://user-images.githubusercontent.com/1080008/45182309-b9e8eb00-b1d5-11e8-8e84-d9d47b61b94e.png)

------------
Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the symbol(s) you are contributing
- [ ] An example screenshot image is very helpful
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
