### PR TITLE
Prevent unit interchangeability in generic opamps

### DIFF
--- a/Device.lib
+++ b/Device.lib
@@ -4656,7 +4656,7 @@ ENDDEF
 #
 # Opamp_Dual_Generic
 #
-DEF Opamp_Dual_Generic U 0 20 Y Y 3 F N
+DEF Opamp_Dual_Generic U 0 20 Y Y 3 L N
 F0 "U" 0 200 50 H V L CNN
 F1 "Opamp_Dual_Generic" 0 -200 50 H V L CNN
 F2 "" 0 0 50 H I C CNN
@@ -4686,7 +4686,7 @@ ENDDEF
 #
 # Opamp_Quad_Generic
 #
-DEF Opamp_Quad_Generic U 0 20 Y Y 5 F N
+DEF Opamp_Quad_Generic U 0 20 Y Y 5 L N
 F0 "U" 0 200 50 H V L CNN
 F1 "Opamp_Quad_Generic" 0 -200 50 H V L CNN
 F2 "" 0 0 50 H I C CNN


### PR DESCRIPTION
Fixes https://github.com/KiCad/kicad-symbols/issues/1554.

Just what it says on the tin. Units are not swappable in the dual and quad generic opamp symbols, but were not marked that way.

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the symbol(s) you are contributing
- [ ] An example screenshot image is very helpful
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
  - A new fitting footprint must be submitted if the library does not yet contain one.
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.
