### PR TITLE
RMK-3-451 and RMK-5-51: fix double underscore in PL-258 footprint

### DIFF
--- a/RF.lib
+++ b/RF.lib
@@ -622,7 +622,7 @@ ENDDEF
 DEF RMK-3-451 U 0 20 Y Y 1 F N
 F0 "U" -250 300 50 H V C CNN
 F1 "RMK-3-451" 250 300 50 H V C CNN
-F2 "Package_SO:Mini-Circuits_TT1224_LandPatternPL-258__ClockwisePinNumbering" -250 -350 50 H I C CNN
+F2 "Package_SO:Mini-Circuits_TT1224_LandPatternPL-258_ClockwisePinNumbering" -250 -350 50 H I C CNN
 F3 "" -150 -250 50 H I C CNN
 $FPLIST
  Mini?Circuits*TT1224*
@@ -644,7 +644,7 @@ ENDDEF
 DEF RMK-5-51 U 0 20 Y Y 1 F N
 F0 "U" -250 300 50 H V C CNN
 F1 "RMK-5-51" 250 300 50 H V C CNN
-F2 "Package_SO:Mini-Circuits_TT1224_LandPatternPL-258__ClockwisePinNumbering" -250 -350 50 H I C CNN
+F2 "Package_SO:Mini-Circuits_TT1224_LandPatternPL-258_ClockwisePinNumbering" -250 -350 50 H I C CNN
 F3 "" -150 -250 50 H I C CNN
 $FPLIST
  Mini?Circuits*TT1224*


### PR DESCRIPTION
See: https://github.com/KiCad/kicad-footprints/pull/1325

this fixes the footprint-assignment.