### PR TITLE
Improve SPICE library symbol descriptions

### DIFF
--- a/Simulation_SPICE.dcm
+++ b/Simulation_SPICE.dcm
@@ -1,14 +1,14 @@
 EESchema-DOCLIB  Version 2.0
 #
 $CMP DIODE
-D Diode, for simulation only, anode on pin 1
+D Diode, anode on pin 1, for simulation only!
 K simulation
 F ~
 $ENDCMP
 #
 $CMP IAM
-D Current source, amplitude modulated (AM)
-K simulation
+D Current source, AM
+K simulation amplitude modulated
 F ~
 $ENDCMP
 #
@@ -37,8 +37,8 @@ F ~
 $ENDCMP
 #
 $CMP ISFFM
-D Current source, single-frequency modulated (FM)
-K simulation
+D Current source, single-frequency FM
+K simulation frequency modulated
 F ~
 $ENDCMP
 #
@@ -61,14 +61,14 @@ F ~
 $ENDCMP
 #
 $CMP OPAMP
-D Operational amplifier, single, +/-/OUT/V+/V-
+D Operational amplifier, single, node sequence=+/-/OUT/V+/V-
 K simulation
 F ~
 $ENDCMP
 #
 $CMP VAM
-D Voltage source, amplitude modulated (AM)
-K simulation
+D Voltage source, AM
+K simulation amplitude modulated
 F ~
 $ENDCMP
 #
@@ -97,8 +97,8 @@ F ~
 $ENDCMP
 #
 $CMP VSFFM
-D Voltage source, single-frequency modulated (FM)
-K simulation
+D Voltage source, single-frequency FM
+K simulation frequency modulated
 F ~
 $ENDCMP
 #

--- a/Simulation_SPICE.dcm
+++ b/Simulation_SPICE.dcm
@@ -61,7 +61,7 @@ F ~
 $ENDCMP
 #
 $CMP OPAMP
-D Operational amplifier, single, node sequence=+/-/OUT/V+/V-
+D Operational amplifier, single, node sequence=1:+ 2:- 3:OUT 4:V+ 5:V-
 K simulation
 F ~
 $ENDCMP

--- a/Simulation_SPICE.dcm
+++ b/Simulation_SPICE.dcm
@@ -1,121 +1,121 @@
 EESchema-DOCLIB  Version 2.0
 #
 $CMP DIODE
-D Diode (For Simulation Only! Pin 1 is Anode, Pin 2 is Cathode)
+D Diode, for simulation only, anode on pin 1
 K simulation
 F ~
 $ENDCMP
 #
 $CMP IAM
-D Current Source, AM (Amplitude-Modulated)
+D Current source, amplitude modulated (AM)
 K simulation
 F ~
 $ENDCMP
 #
 $CMP IDC
-D Current Source, DC
+D Current source, DC
 K simulation
 F ~
 $ENDCMP
 #
 $CMP IEXP
-D Current Source, Exponential
+D Current source, exponential
 K simulation
 F ~
 $ENDCMP
 #
 $CMP IPULSE
-D Current Source, Pulse
+D Current source, pulse
 K simulation
 F ~
 $ENDCMP
 #
 $CMP IPWL
-D Current Source, Piece-Wise Linear
+D Current source, piece-wise linear
 K simulation
 F ~
 $ENDCMP
 #
 $CMP ISFFM
-D Current Source, Single-Frequency FM (Frequency Modulated)
+D Current source, single-frequency modulated (FM)
 K simulation
 F ~
 $ENDCMP
 #
 $CMP ISIN
-D Current Source, Sinusoidal
+D Current source, sinusoidal
 K simulation
 F ~
 $ENDCMP
 #
 $CMP ITRNOISE
-D Current Source, Transient Noise
+D Current source, transient noise
 K simulation
 F ~
 $ENDCMP
 #
 $CMP ITRRANDOM
-D Current Source, Random Noise
+D Current source, random noise
 K simulation
 F ~
 $ENDCMP
 #
 $CMP OPAMP
-D Operational Amplifier, Single (Node Sequence is 1: +, 2: -, 3: OUT, 4: V+, 5: V-)
+D Operational amplifier, single, +/-/OUT/V+/V-
 K simulation
 F ~
 $ENDCMP
 #
 $CMP VAM
-D Voltage Source, AM (Amplitude-Modulated)
+D Voltage source, amplitude modulated (AM)
 K simulation
 F ~
 $ENDCMP
 #
 $CMP VDC
-D Voltage Source, DC
+D Voltage source, DC
 K simulation
 F ~
 $ENDCMP
 #
 $CMP VEXP
-D Voltage Source, Exponential
+D Voltage source, exponential
 K simulation
 F ~
 $ENDCMP
 #
 $CMP VPULSE
-D Voltage Source, Pulse
+D Voltage source, pulse
 K simulation
 F ~
 $ENDCMP
 #
 $CMP VPWL
-D Voltage Source, Piece-Wise Linear
+D Voltage source, piece-wise linear
 K simulation
 F ~
 $ENDCMP
 #
 $CMP VSFFM
-D Voltage Source, Single-Frequency FM (Frequency Modulated)
+D Voltage source, single-frequency modulated (FM)
 K simulation
 F ~
 $ENDCMP
 #
 $CMP VSIN
-D Voltage Source, Sinusoidal
+D Voltage source, sinusoidal
 K simulation
 F ~
 $ENDCMP
 #
 $CMP VTRNOISE
-D Voltage Source, Transient Noise
+D Voltage source, transient noise
 K simulation
 F ~
 $ENDCMP
 #
 $CMP VTRRANDOM
-D Voltage Source, Random Noise
+D Voltage source, random noise
 K simulation
 F ~
 $ENDCMP


### PR DESCRIPTION
Mostly just making them sentence case, but also reworded a couple to match the Device library descriptions (eg. DIODE and OPAMP).

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the symbol(s) you are contributing
- [ ] An example screenshot image is very helpful
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
  - A new fitting footprint must be submitted if the library does not yet contain one.
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.
