### PR TITLE
Fix "bibolar" typo.

### DIFF
--- a/pspice.dcm
+++ b/pspice.dcm
@@ -55,13 +55,13 @@ F ~
 $ENDCMP
 #
 $CMP QNPN
-D Bibolar transistor symbol for simulation only
+D Bipolar transistor symbol for simulation only
 K simulation
 F ~
 $ENDCMP
 #
 $CMP QPNP
-D Bibolar transistor symbol for simulation only
+D Bipolar transistor symbol for simulation only
 K simulstaion
 F ~
 $ENDCMP


### PR DESCRIPTION
Replace "bibolar" with "bipolar".
