### PR TITLE
Add blank datasheet URLs for generic switch symbols

### DIFF
--- a/Switch.dcm
+++ b/Switch.dcm
@@ -3,6 +3,7 @@ EESchema-DOCLIB  Version 2.0
 $CMP SW_Coded
 D Rotary switch, 4-bit encoding
 K rotary hex
+F ~
 $ENDCMP
 #
 $CMP SW_Coded_SH-7010
@@ -44,81 +45,97 @@ $ENDCMP
 $CMP SW_DIP_x01
 D 1x DIP Switch, Single Pole Single Throw (SPST) switch, small symbol
 K dip switch
+F ~
 $ENDCMP
 #
 $CMP SW_DIP_x02
 D 2x DIP Switch, Single Pole Single Throw (SPST) switch, small symbol
 K dip switch
+F ~
 $ENDCMP
 #
 $CMP SW_DIP_x03
 D 3x DIP Switch, Single Pole Single Throw (SPST) switch, small symbol
 K dip switch
+F ~
 $ENDCMP
 #
 $CMP SW_DIP_x04
 D 4x DIP Switch, Single Pole Single Throw (SPST) switch, small symbol
 K dip switch
+F ~
 $ENDCMP
 #
 $CMP SW_DIP_x05
 D 5x DIP Switch, Single Pole Single Throw (SPST) switch, small symbol
 K dip switch
+F ~
 $ENDCMP
 #
 $CMP SW_DIP_x06
 D 6x DIP Switch, Single Pole Single Throw (SPST) switch, small symbol
 K dip switch
+F ~
 $ENDCMP
 #
 $CMP SW_DIP_x07
 D 7x DIP Switch, Single Pole Single Throw (SPST) switch, small symbol
 K dip switch
+F ~
 $ENDCMP
 #
 $CMP SW_DIP_x08
 D 8x DIP Switch, Single Pole Single Throw (SPST) switch, small symbol
 K dip switch
+F ~
 $ENDCMP
 #
 $CMP SW_DIP_x09
 D 9x DIP Switch, Single Pole Single Throw (SPST) switch, small symbol
 K dip switch
+F ~
 $ENDCMP
 #
 $CMP SW_DIP_x10
 D 10x DIP Switch, Single Pole Single Throw (SPST) switch, small symbol
 K dip switch
+F ~
 $ENDCMP
 #
 $CMP SW_DIP_x11
 D 11x DIP Switch, Single Pole Single Throw (SPST) switch, small symbol
 K dip switch
+F ~
 $ENDCMP
 #
 $CMP SW_DIP_x12
 D 12x DIP Switch, Single Pole Single Throw (SPST) switch, small symbol
 K dip switch
+F ~
 $ENDCMP
 #
 $CMP SW_DPDT_x2
 D Switch, dual pole double throw, separate symbols
 K switch dual-pole double-throw DPDT spdt ON-ON
+F ~
 $ENDCMP
 #
 $CMP SW_DPST
 D Double Pole Single Throw (DPST) Switch
 K switch dual double-pole single-throw OFF-ON
+F ~
 $ENDCMP
 #
 $CMP SW_DPST_Temperature
 D Double Pole Single Throw (DPST) Switch, temperature dependent
 K temerature switch dual double-pole single-throw OFF-ON
+F ~
 $ENDCMP
 #
 $CMP SW_DPST_x2
 D Single Pole Single Throw (SPST) switch, separate symbol
 K switch lever
+F ~
 $ENDCMP
 #
 $CMP SW_E3_SA3216
@@ -172,66 +189,79 @@ $ENDCMP
 $CMP SW_Push
 D Push button switch, generic, two pins
 K switch normally-open pushbutton push-button
+F ~
 $ENDCMP
 #
 $CMP SW_Push_45deg
 D Push button switch, normally open, two pins, 45° tilted
 K switch normally-open pushbutton push-button
+F ~
 $ENDCMP
 #
 $CMP SW_Push_Dual
 D Push button switch, generic, symbol, four pins
 K switch normally-open pushbutton push-button
+F ~
 $ENDCMP
 #
 $CMP SW_Push_Dual_x2
 D Push button switch, generic, separate symbols, four pins
 K switch normally-open pushbutton push-button
+F ~
 $ENDCMP
 #
 $CMP SW_Push_LED
 D Push button switch with LED, generic
 K switch normally-open pushbutton push-button LED
+F ~
 $ENDCMP
 #
 $CMP SW_Push_Lamp
 D Push button switch with Signal Lamp, generic
 K switch normally-open pushbutton push-button Lamp
+F ~
 $ENDCMP
 #
 $CMP SW_Push_Open
 D Push button switch, push-to-open, generic, two pins
 K switch normally-closed pushbutton push-button
+F ~
 $ENDCMP
 #
 $CMP SW_Push_Open_Dual
 D Push button switch, normally closed, generic, four pins
 K switch normally-closed pushbutton push-button
+F ~
 $ENDCMP
 #
 $CMP SW_Push_Open_Dual_x2
 D Push button switch, push-to-open, generic, two pins
 K switch normally-closed pushbutton push-button
+F ~
 $ENDCMP
 #
 $CMP SW_Push_SPDT
 D Momentary Switch, single pole double throw
 K switch single-pole double-throw spdt ON-ON
+F ~
 $ENDCMP
 #
 $CMP SW_Reed
 D reed switch
 K reed magnetic switch
+F ~
 $ENDCMP
 #
 $CMP SW_Reed_Opener
 D reed switch, default-closed
 K reed magnetic switch
+F ~
 $ENDCMP
 #
 $CMP SW_Reed_SPDT
 D SPDT reed switch
 K reed magnetic switch SPDT
+F ~
 $ENDCMP
 #
 $CMP SW_Rotary12
@@ -261,36 +291,43 @@ $ENDCMP
 $CMP SW_SP3T
 D Switch, three position, single pole triple throw, 3 position switch, SP3T
 K switch sp3t ON-ON-ON
+F ~
 $ENDCMP
 #
 $CMP SW_SPDT
 D Switch, single pole double throw
 K switch single-pole double-throw spdt ON-ON
+F ~
 $ENDCMP
 #
 $CMP SW_SPDT_MSM
 D Switch, single pole double throw, center OFF position
 K switch spdt single-pole double-throw ON-OFF-ON
+F ~
 $ENDCMP
 #
 $CMP SW_SPST
 D Single Pole Single Throw (SPST) switch
 K switch lever
+F ~
 $ENDCMP
 #
 $CMP SW_SPST_LED
 D Single Pole Single Throw (SPST) switch with LED, generic
 K switch SPST LED OFF-ON
+F ~
 $ENDCMP
 #
 $CMP SW_SPST_Lamp
 D Single Pole Single Throw (SPST) switch with signal lamp, generic
 K switch SPST LED OFF-ON lamp
+F ~
 $ENDCMP
 #
 $CMP SW_SPST_Temperature
 D Single Pole Single Throw (SPST) switch, temperature dependent
 K temperature switch
+F ~
 $ENDCMP
 #
 #End Doc Library


### PR DESCRIPTION
Just noticed this while fixing up the DIP switch generator.

------------
Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [x] Provide a URL to a datasheet for the symbol(s) you are contributing
- [x] An example screenshot image is very helpful
- [x] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
- [x] If there are matching footprint PRs, provide link(s) as appropriate
- [x] Check the output of the Travis automated check scripts - fix any errors as required
