### PR TITLE
Housing reference letter changed to N (EN 81346-2:2018) and Mounting hole reference letter changed to H (symbol guidelines).

### DIFF
--- a/Mechanical.dcm
+++ b/Mechanical.dcm
@@ -13,12 +13,13 @@ $ENDCMP
 #
 $CMP Housing
 D Housing
-K housing
+K housing enclosure
+F ~
 $ENDCMP
 #
 $CMP Housing_Pad
 D Housing with connection pin
-K housing
+K housing enclosure shield
 F ~
 $ENDCMP
 #

--- a/Mechanical.lib
+++ b/Mechanical.lib
@@ -30,11 +30,15 @@ ENDDEF
 #
 # Housing
 #
-DEF Housing MK 0 40 Y Y 1 F N
-F0 "MK" 150 0 50 H V L CNN
+DEF Housing N 0 40 Y Y 1 F N
+F0 "N" 150 0 50 H V L CNN
 F1 "Housing" 150 -75 50 H V L CNN
 F2 "" 50 50 50 H I C CNN
 F3 "" 50 50 50 H I C CNN
+$FPLIST
+ Enclosure*
+ Housing*
+$ENDFPLIST
 DRAW
 C -175 -125 25 0 1 0 F
 C -75 -125 25 0 1 0 F
@@ -68,8 +72,8 @@ ENDDEF
 #
 # Housing_Pad
 #
-DEF Housing_Pad MK 0 40 N N 1 F N
-F0 "MK" 175 0 50 H V L CNN
+DEF Housing_Pad N 0 40 N N 1 F N
+F0 "N" 175 0 50 H V L CNN
 F1 "Housing_Pad" 175 -75 50 H V L CNN
 F2 "" 75 50 50 H I C CNN
 F3 "" 75 50 50 H I C CNN
@@ -107,8 +111,8 @@ ENDDEF
 #
 # MountingHole
 #
-DEF MountingHole MH 0 40 Y Y 1 F N
-F0 "MH" 0 200 50 H V C CNN
+DEF MountingHole H 0 40 Y Y 1 F N
+F0 "H" 0 200 50 H V C CNN
 F1 "MountingHole" 0 125 50 H V C CNN
 F2 "" 0 0 50 H I C CNN
 F3 "" 0 0 50 H I C CNN
@@ -122,8 +126,8 @@ ENDDEF
 #
 # MountingHole_Pad
 #
-DEF MountingHole_Pad MH 0 40 N N 1 F N
-F0 "MH" 0 250 50 H V C CNN
+DEF MountingHole_Pad H 0 40 N N 1 F N
+F0 "H" 0 250 50 H V C CNN
 F1 "MountingHole_Pad" 0 175 50 H V C CNN
 F2 "" 0 0 50 H I C CNN
 F3 "" 0 0 50 H I C CNN


### PR DESCRIPTION
Housing reference letter changed to N (EN 81346-2:2018)
    See: http://81346.com/english/about-81346/about-81346-2-2017-edition/
    Old letters MK were confuse with microphone. 
    See: http://kicad-pcb.org/libraries/klc/S6.1/
    
Mounting hole reference letter changed to H (hardware, mountig screw etc).
    See: http://kicad-pcb.org/libraries/klc/S6.1/

------------
Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [-] Provide a URL to a datasheet for the symbol(s) you are contributing
- [-] An example screenshot image is very helpful
- [-] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
- [-] If there are matching footprint PRs, provide link(s) as appropriate
- [x] Check the output of the Travis automated check scripts - fix any errors as required
