### PR TITLE
Visible pin numbers on R networks

### DIFF
--- a/Device.lib
+++ b/Device.lib
@@ -3217,8 +3217,8 @@ S 50 50 50 50 0 1 0 N
 S 50 150 50 250 0 1 0 N
 S 50 250 50 250 0 1 0 N
 S 110 330 -110 -300 0 1 10 f
-P 2 0 1 0 -50 -150 -50 -250 N
 P 2 0 1 8 -50 -150 -50 -250 N
+P 2 0 1 0 -50 -150 -50 -250 N
 P 2 0 1 0 -50 0 -100 0 N
 P 2 0 1 0 -50 0 50 0 N
 P 2 0 1 8 -50 50 -50 -50 N
@@ -6819,7 +6819,7 @@ ENDDEF
 #
 # R_Network03
 #
-DEF R_Network03 RN 0 0 N N 1 F N
+DEF R_Network03 RN 0 0 Y N 1 F N
 F0 "RN" -200 0 50 V V C CNN
 F1 "R_Network03" 200 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP4" 275 0 50 V I C CNN
@@ -6846,7 +6846,7 @@ ENDDEF
 #
 # R_Network03_US
 #
-DEF R_Network03_US RN 0 0 N N 1 F N
+DEF R_Network03_US RN 0 0 Y N 1 F N
 F0 "RN" -200 0 50 V V C CNN
 F1 "R_Network03_US" 200 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP4" 275 0 50 V I C CNN
@@ -6877,7 +6877,7 @@ ENDDEF
 #
 # R_Network04
 #
-DEF R_Network04 RN 0 0 N N 1 F N
+DEF R_Network04 RN 0 0 Y N 1 F N
 F0 "RN" -300 0 50 V V C CNN
 F1 "R_Network04" 200 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP5" 275 0 50 V I C CNN
@@ -6908,7 +6908,7 @@ ENDDEF
 #
 # R_Network04_US
 #
-DEF R_Network04_US RN 0 0 N N 1 F N
+DEF R_Network04_US RN 0 0 Y N 1 F N
 F0 "RN" -300 0 50 V V C CNN
 F1 "R_Network04_US" 200 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP5" 275 0 50 V I C CNN
@@ -6942,7 +6942,7 @@ ENDDEF
 #
 # R_Network05
 #
-DEF R_Network05 RN 0 0 N N 1 F N
+DEF R_Network05 RN 0 0 Y N 1 F N
 F0 "RN" -300 0 50 V V C CNN
 F1 "R_Network05" 300 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP6" 375 0 50 V I C CNN
@@ -6977,7 +6977,7 @@ ENDDEF
 #
 # R_Network05_US
 #
-DEF R_Network05_US RN 0 0 N N 1 F N
+DEF R_Network05_US RN 0 0 Y N 1 F N
 F0 "RN" -300 0 50 V V C CNN
 F1 "R_Network05_US" 300 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP6" 375 0 50 V I C CNN
@@ -7016,7 +7016,7 @@ ENDDEF
 #
 # R_Network06
 #
-DEF R_Network06 RN 0 0 N N 1 F N
+DEF R_Network06 RN 0 0 Y N 1 F N
 F0 "RN" -400 0 50 V V C CNN
 F1 "R_Network06" 300 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP7" 375 0 50 V I C CNN
@@ -7055,7 +7055,7 @@ ENDDEF
 #
 # R_Network06_US
 #
-DEF R_Network06_US RN 0 0 N N 1 F N
+DEF R_Network06_US RN 0 0 Y N 1 F N
 F0 "RN" -400 0 50 V V C CNN
 F1 "R_Network06_US" 300 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP7" 375 0 50 V I C CNN
@@ -7099,7 +7099,7 @@ ENDDEF
 #
 # R_Network07
 #
-DEF R_Network07 RN 0 0 N N 1 F N
+DEF R_Network07 RN 0 0 Y N 1 F N
 F0 "RN" -400 0 50 V V C CNN
 F1 "R_Network07" 400 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP8" 475 0 50 V I C CNN
@@ -7142,7 +7142,7 @@ ENDDEF
 #
 # R_Network07_US
 #
-DEF R_Network07_US RN 0 0 N N 1 F N
+DEF R_Network07_US RN 0 0 Y N 1 F N
 F0 "RN" -400 0 50 V V C CNN
 F1 "R_Network07_US" 400 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP8" 475 0 50 V I C CNN
@@ -7191,7 +7191,7 @@ ENDDEF
 #
 # R_Network08
 #
-DEF R_Network08 RN 0 0 N N 1 F N
+DEF R_Network08 RN 0 0 Y N 1 F N
 F0 "RN" -500 0 50 V V C CNN
 F1 "R_Network08" 400 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP9" 475 0 50 V I C CNN
@@ -7238,7 +7238,7 @@ ENDDEF
 #
 # R_Network08_US
 #
