### PR TITLE
Interface_USB: Fix encoding issues in DCM file

### DIFF
--- a/Interface_USB.dcm
+++ b/Interface_USB.dcm
@@ -193,25 +193,25 @@ F http://www.ftdichip.com/Products/ICs/FT245B.html
 $ENDCMP
 #
 $CMP FUSB302B01MPX
-D Programmable USB Type‐C Controller w/PD, I2C address 0x23, WQFN-14
+D Programmable USB Type-C Controller w/PD, I2C address 0x23, WQFN-14
 K USB USB-C PD Power Delivery PHY
 F http://www.onsemi.com/pub/Collateral/FUSB302B-D.PDF
 $ENDCMP
 #
 $CMP FUSB302B10MPX
-D Programmable USB Type‐C Controller w/PD, I2C address 0x24, WQFN-14
+D Programmable USB Type-C Controller w/PD, I2C address 0x24, WQFN-14
 K USB USB-C PD Power Delivery PHY
 F http://www.onsemi.com/pub/Collateral/FUSB302B-D.PDF
 $ENDCMP
 #
 $CMP FUSB302B11MPX
-D Programmable USB Type‐C Controller w/PD, I2C address 0x25, WQFN-14
+D Programmable USB Type-C Controller w/PD, I2C address 0x25, WQFN-14
 K USB USB-C PD Power Delivery PHY
 F http://www.onsemi.com/pub/Collateral/FUSB302B-D.PDF
 $ENDCMP
 #
 $CMP FUSB302BMPX
-D Programmable USB Type‐C Controller w/PD, I2C address 0x22, WQFN-14
+D Programmable USB Type-C Controller w/PD, I2C address 0x22, WQFN-14
 K USB USB-C PD Power Delivery PHY
 F http://www.onsemi.com/pub/Collateral/FUSB302B-D.PDF
 $ENDCMP


### PR DESCRIPTION
It seems that during a descriptions update some rare characters got into a DCM file in https://github.com/KiCad/kicad-symbols/commit/9c63ffd7bac0294724b88669c2c2d837bac95504#diff-53710c242b8a37ab5f0e1e83f9809318.

I've restored those to UTF-8 hyphens so that my check scripts wouldn't crash.

Asking for @Ratfink  supervision as he made the changes originally.