### PR TITLE
New component SN74LVC2T45DCUR

### DIFF
--- a/Logic_LevelTranslator.dcm
+++ b/Logic_LevelTranslator.dcm
@@ -42,6 +42,12 @@ K Level-Shifter CMOS-TTL-Translation
 F http://www.ti.com/lit/ds/symlink/sn74lvc1t45.pdf
 $ENDCMP
 #
+$CMP SN74LVC2T45DCUR
+D 2-Bit Dual-Supply Bus Transceiver With Configurable Voltage Translation and 3-State Outputs, VSSOP-8
+K Level-Shifter CMOS-TTL-Translation
+F http://www.ti.com/lit/ds/symlink/sn74lvc2t45.pdf
+$ENDCMP
+#
 $CMP TXB0102DCT
 D 2-Bit Bidirectional Voltage-Level Translator in TSSOP Package With Auto Direction Sensing and ±15-kV ESD Protection
 K Level-Shifter CMOS-TTL-Translation


### PR DESCRIPTION
This is Dual-Bit Dual-Supply Bus Transceiver With Configurable Voltage Translation in VSSOP-8

image
![image](https://user-images.githubusercontent.com/45284251/48951014-1e525580-ef4e-11e8-8195-1fa55c13aa67.png)
Footprint: Package_SO:VSSOP-8_2.4x2.1mm_P0.5mm from official footprint library.