### PR TITLE
new symbol: Conn_Coaxial_x2_Isolated

### DIFF
--- a/Connector.dcm
+++ b/Connector.dcm
@@ -756,6 +756,12 @@ K BNC SMA SMB SMC coaxial connector CINCH RCA
 F  ~
 $ENDCMP
 #
+$CMP Conn_Coaxial_x2_Isolated
+D coaxial connector (BNC, SMA, SMB, SMC, Cinch/RCA, ...)
+K BNC SMA SMB SMC coaxial connector CINCH RCA
+F  ~
+$ENDCMP
+#
 $CMP Conn_WallPlug
 D 3-pin general wall plug, no Earth wire (110VAC, 220VAC)
 K wall plug 110VAC 220VAC

--- a/Connector.lib
+++ b/Connector.lib
@@ -7963,6 +7963,33 @@ X EXT 3 0 -300 100 U 50 50 1 1 P
 ENDDRAW
 ENDDEF
 #
+# Conn_Coaxial_x2_Isolated
+#
+DEF Conn_Coaxial_x2_Isolated J 0 40 Y N 2 F N
+F0 "J" 10 120 50 H V C CNN
+F1 "Conn_Coaxial_x2_Isolated" 115 0 50 V V C CNN
+F2 "" 0 0 50 H I C CNN
+F3 "" 0 0 50 H I C CNN
+$FPLIST
+ *BNC*
+ *SMA*
+ *SMB*
+ *SMC*
+ *Cinch*
+$ENDFPLIST
+DRAW
+A -2 0 71 1636 0 0 1 10 N -70 20 70 0
+A -1 0 71 0 -1638 0 1 10 N 70 0 -70 -20
+C 0 0 20 0 1 8 N
+P 2 0 1 0 -100 0 -20 0 N
+P 2 0 1 0 0 -100 0 -70 N
+X In1 1 -200 0 100 R 50 50 1 1 P
+X Ext1 2 0 -200 100 U 50 50 1 1 P
+X In2 3 -200 0 100 R 50 50 2 1 P
+X Ext2 4 0 -200 100 U 50 50 2 1 P
+ENDDRAW
+ENDDEF
+#
 # Conn_WallPlug
 #
 DEF Conn_WallPlug P 0 0 Y Y 1 F N


### PR DESCRIPTION
the existing `Conn_Coaxial_x2` connects the outer pins of both connectors
together, this is not the case for isolated connectors (e.g. for BNC)

It is a copy of the existing `Conn_Coaxial`, converting it into a two part unit with two identical components. As this is a generic connector there is no datasheet linked, an example component is [this](https://www.amphenolrf.com/031-6575.html). A footprint will follow in the near future.

![conn_coaxial_x2_isolated](https://user-images.githubusercontent.com/1010629/47702991-fe659580-dc1e-11e8-96a2-11294b36b142.png)
![conn_coaxial_x2_isolated_2](https://user-images.githubusercontent.com/1010629/47702992-fe659580-dc1e-11e8-9741-6ac114076f5a.png)

