### PR TITLE
Add Fiducial as schematic symbol

### DIFF
--- a/Mechanical.dcm
+++ b/Mechanical.dcm
@@ -1,7 +1,7 @@
 EESchema-DOCLIB  Version 2.0
 #
 $CMP Fiducial
-D Fiducial Marker without connection
+D Fiducial Marker
 K fiducial marker
 F ~
 $ENDCMP

--- a/Mechanical.dcm
+++ b/Mechanical.dcm
@@ -1,8 +1,15 @@
 EESchema-DOCLIB  Version 2.0
 #
+$CMP Fiducial
+D Fiducial Marker without connection
+K fiducial marker
+F ~
+$ENDCMP
+#
 $CMP Heatsink
 D Heatsink
 K thermal heat temperature
+F ~
 $ENDCMP
 #
 $CMP Heatsink_Pad

--- a/Mechanical.lib
+++ b/Mechanical.lib
@@ -1,6 +1,21 @@
 EESchema-LIBRARY Version 2.4
 #encoding utf-8
 #
+# Fiducial
+#
+DEF Fiducial FID 0 40 Y Y 1 F N
+F0 "FID" 0 200 50 H V C CNN
+F1 "Fiducial" 0 125 50 H V C CNN
+F2 "" 0 0 50 H I C CNN
+F3 "" 0 0 50 H I C CNN
+$FPLIST
+ Fiducial*
+$ENDFPLIST
+DRAW
+C 0 0 50 0 1 20 f
+ENDDRAW
+ENDDEF
+#
 # Heatsink
 #
 DEF Heatsink HS 0 40 Y Y 1 F N

--- a/Mechanical.lib
+++ b/Mechanical.lib
@@ -3,7 +3,7 @@ EESchema-LIBRARY Version 2.4
 #
 # Fiducial
 #
-DEF Fiducial FID 0 20 Y Y 1 F N
+DEF Fiducial FD 0 20 Y Y 1 F N
 F0 "FID" 0 200 50 H V C CNN
 F1 "Fiducial" 0 125 50 H V C CNN
 F2 "" 0 0 50 H I C CNN

--- a/Mechanical.lib
+++ b/Mechanical.lib
@@ -3,7 +3,7 @@ EESchema-LIBRARY Version 2.4
 #
 # Fiducial
 #
-DEF Fiducial FID 0 40 Y Y 1 F N
+DEF Fiducial FID 0 20 Y Y 1 F N
 F0 "FID" 0 200 50 H V C CNN
 F1 "Fiducial" 0 125 50 H V C CNN
 F2 "" 0 0 50 H I C CNN


### PR DESCRIPTION
Analogously to the Mounting Hole, that is also a symbol in the schematics and not only a footprint.

![image](https://user-images.githubusercontent.com/10653970/48297456-893a7000-e4fc-11e8-900d-c4ff2592a7d3.png)

------------

- [x] An example screenshot image is very helpful
- [x] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
- [x] Check the output of the Travis automated check scripts - fix any errors as required