-DEF R_Network08_US RN 0 0 N N 1 F N
+DEF R_Network08_US RN 0 0 Y N 1 F N
 F0 "RN" -500 0 50 V V C CNN
 F1 "R_Network08_US" 400 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP9" 475 0 50 V I C CNN
@@ -7292,7 +7292,7 @@ ENDDEF
 #
 # R_Network09
 #
-DEF R_Network09 RN 0 0 N N 1 F N
+DEF R_Network09 RN 0 0 Y N 1 F N
 F0 "RN" -500 0 50 V V C CNN
 F1 "R_Network09" 500 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP10" 575 0 50 V I C CNN
@@ -7343,7 +7343,7 @@ ENDDEF
 #
 # R_Network09_US
 #
-DEF R_Network09_US RN 0 0 N N 1 F N
+DEF R_Network09_US RN 0 0 Y N 1 F N
 F0 "RN" -500 0 50 V V C CNN
 F1 "R_Network09_US" 500 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP10" 575 0 50 V I C CNN
@@ -7402,7 +7402,7 @@ ENDDEF
 #
 # R_Network10
 #
-DEF R_Network10 RN 0 0 N N 1 F N
+DEF R_Network10 RN 0 0 Y N 1 F N
 F0 "RN" -600 0 50 V V C CNN
 F1 "R_Network10" 500 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP11" 575 0 50 V I C CNN
@@ -7457,7 +7457,7 @@ ENDDEF
 #
 # R_Network10_US
 #
-DEF R_Network10_US RN 0 0 N N 1 F N
+DEF R_Network10_US RN 0 0 Y N 1 F N
 F0 "RN" -600 0 50 V V C CNN
 F1 "R_Network10_US" 500 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP11" 575 0 50 V I C CNN
@@ -7521,7 +7521,7 @@ ENDDEF
 #
 # R_Network11
 #
-DEF R_Network11 RN 0 0 N N 1 F N
+DEF R_Network11 RN 0 0 Y N 1 F N
 F0 "RN" -600 0 50 V V C CNN
 F1 "R_Network11" 600 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP12" 675 0 50 V I C CNN
@@ -7580,7 +7580,7 @@ ENDDEF
 #
 # R_Network11_US
 #
-DEF R_Network11_US RN 0 0 N N 1 F N
+DEF R_Network11_US RN 0 0 Y N 1 F N
 F0 "RN" -600 0 50 V V C CNN
 F1 "R_Network11_US" 600 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP12" 675 0 50 V I C CNN
@@ -7649,7 +7649,7 @@ ENDDEF
 #
 # R_Network12
 #
-DEF R_Network12 RN 0 0 N N 1 F N
+DEF R_Network12 RN 0 0 Y N 1 F N
 F0 "RN" -700 0 50 V V C CNN
 F1 "R_Network12" 600 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP13" 675 0 50 V I C CNN
@@ -7712,7 +7712,7 @@ ENDDEF
 #
 # R_Network12_US
 #
-DEF R_Network12_US RN 0 0 N N 1 F N
+DEF R_Network12_US RN 0 0 Y N 1 F N
 F0 "RN" -700 0 50 V V C CNN
 F1 "R_Network12_US" 600 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP13" 675 0 50 V I C CNN
@@ -7786,7 +7786,7 @@ ENDDEF
 #
 # R_Network13
 #
-DEF R_Network13 RN 0 0 N N 1 F N
+DEF R_Network13 RN 0 0 Y N 1 F N
 F0 "RN" -700 0 50 V V C CNN
 F1 "R_Network13" 700 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP14" 775 0 50 V I C CNN
@@ -7853,7 +7853,7 @@ ENDDEF
 #
 # R_Network13_US
 #
-DEF R_Network13_US RN 0 0 N N 1 F N
+DEF R_Network13_US RN 0 0 Y N 1 F N
 F0 "RN" -700 0 50 V V C CNN
 F1 "R_Network13_US" 700 0 50 V V C CNN
 F2 "Resistor_THT:R_Array_SIP14" 775 0 50 V I C CNN


### PR DESCRIPTION
As noticed at https://github.com/KiCad/kicad-footprints/issues/961, there are no visible pin numbers on resistor network symbols. This makes knowing which resistor in the package you've connected to difficult, which is annoying since they're interchangeable.

This PR turns on pin number visibility for the entire group of symbols.
![image](https://user-images.githubusercontent.com/1936989/46506921-e8fd7700-c7ea-11e8-91ae-2967b35c38d7.png)

At higher pin counts the pin number runs over the symbol body, which looks ugly, but I think having pin numbers with this caveat is better than no pin numbers. Unless there's a real reason to do more, I'd rather have this merged and then think about a better way later once we have more freedom to change symbols.

------------
Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the symbol(s) you are contributing
- [ ] An example screenshot image is very helpful
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
