### PR TITLE
convert linear.com links to analog.com

### DIFF
--- a/Amplifier_Current.dcm
+++ b/Amplifier_Current.dcm
@@ -255,43 +255,43 @@ $ENDCMP
 $CMP LT6106
 D 36V Low Cost, High Side Current Sense, SOT-23-5
 K current sense
-F http://cds.linear.com/docs/en/datasheet/6106fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/6106fb.pdf
 $ENDCMP
 #
 $CMP LTC6102HVxDD
 D Precision Zero Drift Current Sense Amplifier, 100V, DFN-8
 K current sense amplifier
-F http://cds.linear.com/docs/en/datasheet/6102fe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/6102fe.pdf
 $ENDCMP
 #
 $CMP LTC6102HVxMS8
 D Precision Zero Drift Current Sense Amplifier, 100V, MSOP-8
 K current sense amplifier
-F http://cds.linear.com/docs/en/datasheet/6102fe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/6102fe.pdf
 $ENDCMP
 #
 $CMP LTC6102xDD
 D Precision Zero Drift Current Sense Amplifier, 60V, DFN-8
 K current sense amplifier
-F http://cds.linear.com/docs/en/datasheet/6102fe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/6102fe.pdf
 $ENDCMP
 #
 $CMP LTC6102xDD-1
 D Precision Zero Drift Current Sense Amplifier, 60V, DFN-8
 K current sense amplifier
-F http://cds.linear.com/docs/en/datasheet/6102fe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/6102fe.pdf
 $ENDCMP
 #
 $CMP LTC6102xMS8
 D Precision Zero Drift Current Sense Amplifier, 60V, MSOP-8
 K current sense amplifier
-F http://cds.linear.com/docs/en/datasheet/6102fe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/6102fe.pdf
 $ENDCMP
 #
 $CMP LTC6102xMS8-1
 D Precision Zero Drift Current Sense Amplifier, 60V, MSOP-8
 K current sense amplifier
-F http://cds.linear.com/docs/en/datasheet/6102fe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/6102fe.pdf
 $ENDCMP
 #
 $CMP MAX4080F

--- a/Amplifier_Instrumentation.dcm
+++ b/Amplifier_Instrumentation.dcm
@@ -195,13 +195,13 @@ $ENDCMP
 $CMP LTC1100xN8
 D Single Precision, Zero-Drift Instrumentation Amplifier, Gain = 100, DIP-8
 K single instrumentation amp
-F http://cds.linear.com/docs/en/datasheet/1100fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1100fc.pdf
 $ENDCMP
 #
 $CMP LTC1100xSW
 D Single Precision, Zero-Drift Instrumentation Amplifier, Gain = 10/100, SOIC-16W
 K single instrumentation amp
-F http://cds.linear.com/docs/en/datasheet/1100fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1100fc.pdf
 $ENDCMP
 #
 #End Doc Library

--- a/Amplifier_Operational.dcm
+++ b/Amplifier_Operational.dcm
@@ -423,7 +423,7 @@ $ENDCMP
 $CMP LT1012
 D Single Picoamp Input Current, Microvolt Offset, Low Noise Op Amp, DIP-8/SOIC-8/TO-5-8
 K single opamp
-F https://www.analog.com/media/en/technical-documentation/data-sheets/1012afbs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt1012.pdf
 $ENDCMP
 #
 $CMP LT1363
@@ -453,19 +453,19 @@ $ENDCMP
 $CMP LTC1151CN8
 D Dual ±15V, Zero-Drift, Operational Amplifier, DIP-8
 K dual opamp
-F https://www.analog.com/media/en/technical-documentation/data-sheets/3482
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1151fa.pdf
 $ENDCMP
 #
 $CMP LTC1151CSW
 D Dual ±15V, Zero-Drift, Operational Amplifier, SOIC-16W
 K dual opamp
-F https://www.analog.com/media/en/technical-documentation/data-sheets/3482
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1151fa.pdf
 $ENDCMP
 #
 $CMP LTC1152
 D Rail-to-Rail Input, Rail-to-Rail Output, Zero-Drift Op Amp, DIP-8, SOIC-8
 K single opamp
-F https://www.analog.com/media/en/technical-documentation/data-sheets/2857
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt1152.pdf
 $ENDCMP
 #
 $CMP LTC6081xDD

--- a/Amplifier_Operational.dcm
+++ b/Amplifier_Operational.dcm
@@ -423,85 +423,85 @@ $ENDCMP
 $CMP LT1012
 D Single Picoamp Input Current, Microvolt Offset, Low Noise Op Amp, DIP-8/SOIC-8/TO-5-8
 K single opamp
-F http://cds.linear.com/docs/en/datasheet/1012afbs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1012afbs.pdf
 $ENDCMP
 #
 $CMP LT1363
 D 70MHz, 1000V/µs Operational Amplifier, DIP-8/SOIC-8
 K single opamp
-F http://cds.linear.com/docs/en/datasheet/1363fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1363fa.pdf
 $ENDCMP
 #
 $CMP LT1492
 D 5MHz, 3V/µs, Low Power, Single Supply, Dual Precision Op Amps, DIP-8/SOIC-8
 K dual opamp
-F http://cds.linear.com/docs/en/datasheet/14923f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/14923f.pdf
 $ENDCMP
 #
 $CMP LT1493
 D 5MHz, 3V/µs, Low Power, Single Supply, Quad Precision Op Amps, SOIC-16
 K quad opamp
-F http://cds.linear.com/docs/en/datasheet/14923f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/14923f.pdf
 $ENDCMP
 #
 $CMP LT6233
 D Dual 60MHz, Rail-to-Rail Output, 1.9nV/√Hz, 1.2mA, Operational Amplifier, SOIC-8
 K dual opamp
-F http://cds.linear.com/docs/en/datasheet/623345fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/623345fc.pdf
 $ENDCMP
 #
 $CMP LTC1151CN8
 D Dual ±15V, Zero-Drift, Operational Amplifier, DIP-8
 K dual opamp
-F http://www.linear.com/docs/3482
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3482
 $ENDCMP
 #
 $CMP LTC1151CSW
 D Dual ±15V, Zero-Drift, Operational Amplifier, SOIC-16W
 K dual opamp
-F http://www.linear.com/docs/3482
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3482
 $ENDCMP
 #
 $CMP LTC1152
 D Rail-to-Rail Input, Rail-to-Rail Output, Zero-Drift Op Amp, DIP-8, SOIC-8
 K single opamp
-F http://www.linear.com/docs/2857
+F https://www.analog.com/media/en/technical-documentation/data-sheets/2857
 $ENDCMP
 #
 $CMP LTC6081xDD
 D Precision Dual CMOS Rail-to-Rail Input/Output Amplifiers, DFN-10
 K dual opamp
-F http://cds.linear.com/docs/en/datasheet/60812fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/60812fd.pdf
 $ENDCMP
 #
 $CMP LTC6081xMS8
 D Precision Dual CMOS Rail-to-Rail Input/Output Amplifiers, MSOP-8
 K dual opamp
-F http://cds.linear.com/docs/en/datasheet/60812fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/60812fd.pdf
 $ENDCMP
 #
 $CMP LTC6082xDHC
 D Precision Quad CMOS Rail-to-Rail Input/Output Amplifiers, DFN-16
 K quad opamp
-F http://cds.linear.com/docs/en/datasheet/60812fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/60812fd.pdf
 $ENDCMP
 #
 $CMP LTC6082xGN
 D Precision Quad CMOS Rail-to-Rail Input/Output Amplifiers, SSOP-16
 K quad opamp
-F http://cds.linear.com/docs/en/datasheet/60812fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/60812fd.pdf
 $ENDCMP
 #
 $CMP LTC6362xDD
 D Precision, Low Power, Rail-to-Rail Input/Output, Differential Op Amp/SAR ADC Driver, DFN-8
 K single differential opamp
-F http://cds.linear.com/docs/en/datasheet/6362fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/6362fa.pdf
 $ENDCMP
 #
 $CMP LTC6362xMS8
 D Precision, Low Power, Rail-to-Rail Input/Output, Differential Op Amp/SAR ADC Driver, DFN-8
 K single differential opamp
-F http://cds.linear.com/docs/en/datasheet/6362fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/6362fa.pdf
 $ENDCMP
 #
 $CMP MAX4238ASA

--- a/Analog.dcm
+++ b/Analog.dcm
@@ -33,7 +33,7 @@ $ENDCMP
 $CMP LF398_SOIC8
 D Sample And Hold Unity Gain Follower, SOIC-8
 K sample hold buffer unity gain
-F http://cds.linear.com/docs/en/datasheet/lt0398s8.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt0398s8.pdf
 $ENDCMP
 #
 $CMP MPY634KP

--- a/Analog_ADC.dcm
+++ b/Analog_ADC.dcm
@@ -338,37 +338,37 @@ $ENDCMP
 $CMP LTC1406CGN
 D ADC 8bit Low Power 20Msps, SSOP-24
 K Low Power ADC 8bit 20Msps
-F http://cds.linear.com/docs/en/datasheet/1406f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1406f.pdf
 $ENDCMP
 #
 $CMP LTC1406IGN
 D ADC 8bit Low Power 20Msps, SSOP-24
 K Low Power ADC 8bit 20Msps
-F http://cds.linear.com/docs/en/datasheet/1406f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1406f.pdf
 $ENDCMP
 #
 $CMP LTC1594CS
 D Micropower 12-bit 4 Channel ADC, Serial IO, SOIC-16
 K 12bit ADC 4 Channel
-F http://cds.linear.com/docs/en/datasheet/15948fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/15948fb.pdf
 $ENDCMP
 #
 $CMP LTC1594IS
 D Micropower 12-bit 4 Channel ADC, Serial IO, SO-16
 K 12bit ADC 4 Channel
-F http://cds.linear.com/docs/en/datasheet/15948fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/15948fb.pdf
 $ENDCMP
 #
 $CMP LTC1598CG
 D Micropower 12-bit 8 Channel ADC, Serial IO, SSOP-24
 K 12bit ADC 4 Channel
-F http://cds.linear.com/docs/en/datasheet/15948fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/15948fb.pdf
 $ENDCMP
 #
 $CMP LTC1598IG
 D Micropower 12-bit 8 Channel ADC, Serial IO, SSOP-24
 K 12bit ADC 4 Channel
-F http://cds.linear.com/docs/en/datasheet/15948fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/15948fb.pdf
 $ENDCMP
 #
 $CMP LTC1742
@@ -398,37 +398,37 @@ $ENDCMP
 $CMP LTC1864
 D Single channel 16-bit Analog to Digial Converter, 5V supply, differential input, 150ksps, SPI interface
 K sigma-delta adc spi 1ch
-F http://cds.linear.com/docs/en/datasheet/18645fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/18645fb.pdf
 $ENDCMP
 #
 $CMP LTC1864L
 D Single channel 16-bit Analog to Digial Converter, 3V supply, differential input, 150ksps, SPI interface
 K sigma-delta adc spi 1ch
-F http://cds.linear.com/docs/en/datasheet/18645lfs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/18645lfs.pdf
 $ENDCMP
 #
 $CMP LTC1865-MS
 D Dual channel 16-bit Analog to Digital Converter, 5V supply, 150ksps, SPI interface
 K sigma-delta adc 2ch
-F http://cds.linear.com/docs/en/datasheet/18645fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/18645fb.pdf
 $ENDCMP
 #
 $CMP LTC1865-S8
 D Dual channel 16-bit Analog to Digital Converter, 5V supply, 150ksps, SPI interface
 K sigma-delta adc 2ch
-F http://cds.linear.com/docs/en/datasheet/18645fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/18645fb.pdf
 $ENDCMP
 #
 $CMP LTC1865L-MS
 D Dual channel 16-bit Analog to Digital Converter, 3V supply, 150ksps, SPI interface
 K sigma-delta adc 2ch
-F http://cds.linear.com/docs/en/datasheet/18645lfs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/18645lfs.pdf
 $ENDCMP
 #
 $CMP LTC1865L-S8
 D Dual channel 16-bit Analog to Digital Converter, 3V supply, 150ksps, SPI interface
 K sigma-delta adc 2ch
-F http://cds.linear.com/docs/en/datasheet/18645lfs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/18645lfs.pdf
 $ENDCMP
 #
 $CMP LTC2282xUP
@@ -506,13 +506,13 @@ $ENDCMP
 $CMP LTC2309_QFN
 D 8 Channels, 12-Bit SAR ADC, I2C interface, QFN-24 package
 K LT ADC 12bit I2C SAR QFN
-F http://cds.linear.com/docs/en/datasheet/2309fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/2309fd.pdf
 $ENDCMP
 #
 $CMP LTC2309_TSSOP
 D 8 Channels, 12-Bit SAR ADC, I2C interface, TSSOP-20 package
 K LT ADC 12bit I2C SAR TSSOP
-F http://cds.linear.com/docs/en/datasheet/2309fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/2309fd.pdf
 $ENDCMP
 #
 $CMP LTC2358-16
@@ -530,13 +530,13 @@ $ENDCMP
 $CMP LTC2508CDKD-32
 D 32-Bit Oversampling ADC with Configurable Digital Filter, 0°C to 70°C, DFN-24 package
 K LT ADC 32bit
-F http://cds.linear.com/docs/en/datasheet/250832fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/ltc2508-32.pdf
 $ENDCMP
 #
 $CMP LTC2508IDKD-32
 D 32-Bit Oversampling ADC with Configurable Digital Filter, -40°C to 85°C, DFN-24 package
 K LT ADC 32bit
-F http://cds.linear.com/docs/en/datasheet/250832fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/ltc2508-32.pdf
 $ENDCMP
 #
 $CMP MAX1112

--- a/Analog_ADC.dcm
+++ b/Analog_ADC.dcm
@@ -530,13 +530,13 @@ $ENDCMP
 $CMP LTC2508CDKD-32
 D 32-Bit Oversampling ADC with Configurable Digital Filter, 0°C to 70°C, DFN-24 package
 K LT ADC 32bit
-F https://www.analog.com/media/en/technical-documentation/data-sheets/ltc2508-32.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/250832fc.pdf
 $ENDCMP
 #
 $CMP LTC2508IDKD-32
 D 32-Bit Oversampling ADC with Configurable Digital Filter, -40°C to 85°C, DFN-24 package
 K LT ADC 32bit
-F https://www.analog.com/media/en/technical-documentation/data-sheets/ltc2508-32.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/250832fc.pdf
 $ENDCMP
 #
 $CMP MAX1112

--- a/Analog_DAC.dcm
+++ b/Analog_DAC.dcm
@@ -405,43 +405,43 @@ $ENDCMP
 $CMP LTC1257
 D Single Supply 12-bit DAC with Internal Reference Voltage, SOIC-8
 K DAC 12-bit
-F http://cds.linear.com/docs/en/datasheet/1257fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1257fc.pdf
 $ENDCMP
 #
 $CMP LTC1446
 D 2-Channel 12-Bit Rail-To-Rail D/A Converters with SPI Interface and Internal Reference (4.096V)
 K 12-Bit DAC SPI Reference 2ch
-F http://cds.linear.com/docs/en/datasheet/1446fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1446fa.pdf
 $ENDCMP
 #
 $CMP LTC1446L
 D 2-Channel 12-Bit Rail-To-Rail D/A Converters with SPI Interface and Internal Reference (2.500V)
 K 12-Bit DAC SPI 2ch
-F http://cds.linear.com/docs/en/datasheet/1446fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1446fa.pdf
 $ENDCMP
 #
 $CMP LTC1664CGN
 D Quad Micropower 10-bit DAC, Standard, SSOP-16
 K Quad DAC Micropower 10bit 4ch
-F http://cds.linear.com/docs/Datasheet/1664fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1664fa.pdf
 $ENDCMP
 #
 $CMP LTC1664CN
 D Quad Micropower 10-bit DAC, Standard, DIP-16
 K Quad DAC Micropower 10bit 4ch
-F http://cds.linear.com/docs/Datasheet/1664fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1664fa.pdf
 $ENDCMP
 #
 $CMP LTC1664IGN
 D Quad Micropower 10-bit DAC, Industrial, SSOP-16
 K Quad DAC Micropower 10bit 4ch
-F http://cds.linear.com/docs/Datasheet/1664fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1664fa.pdf
 $ENDCMP
 #
 $CMP LTC1664IN
 D Quad Micropower 10-bit DAC, Industrial, DIP-16
 K Quad DAC Micropower 10bit 4ch
-F http://cds.linear.com/docs/Datasheet/1664fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1664fa.pdf
 $ENDCMP
 #
 $CMP MAX5138

--- a/Battery_Management.dcm
+++ b/Battery_Management.dcm
@@ -168,28 +168,28 @@ K Step-down  battery charger, Lithium Phosphate ( LiFePO4), Lead (Pb), Lithium+ 
 F https://www.analog.com/media/en/technical-documentation/data-sheets/3652fe.pdf
 $ENDCMP
 #
-$CMP LTC3553
+$CMP 3553fc
 D Micropower USB Power Manager With Li-Ion Charger, LDO and Buck Regulator, 4.2 V float, QFN-20
 K USB PMIC
-F https://www.analog.com/media/en/technical-documentation/data-sheets/ltc3553.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3553fc.pdf
 $ENDCMP
 #
 $CMP LTC3555
 D High Efficiency USB Power Manager + Triple Step-Down DC/DC, 4.2 V float, QFN-28
 K USB PMIC
-F https://www.analog.com/media/en/technical-documentation/data-sheets/ltc3553.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3553fc.pdf
 $ENDCMP
 #
 $CMP LTC3555-1
 D High Efficiency USB Power Manager + Triple Step-Down DC/DC, instant-on power, 4.2 V float, QFN-28
 K USB PMIC
-F https://www.analog.com/media/en/technical-documentation/data-sheets/ltc3553.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3553fc.pdf
 $ENDCMP
 #
 $CMP LTC3555-3
 D High Efficiency USB Power Manager + Triple Step-Down DC/DC, instant-on power, 4.1 V float, QFN-28
 K USB PMIC
-F https://www.analog.com/media/en/technical-documentation/data-sheets/ltc3553.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3553fc.pdf
 $ENDCMP
 #
 $CMP LTC4001

--- a/Battery_Management.dcm
+++ b/Battery_Management.dcm
@@ -147,85 +147,85 @@ $ENDCMP
 $CMP LT3652EDD
 D Step-down  battery charger, Lithium Phosphate ( LiFePO4), Lead (Pb), Lithium+ (Li+) , 4.95V to 32V VDD, -40 to +125 degree Celcius, DFN-12
 K Step-down  battery charger, Lithium Phosphate ( LiFePO4), Lead (Pb), Lithium+ (Li+) , 4.95V to 32V VDD, -40 to +125 degree Celcius, DFN-12
-F http://cds.linear.com/docs/en/datasheet/3652fe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3652fe.pdf
 $ENDCMP
 #
 $CMP LT3652EMSE
 D Step-down  battery charger, Lithium Phosphate ( LiFePO4), Lead (Pb), Lithium+ (Li+) , 4.95V to 32V VDD, -40 to +125 degree Celcius, MSOP-12
 K Step-down  battery charger, Lithium Phosphate ( LiFePO4), Lead (Pb), Lithium+ (Li+) , 4.95V to 32V VDD, -40 to +125 degree Celcius, MSOP-12
-F http://cds.linear.com/docs/en/datasheet/3652fe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3652fe.pdf
 $ENDCMP
 #
 $CMP LT3652IDD
 D Step-down  battery charger, Lithium Phosphate ( LiFePO4), Lead (Pb), Lithium+ (Li+) , 4.95V to 32V VDD, -40 to +125 degree Celcius, DFN-12
 K Step-down  battery charger, Lithium Phosphate ( LiFePO4), Lead (Pb), Lithium+ (Li+) , 4.95V to 32V VDD, -40 to +125 degree Celcius, DFN-12
-F http://cds.linear.com/docs/en/datasheet/3652fe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3652fe.pdf
 $ENDCMP
 #
 $CMP LT3652IMSE
 D Step-down  battery charger, Lithium Phosphate ( LiFePO4), Lead (Pb), Lithium+ (Li+) , 4.95V to 32V VDD, -40 to +125 degree Celcius, MSOP-12
 K Step-down  battery charger, Lithium Phosphate ( LiFePO4), Lead (Pb), Lithium+ (Li+) , 4.95V to 32V VDD, -40 to +125 degree Celcius, MSOP-12
-F http://cds.linear.com/docs/en/datasheet/3652fe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3652fe.pdf
 $ENDCMP
 #
 $CMP LTC3553
 D Micropower USB Power Manager With Li-Ion Charger, LDO and Buck Regulator, 4.2 V float, QFN-20
 K USB PMIC
-F www.linear.com/docs/28574
+F https://www.analog.com/media/en/technical-documentation/data-sheets/ltc3553.pdf
 $ENDCMP
 #
 $CMP LTC3555
 D High Efficiency USB Power Manager + Triple Step-Down DC/DC, 4.2 V float, QFN-28
 K USB PMIC
-F www.linear.com/docs/25066
+F https://www.analog.com/media/en/technical-documentation/data-sheets/ltc3553.pdf
 $ENDCMP
 #
 $CMP LTC3555-1
 D High Efficiency USB Power Manager + Triple Step-Down DC/DC, instant-on power, 4.2 V float, QFN-28
 K USB PMIC
-F www.linear.com/docs/25066
+F https://www.analog.com/media/en/technical-documentation/data-sheets/ltc3553.pdf
 $ENDCMP
 #
 $CMP LTC3555-3
 D High Efficiency USB Power Manager + Triple Step-Down DC/DC, instant-on power, 4.1 V float, QFN-28
 K USB PMIC
-F www.linear.com/docs/25066
+F https://www.analog.com/media/en/technical-documentation/data-sheets/ltc3553.pdf
 $ENDCMP
 #
 $CMP LTC4001
 D Single cell (4.2V) programmable synchronous buck Li-Ion charger, 2A, 5.5V input
 K Li-Ion charger
-F http://cds.linear.com/docs/en/datasheet/4001f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/4001f.pdf
 $ENDCMP
 #
 $CMP LTC4001-1
 D Single cell (4.1V) programmable synchronous buck Li-Ion charger, 2A, 5.5V input
 K Li-Ion Charger
-F http://cds.linear.com/docs/en/datasheet/40011fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/40011fa.pdf
 $ENDCMP
 #
 $CMP LTC4002EDD-4.2
 D Standalone Li-Ion Switch Mode Battery Charger, 4.7-22V input, single cell, DFN-10
 K lithium li-ion battery charger
-F http://cds.linear.com/docs/en/datasheet/4002f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/4002f.pdf
 $ENDCMP
 #
 $CMP LTC4002EDD-8.4
 D Standalone Li-Ion Switch Mode Battery Charger, 8.9-22V input, double cell, DFN-10
 K lithium li-ion battery charger
-F http://cds.linear.com/docs/en/datasheet/4002f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/4002f.pdf
 $ENDCMP
 #
 $CMP LTC4002ES8-4.2
 D Standalone Li-Ion Switch Mode Battery Charger, 4.7-22V input, single cell, SOIC-8
 K lithium li-ion battery charger
-F http://cds.linear.com/docs/en/datasheet/4002f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/4002f.pdf
 $ENDCMP
 #
 $CMP LTC4002ES8-8.4
 D Standalone Li-Ion Switch Mode Battery Charger, 8.9-22V input, double cell, SOIC-8
 K lithium li-ion battery charger
-F http://cds.linear.com/docs/en/datasheet/4002f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/4002f.pdf
 $ENDCMP
 #
 $CMP LTC4007
@@ -237,13 +237,13 @@ $ENDCMP
 $CMP LTC4054ES5-4.2
 D Constant-current/constant-voltage linear charger for single cell lithium-ion batteries with 2.9V Trickle Charge, 4.5V to 6.5V VDD, -40 to +85 degree Celcius, TSOT-23-5
 K Constant-current constant-voltage linear charger single cell lithium-ion battery
-F http://cds.linear.com/docs/en/datasheet/405442xf.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/405442xf.pdf
 $ENDCMP
 #
 $CMP LTC4054XES5-4.2
 D Constant-current/constant-voltage linear charger for single cell lithium-ion batteries no Trickle Charge, 4.5V to 6.5V VDD, -40 to +85 degree Celcius, TSOT-23-5
 K Constant-current constant-voltage linear charger single cell lithium-ion battery
-F http://cds.linear.com/docs/en/datasheet/405442xf.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/405442xf.pdf
 $ENDCMP
 #
 $CMP LTC4055
@@ -261,13 +261,13 @@ $ENDCMP
 $CMP LTC4060EDHC
 D Complete fast charging system for 2, 3 or 4 series  NiMH or NiCd batteries, 0.4 to 2A, 4.5 to 10V VDD, -40 to +85 degree Celcisus, DFN-16
 K Complete fast charging system for 2, 3 or 4 series NiMH or NiCd batteries, 0.4 to 2A, 4.5 to 10V VDD, -40 to +85 degree Celcisus, DFN-16
-F http://cds.linear.com/docs/en/datasheet/405442xf.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/405442xf.pdf
 $ENDCMP
 #
 $CMP LTC4060EFE
 D Complete fast charging system for 2, 3 or 4 series NiMH or NiCd batteries, 0.4 to 2A, 4.5 to 10V VDD, -40 to +85 degree Celcisus, TSSOP-16
 K Complete fast charging system for 2, 3 or 4 series NiMH or NiCd batteries, 0.4 to 2A, 4.5 to 10V VDD, -40 to +85 degree Celcisus, TSSOP-16
-F http://cds.linear.com/docs/en/datasheet/405442xf.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/405442xf.pdf
 $ENDCMP
 #
 $CMP LTC4156
@@ -279,13 +279,13 @@ $ENDCMP
 $CMP LTC6803-2
 D Multicell Battery Stack Monitor, 12-cell max, multi-chemistry, integrated balancing, stackable, serial interface
 K battery balance afe
-F http://cds.linear.com/docs/en/datasheet/680324fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/680324fa.pdf
 $ENDCMP
 #
 $CMP LTC6803-4
 D Multicell Battery Stack Monitor, 12-cell max, multi-chemistry, integrated balancing, stackable, serial interface
 K battery balance afe
-F http://cds.linear.com/docs/en/datasheet/680324fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/680324fa.pdf
 $ENDCMP
 #
 $CMP MAX1647

--- a/Battery_Management.dcm
+++ b/Battery_Management.dcm
@@ -177,19 +177,19 @@ $ENDCMP
 $CMP LTC3555
 D High Efficiency USB Power Manager + Triple Step-Down DC/DC, 4.2 V float, QFN-28
 K USB PMIC
-F https://www.analog.com/media/en/technical-documentation/data-sheets/3553fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3555fe.pdf
 $ENDCMP
 #
 $CMP LTC3555-1
 D High Efficiency USB Power Manager + Triple Step-Down DC/DC, instant-on power, 4.2 V float, QFN-28
 K USB PMIC
-F https://www.analog.com/media/en/technical-documentation/data-sheets/3553fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3555fe.pdf
 $ENDCMP
 #
 $CMP LTC3555-3
 D High Efficiency USB Power Manager + Triple Step-Down DC/DC, instant-on power, 4.1 V float, QFN-28
 K USB PMIC
-F https://www.analog.com/media/en/technical-documentation/data-sheets/3553fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3555fe.pdf
 $ENDCMP
 #
 $CMP LTC4001

--- a/Battery_Management.dcm
+++ b/Battery_Management.dcm
@@ -168,7 +168,7 @@ K Step-down  battery charger, Lithium Phosphate ( LiFePO4), Lead (Pb), Lithium+ 
 F https://www.analog.com/media/en/technical-documentation/data-sheets/3652fe.pdf
 $ENDCMP
 #
-$CMP 3553fc
+$CMP LTC3553
 D Micropower USB Power Manager With Li-Ion Charger, LDO and Buck Regulator, 4.2 V float, QFN-20
 K USB PMIC
 F https://www.analog.com/media/en/technical-documentation/data-sheets/3553fc.pdf

--- a/Comparator.dcm
+++ b/Comparator.dcm
@@ -111,19 +111,19 @@ $ENDCMP
 $CMP LT1011
 D Voltage Comparator, DIP-8/SOIC-8/TO-5-8
 K comp
-F http://cds.linear.com/docs/en/datasheet/1011afe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1011afe.pdf
 $ENDCMP
 #
 $CMP LT1016
 D Single UltraFast Precision 10ns Comparator, DIP-8/SOIC-8
 K single comparator
-F http://cds.linear.com/docs/en/datasheet/1016fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1016fc.pdf
 $ENDCMP
 #
 $CMP LT1116
 D Single 12ns, Single Supply Ground-Sensing Comparator, DIP-8/SOIC-8
 K single comparator
-F http://cds.linear.com/docs/en/datasheet/1116fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1116fc.pdf
 $ENDCMP
 #
 $CMP LT1711xMS8

--- a/Comparator.dcm
+++ b/Comparator.dcm
@@ -111,13 +111,13 @@ $ENDCMP
 $CMP LT1011
 D Voltage Comparator, DIP-8/SOIC-8/TO-5-8
 K comp
-F https://www.analog.com/media/en/technical-documentation/data-sheets/1011afe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt1011.pdf
 $ENDCMP
 #
 $CMP LT1016
 D Single UltraFast Precision 10ns Comparator, DIP-8/SOIC-8
 K single comparator
-F https://www.analog.com/media/en/technical-documentation/data-sheets/1016fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt1016.pdf
 $ENDCMP
 #
 $CMP LT1116

--- a/Driver_FET.dcm
+++ b/Driver_FET.dcm
@@ -237,25 +237,25 @@ $ENDCMP
 $CMP LTC4440EMS8
 D High-side, N-Channel, Mosfet driver, 80V input, -40°C to +85°C, MSOP-8
 K high-side mosfet-driver
-F http://cds.linear.com/docs/en/datasheet/4440fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/4440fb.pdf
 $ENDCMP
 #
 $CMP LTC4440ES6
 D High-side, N-Channel, Mosfet driver, 80V input, -40°C to +85°C, SOT23-6
 K high-side mosfet-driver
-F http://cds.linear.com/docs/en/datasheet/4440fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/4440fb.pdf
 $ENDCMP
 #
 $CMP LTC4440IMS8
 D High-side, N-Channel, Mosfet driver, 80V input, -40°C to +125°C, MSOP-8
 K high-side mosfet-driver
-F http://cds.linear.com/docs/en/datasheet/4440fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/4440fb.pdf
 $ENDCMP
 #
 $CMP LTC4440IS6
 D High-side, N-Channel, Mosfet driver, 80V input, -40°C to +85°C, SOT23-6
 K high-side mosfet-driver
-F http://cds.linear.com/docs/en/datasheet/4440fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/4440fb.pdf
 $ENDCMP
 #
 $CMP MC33152

--- a/Driver_LED.dcm
+++ b/Driver_LED.dcm
@@ -111,49 +111,49 @@ $ENDCMP
 $CMP LT3465
 D 1.2MHz White LED Drivers with Built-in Schottky, ThinSOT-23-6
 K Switching LED driver
-F http://cds.linear.com/docs/en/datasheet/3465fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3465fa.pdf
 $ENDCMP
 #
 $CMP LT3465A
 D 2.4MHz White LED Drivers with Built-in Schottky in ThinSOT
 K Switching LED driver
-F http://cds.linear.com/docs/en/datasheet/3465fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3465fa.pdf
 $ENDCMP
 #
 $CMP LT3755xMSE
 D 40 Vin, 75 Vout, DC/DC LED Controllers, Hysteresis Open led Status pin, MSOP-16
 K Boost Buck Buck-Boost SEPIC Flyback
-F http://cds.linear.com/docs/en/datasheet/37551fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/37551fd.pdf
 $ENDCMP
 #
 $CMP LT3755xMSE-1
 D 40 Vin, 75 Vout, DC/DC LED Controllers, Frequency Synchronisation, MSOP-16
 K Boost Buck Buck-Boost SEPIC Flyback
-F http://cds.linear.com/docs/en/datasheet/37551fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/37551fd.pdf
 $ENDCMP
 #
 $CMP LT3755xMSE-2
 D 40 Vin, 75 Vout, DC/DC LED Controllers, Improved Open Led Status Pin, MSOP-16
 K Boost Buck Buck-Boost SEPIC Flyback
-F http://cds.linear.com/docs/en/datasheet/37551fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/37551fd.pdf
 $ENDCMP
 #
 $CMP LT3755xUD
 D 40 Vin, 75 Vout, DC/DC LED Controller, Hysteresis Open led Status pins, QFN-16
 K Boost Buck Buck-Boost SEPIC Flyback
-F http://cds.linear.com/docs/en/datasheet/37551fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/37551fd.pdf
 $ENDCMP
 #
 $CMP LT3755xUD-1
 D 40 Vin, 75 Vout, DC/DC LED Controllers, Frequency Synchronisation, QFN-16
 K Boost Buck Buck-Boost SEPIC Flyback
-F http://cds.linear.com/docs/en/datasheet/37551fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/37551fd.pdf
 $ENDCMP
 #
 $CMP LT3755xUD-2
 D 40 Vin, 75 Vout, DC/DC LED Controllers, Improved Open led Status pin, QFN-16
 K Boost Buck Buck-Boost SEPIC Flyback
-F http://cds.linear.com/docs/en/datasheet/37551fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/37551fd.pdf
 $ENDCMP
 #
 $CMP PCA9685BS

--- a/Interface.dcm
+++ b/Interface.dcm
@@ -168,25 +168,25 @@ $ENDCMP
 $CMP LTC1518
 D 52Mbps Precision Delay RS485 Quad Line Receivers
 K receiver rs485 rs422 differential
-F http://cds.linear.com/docs/en/datasheet/15189fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/15189fa.pdf
 $ENDCMP
 #
 $CMP LTC1519
 D 52Mbps Precision Delay RS485 Quad Line Receivers
 K receiver rs485 rs422 differential
-F http://cds.linear.com/docs/en/datasheet/15189fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/15189fa.pdf
 $ENDCMP
 #
 $CMP LTC1688
 D 100Mbps RS485 Hot Swapable Quad Drivers
 K driver rs485 rs422 differential
-F http://cds.linear.com/docs/en/datasheet/16889fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/16889fa.pdf
 $ENDCMP
 #
 $CMP LTC1689
 D 100Mbps RS485 Hot Swapable Quad Drivers
 K driver rs485 rs422 differential
-F http://cds.linear.com/docs/en/datasheet/16889fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/16889fa.pdf
 $ENDCMP
 #
 $CMP LTC6957xDD-1

--- a/Interface_CAN_LIN.dcm
+++ b/Interface_CAN_LIN.dcm
@@ -15,13 +15,13 @@ $ENDCMP
 $CMP LTC2875-DD
 D High-Speed CAN Transceiver, 4Mbps, 3.3V or 5V supply, DFN8 package
 K High-Speed CAN Transceiver
-F http://cds.linear.com/docs/en/datasheet/2875f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/2875f.pdf
 $ENDCMP
 #
 $CMP LTC2875-S8
 D High-Speed CAN Transceiver, 4Mbps, 3.3V or 5V supply, SOIC8 package
 K High-Speed CAN Transceiver
-F http://cds.linear.com/docs/en/datasheet/2875f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/2875f.pdf
 $ENDCMP
 #
 $CMP MCP2021A-xxxxMD

--- a/Interface_UART.dcm
+++ b/Interface_UART.dcm
@@ -144,7 +144,7 @@ $ENDCMP
 $CMP LT1080
 D Dual RS232 driver/receiver, 5V supply, 120kb/s
 K rs232 uart transceiver
-F http://cds.linear.com/docs/en/datasheet/10801fe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/10801fe.pdf
 $ENDCMP
 #
 $CMP LTC2861

--- a/Power_Management.dcm
+++ b/Power_Management.dcm
@@ -411,13 +411,13 @@ $ENDCMP
 $CMP LT1641-1
 D High voltage hot swap controller, +9V to +80V operation, with latching feature
 K high-voltage hot-swap
-F http://cds.linear.com/docs/en/datasheet/164112fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/164112fc.pdf
 $ENDCMP
 #
 $CMP LT1641-2
 D High voltage hot swap controller, +9V to +80V operation, with auto-retry feature
 K high-voltage hot-swap
-F http://cds.linear.com/docs/en/datasheet/164112fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/164112fc.pdf
 $ENDCMP
 #
 $CMP LTC4242xUHF
@@ -429,103 +429,103 @@ $ENDCMP
 $CMP LTC4357DCB
 D Ideal diode controller, 9-80V operation, DFN-6 package
 K ideal-diode or-ing
-F http://cds.linear.com/docs/en/datasheet/4357fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/4357fd.pdf
 $ENDCMP
 #
 $CMP LTC4357MS8
 D Ideal diode controller, 9-80V operation, MSOP-8 package
 K ideal-diode or-ing
-F http://cds.linear.com/docs/en/datasheet/4357fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/4357fd.pdf
 $ENDCMP
 #
 $CMP LTC4359-DCB
 D Ideal diode controller with reverse input protection, DFN-6 package
 K ideal-diode or-ing reverse-protection
-F http://cds.linear.com/docs/en/datasheet/4359fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/ltc4359.pdf
 $ENDCMP
 #
 $CMP LTC4359-MS8
 D Ideal diode controller with reverse input protection, MSOP-8 package
 K ideal-diode or-ing reverse-protection
-F http://cds.linear.com/docs/en/datasheet/4359fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/ltc4359.pdf
 $ENDCMP
 #
 $CMP LTC4364CDE
 D Surge stopper with ideal diode, UV and OV protection, -40V to +80V operation, DFN-14 package, 0°C to +40°C
 K ideal-diode or-ing reverse-protection undervoltage overvoltage surge-stopper
-F http://cds.linear.com/docs/en/datasheet/436412f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/436412f.pdf
 $ENDCMP
 #
 $CMP LTC4364CMS
 D Surge stopper with ideal diode, UV and OV protection, -40V to +80V operation, MSOP-16 package, 0°C to +40°C
 K ideal-diode or-ing reverse-protection undervoltage overvoltage surge-stopper
-F http://cds.linear.com/docs/en/datasheet/436412f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/436412f.pdf
 $ENDCMP
 #
 $CMP LTC4364CS
 D Surge stopper with ideal diode, UV and OV protection -40V to +80V in SOIC-16 package, 0°C to +40°C
 K ideal-diode or-ing reverse-protection undervoltage overvoltage surge-stopper
-F http://cds.linear.com/docs/en/datasheet/436412f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/436412f.pdf
 $ENDCMP
 #
 $CMP LTC4364HDE
 D Surge stopper with ideal diode, UV and OV protection -40V to +80V in DFN-14 package, -40°C to +125°C
 K surge overvoltage undervoltage reverse-polarity protection diode ORing MOSFET driver
-F http://cds.linear.com/docs/en/datasheet/436412f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/436412f.pdf
 $ENDCMP
 #
 $CMP LTC4364HMS
 D Surge stopper with ideal diode, UV and OV protection -40V to +80V in MSOP-16 package, -40°C to +125°C
 K surge overvoltage undervoltage reverse-polarity protection diode ORing MOSFET driver
-F http://cds.linear.com/docs/en/datasheet/436412f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/436412f.pdf
 $ENDCMP
 #
 $CMP LTC4364HS
 D Surge stopper with ideal diode, UV and OV protection -40V to +80V in SOIC-16 package, -40°C to +125°C
 K surge overvoltage undervoltage reverse-polarity protection diode ORing MOSFET driver
-F http://cds.linear.com/docs/en/datasheet/436412f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/436412f.pdf
 $ENDCMP
 #
 $CMP LTC4364IDE
 D Surge stopper with ideal diode, UV and OV protection -40V to +80V in DFN-14 package, -40°C to +85°C
 K surge overvoltage undervoltage reverse-polarity protection diode ORing MOSFET driver
-F http://cds.linear.com/docs/en/datasheet/436412f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/436412f.pdf
 $ENDCMP
 #
 $CMP LTC4364IMS
 D Surge stopper with ideal diode, UV and OV protection -40V to +80V in MSOP-16 package, -40°C to +85°C
 K surge overvoltage undervoltage reverse-polarity protection diode ORing MOSFET driver
-F http://cds.linear.com/docs/en/datasheet/436412f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/436412f.pdf
 $ENDCMP
 #
 $CMP LTC4364IS
 D Surge stopper with ideal diode, UV and OV protection -40V to +80V in SOIC-16 package, -40°C to +85°C
 K surge overvoltage undervoltage reverse-polarity protection diode ORing MOSFET driver
-F http://cds.linear.com/docs/en/datasheet/436412f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/436412f.pdf
 $ENDCMP
 #
 $CMP LTC4365DDB
 D Overvoltage, Undervoltage and Reverse Supply Protection Controller, 3x2mm DFN-8 package, 50Hz/60Hz noise rejection
 K overvoltage undervoltage reverse-polarity protection
-F http://cds.linear.com/docs/en/datasheet/4365fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/4365fa.pdf
 $ENDCMP
 #
 $CMP LTC4365DDB-1
 D Overvoltage, Undervoltage and Reverse Supply Protection Controller, 3x2mm DFN-8 package, 1ms fault recovery
 K overvoltage undervoltage reverse-polarity protection
-F http://www.linear.com/docs/29832
+F https://www.analog.com/media/en/technical-documentation/data-sheets/4365fa.pdf
 $ENDCMP
 #
 $CMP LTC4365TS8
 D Overvoltage, Undervoltage and Reverse Supply Protection Controller, TSOT23-8 package, 50Hz/60Hz noise rejection
 K overvoltage undervoltage reverse-polarity protection
-F http://cds.linear.com/docs/en/datasheet/4365fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/4365fa.pdf
 $ENDCMP
 #
 $CMP LTC4365TS8-1
 D Overvoltage, Undervoltage and Reverse Supply Protection Controller, TSOT23-8 package, 1ms fault recovery
 K overvoltage undervoltage reverse-polarity protection
-F http://www.linear.com/docs/29832
+F https://www.analog.com/media/en/technical-documentation/data-sheets/4365fa.pdf
 $ENDCMP
 #
 $CMP LTC4417CGN

--- a/RF_Mixer.dcm
+++ b/RF_Mixer.dcm
@@ -27,7 +27,7 @@ $ENDCMP
 $CMP LT5560
 D 0.01MHz to 4GHz Low Power Active Mixer, DFN-8
 K rf mixer
-F http://cds.linear.com/docs/en/datasheet/5560f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/5560f.pdf
 $ENDCMP
 #
 #End Doc Library

--- a/Reference_Voltage.dcm
+++ b/Reference_Voltage.dcm
@@ -75,13 +75,13 @@ $ENDCMP
 $CMP LM285S-1.2
 D 1.235V Micropower Voltage Reference Diodes, SO-8
 K diode device voltage reference
-F http://cds.linear.com/docs/en/datasheet/185fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/185fc.pdf
 $ENDCMP
 #
 $CMP LM285S-2.5
 D 2.500V Micropower Voltage Reference Diodes, SO-8
 K diode device voltage reference
-F http://cds.linear.com/docs/en/datasheet/185fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/185fc.pdf
 $ENDCMP
 #
 $CMP LM285Z-1.2
@@ -141,13 +141,13 @@ $ENDCMP
 $CMP LM385S-1.2
 D 1.235V Micropower Voltage Reference Diodes, SO-8
 K diode device voltage reference
-F http://cds.linear.com/docs/en/datasheet/185fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/185fc.pdf
 $ENDCMP
 #
 $CMP LM385S-2.5
 D 2.500V Micropower Voltage Reference Diodes, SO-8
 K diode device voltage reference
-F http://cds.linear.com/docs/en/datasheet/185fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/185fc.pdf
 $ENDCMP
 #
 $CMP LM385Z-1.2
@@ -381,37 +381,37 @@ $ENDCMP
 $CMP LT6657AHMS8-2.5
 D Precision voltage reference, 40V input, 10mA output, 1.5ppm/C drift, 2.5V output, MSOP-8
 K voltage reference vref
-F http://cds.linear.com/docs/en/datasheet/6657fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt6657.pdf
 $ENDCMP
 #
 $CMP LT6657AHMS8-3
 D Precision voltage reference, 40V input, 10mA output, 1.5ppm/C drift, 3.0V output, MSOP-8
 K voltage reference vref
-F http://cds.linear.com/docs/en/datasheet/6657fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt6657.pdf
 $ENDCMP
 #
 $CMP LT6657AHMS8-5
 D Precision voltage reference, 40V input, 10mA output, 1.5ppm/C drift, 5.0V output, MSOP-8
 K voltage reference vref
-F http://cds.linear.com/docs/en/datasheet/6657fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt6657.pdf
 $ENDCMP
 #
 $CMP LT6657BHMS8-2.5
 D Precision voltage reference, 40V input, 10mA output, 3.0ppm/C drift, 2.5V output, MSOP-8
 K voltage reference vref
-F http://cds.linear.com/docs/en/datasheet/6657fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt6657.pdf
 $ENDCMP
 #
 $CMP LT6657BHMS8-3
 D Precision voltage reference, 40V input, 10mA output, 3.0ppm/C drift, 3.0V output, MSOP-8
 K voltage reference vref
-F http://cds.linear.com/docs/en/datasheet/6657fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt6657.pdf
 $ENDCMP
 #
 $CMP LT6657BHMS8-5
 D Precision voltage reference, 40V input, 10mA output, 3.0ppm/C drift, 5.0V output, MSOP-8
 K voltage reference vref
-F http://cds.linear.com/docs/en/datasheet/6657fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt6657.pdf
 $ENDCMP
 #
 $CMP MAX6100

--- a/Reference_Voltage.dcm
+++ b/Reference_Voltage.dcm
@@ -378,37 +378,37 @@ K voltage reference Micropower
 F https://www.analog.com/media/en/technical-documentation/data-sheets/1790fc.pdf
 $ENDCMP
 #
-$CMP 6657fdAHMS8-2.5
+$CMP LT6657AHMS8-2.5
 D Precision voltage reference, 40V input, 10mA output, 1.5ppm/C drift, 2.5V output, MSOP-8
 K voltage reference vref
 F https://www.analog.com/media/en/technical-documentation/data-sheets/6657fd.pdf
 $ENDCMP
 #
-$CMP 6657fdAHMS8-3
+$CMP LT6657AHMS8-3
 D Precision voltage reference, 40V input, 10mA output, 1.5ppm/C drift, 3.0V output, MSOP-8
 K voltage reference vref
 F https://www.analog.com/media/en/technical-documentation/data-sheets/6657fd.pdf
 $ENDCMP
 #
-$CMP 6657fdAHMS8-5
+$CMP LT6657AHMS8-5
 D Precision voltage reference, 40V input, 10mA output, 1.5ppm/C drift, 5.0V output, MSOP-8
 K voltage reference vref
 F https://www.analog.com/media/en/technical-documentation/data-sheets/6657fd.pdf
 $ENDCMP
 #
-$CMP 6657fdBHMS8-2.5
+$CMP LT6657BHMS8-2.5
 D Precision voltage reference, 40V input, 10mA output, 3.0ppm/C drift, 2.5V output, MSOP-8
 K voltage reference vref
 F https://www.analog.com/media/en/technical-documentation/data-sheets/6657fd.pdf
 $ENDCMP
 #
-$CMP 6657fdBHMS8-3
+$CMP LT6657BHMS8-3
 D Precision voltage reference, 40V input, 10mA output, 3.0ppm/C drift, 3.0V output, MSOP-8
 K voltage reference vref
 F https://www.analog.com/media/en/technical-documentation/data-sheets/6657fd.pdf
 $ENDCMP
 #
-$CMP 6657fdBHMS8-5
+$CMP LT6657BHMS8-5
 D Precision voltage reference, 40V input, 10mA output, 3.0ppm/C drift, 5.0V output, MSOP-8
 K voltage reference vref
 F https://www.analog.com/media/en/technical-documentation/data-sheets/6657fd.pdf

--- a/Reference_Voltage.dcm
+++ b/Reference_Voltage.dcm
@@ -378,40 +378,40 @@ K voltage reference Micropower
 F https://www.analog.com/media/en/technical-documentation/data-sheets/1790fc.pdf
 $ENDCMP
 #
-$CMP LT6657AHMS8-2.5
+$CMP 6657fdAHMS8-2.5
 D Precision voltage reference, 40V input, 10mA output, 1.5ppm/C drift, 2.5V output, MSOP-8
 K voltage reference vref
-F https://www.analog.com/media/en/technical-documentation/data-sheets/lt6657.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/6657fd.pdf
 $ENDCMP
 #
-$CMP LT6657AHMS8-3
+$CMP 6657fdAHMS8-3
 D Precision voltage reference, 40V input, 10mA output, 1.5ppm/C drift, 3.0V output, MSOP-8
 K voltage reference vref
-F https://www.analog.com/media/en/technical-documentation/data-sheets/lt6657.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/6657fd.pdf
 $ENDCMP
 #
-$CMP LT6657AHMS8-5
+$CMP 6657fdAHMS8-5
 D Precision voltage reference, 40V input, 10mA output, 1.5ppm/C drift, 5.0V output, MSOP-8
 K voltage reference vref
-F https://www.analog.com/media/en/technical-documentation/data-sheets/lt6657.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/6657fd.pdf
 $ENDCMP
 #
-$CMP LT6657BHMS8-2.5
+$CMP 6657fdBHMS8-2.5
 D Precision voltage reference, 40V input, 10mA output, 3.0ppm/C drift, 2.5V output, MSOP-8
 K voltage reference vref
-F https://www.analog.com/media/en/technical-documentation/data-sheets/lt6657.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/6657fd.pdf
 $ENDCMP
 #
-$CMP LT6657BHMS8-3
+$CMP 6657fdBHMS8-3
 D Precision voltage reference, 40V input, 10mA output, 3.0ppm/C drift, 3.0V output, MSOP-8
 K voltage reference vref
-F https://www.analog.com/media/en/technical-documentation/data-sheets/lt6657.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/6657fd.pdf
 $ENDCMP
 #
-$CMP LT6657BHMS8-5
+$CMP 6657fdBHMS8-5
 D Precision voltage reference, 40V input, 10mA output, 3.0ppm/C drift, 5.0V output, MSOP-8
 K voltage reference vref
-F https://www.analog.com/media/en/technical-documentation/data-sheets/lt6657.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/6657fd.pdf
 $ENDCMP
 #
 $CMP MAX6100

--- a/Regulator_Controller.dcm
+++ b/Regulator_Controller.dcm
@@ -183,43 +183,43 @@ $ENDCMP
 $CMP LT1248
 D Power Factor Controller, DIP-16/SOIC-16
 K pfc controller
-F http://cds.linear.com/docs/en/datasheet/1248fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1248fd.pdf
 $ENDCMP
 #
 $CMP LT1249
 D Power Factor Controller, DIP-8/SOIC-8
 K pfc controller
-F http://cds.linear.com/docs/en/datasheet/1249fbs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1249fbs.pdf
 $ENDCMP
 #
 $CMP LT1509
 D Power Factor and PWM Controller, DIP-20/SOIC-20
 K pfc pwm controller
-F http://cds.linear.com/docs/en/datasheet/lt1509.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt1509.pdf
 $ENDCMP
 #
 $CMP LTC1624CS8
 D High Efficiency N-Channel Switching Regulator Controller, SOIC-8
 K Switching Regulator Controller
-F http://cds.linear.com/docs/en/datasheet/1624f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1624f.pdf
 $ENDCMP
 #
 $CMP LTC3805xMSE
 D Adjustable Frequency current Mode Flyback DC/DC controller, MSOP-10
 K flyback dc-dc switcher switching
-F http://cds.linear.com/docs/en/datasheet/3805fg.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3805fg.pdf
 $ENDCMP
 #
 $CMP LTC3890
 D 60V dual 2-phase synchronous step-down DC/DC controller, QFN-32
 K switching buck converter regulator dual-output
-F http://cds.linear.com/docs/en/datasheet/3890fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3890fc.pdf
 $ENDCMP
 #
 $CMP LTC3890-1
 D 60V dual 2-phase synchronous step-down DC/DC controller, SSOP-28
 K switching buck converter regulator dual-output
-F http://cds.linear.com/docs/en/datasheet/38901fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/38901fb.pdf
 $ENDCMP
 #
 $CMP LTC3892

--- a/Regulator_Linear.dcm
+++ b/Regulator_Linear.dcm
@@ -3559,7 +3559,7 @@ F https://www.analog.com/media/en/technical-documentation/data-sheets/1962fb.pdf
 $ENDCMP
 #
 $CMP LT1962-1.5
-D 1.5V, 300mA, Low Noise, Micropower LDO Regulator
+D 1.5V, 300mA, Low Noise, Micropower LDO Regulator, MSOP-8
 K LDO 1.5V
 F https://www.analog.com/media/en/technical-documentation/data-sheets/1962fb.pdf
 $ENDCMP

--- a/Regulator_Linear.dcm
+++ b/Regulator_Linear.dcm
@@ -3561,7 +3561,7 @@ $ENDCMP
 $CMP LT1962-1.5
 D 1.5V, 300mA, Low Noise, Micropower LDO Regulator
 K LDO 1.5V
-F https://www.analog.com/media/en/technical-documentation/data-sheets/1962fb.pdf, MSOP-8
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1962fb.pdf
 $ENDCMP
 #
 $CMP LT1962-1.8

--- a/Regulator_Linear.dcm
+++ b/Regulator_Linear.dcm
@@ -3135,391 +3135,391 @@ $ENDCMP
 $CMP LT1033C
 D Negative 3A 35V Adjustable Linear Regulator, TO-220
 K Adjustable Voltage Regulator 3A Negative
-F http://cds.linear.com/docs/en/datasheet/1033fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1033fd.pdf
 $ENDCMP
 #
 $CMP LT1083-12
 D 7.5A 25V LDO Linear Regulator, Fixed Output 12V, TO-220/TO-263
 K Voltage Regulator Fixed 7.5A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1083ffe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1083ffe.pdf
 $ENDCMP
 #
 $CMP LT1083-3.3
 D 7.5A 20V LDO Linear Regulator, Fixed Output 3.3V, TO-220/TO-263
 K Voltage Regulator Fixed 7.5A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1083ffe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1083ffe.pdf
 $ENDCMP
 #
 $CMP LT1083-3.6
 D 7.5A 20V LDO Linear Regulator, Fixed Output 3.6V, TO-220/TO-263
 K Voltage Regulator Fixed 7.5A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1083ffe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1083ffe.pdf
 $ENDCMP
 #
 $CMP LT1083-5.0
 D 7.5A 20V LDO Linear Regulator, Fixed Output 5.V, TO-220/TO-263
 K Voltage Regulator Fixed 7.5A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1083ffe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1083ffe.pdf
 $ENDCMP
 #
 $CMP LT1083-ADJ
 D 7.5A 25V LDO Linear Regulator, Adjustable Output, TO-220/TO-263
 K Voltage Regulator Adjustable 7.5A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/108345fh.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/108345fh.pdf
 $ENDCMP
 #
 $CMP LT1084-12
 D 5.0A 25V LDO Linear Regulator, Fixed Output 12V, TO-220/TO-263
 K Voltage Regulator Fixed 5.0A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1083ffe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1083ffe.pdf
 $ENDCMP
 #
 $CMP LT1084-3.3
 D 5.0A 20V LDO Linear Regulator, Fixed Output 3.3V, TO-220/TO-263
 K Voltage Regulator Fixed 5.0A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1083ffe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1083ffe.pdf
 $ENDCMP
 #
 $CMP LT1084-3.6
 D 5.0A 20V LDO Linear Regulator, Fixed Output 3.6V, TO-220/TO-263
 K Voltage Regulator Fixed 5.0A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1083ffe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1083ffe.pdf
 $ENDCMP
 #
 $CMP LT1084-5.0
 D 5.0A 20V LDO Linear Regulator, Fixed Output 5.V, TO-220/TO-263
 K Voltage Regulator Fixed 5.0A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1083ffe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1083ffe.pdf
 $ENDCMP
 #
 $CMP LT1084-ADJ
 D 5.0A 25V LDO Linear Regulator, Adjustable Output, TO-220/TO-263
 K Voltage Regulator Adjustable 5.0A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/108345fh.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/108345fh.pdf
 $ENDCMP
 #
 $CMP LT1085-12
 D 3.0A 25V LDO Linear Regulator, Fixed Output 12V, TO-220/TO-263
 K Voltage Regulator Fixed 3.0A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1083ffe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1083ffe.pdf
 $ENDCMP
 #
 $CMP LT1085-3.3
 D 3.0A 20V LDO Linear Regulator, Fixed Output 3.3V, TO-220/TO-263
 K Voltage Regulator Fixed 3.0A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1083ffe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1083ffe.pdf
 $ENDCMP
 #
 $CMP LT1085-3.6
 D 3.0A 20V LDO Linear Regulator, Fixed Output 3.6V, TO-220/TO-263
 K Voltage Regulator Fixed 3.0A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1083ffe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1083ffe.pdf
 $ENDCMP
 #
 $CMP LT1085-5.0
 D 3.0A 20V LDO Linear Regulator, Fixed Output 5.V, TO-220/TO-263
 K Voltage Regulator Fixed 3.0A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1083ffe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1083ffe.pdf
 $ENDCMP
 #
 $CMP LT1085-ADJ
 D 3.0A 25V LDO Linear Regulator, Adjustable Output, TO-220/TO-263
 K Voltage Regulator Adjustable 3.0A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/108345fh.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/108345fh.pdf
 $ENDCMP
 #
 $CMP LT1086-12
 D 1.5A 25V LDO Linear Regulator, Fixed Output 12V, TO-220/TO-263
 K Voltage Regulator Fixed 1.5A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1086ffs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1086ffs.pdf
 $ENDCMP
 #
 $CMP LT1086-2.85
 D 1.5A 18V LDO Linear Regulator, Fixed Output 2.85V, TO-220/TO-263
 K Voltage Regulator Fixed 1.5A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1086ffs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1086ffs.pdf
 $ENDCMP
 #
 $CMP LT1086-3.3
 D 1.5A 20V LDO Linear Regulator, Fixed Output 3.3V, TO-220/TO-263
 K Voltage Regulator Fixed 1.5A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1086ffs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1086ffs.pdf
 $ENDCMP
 #
 $CMP LT1086-3.6
 D 1.5A 20V LDO Linear Regulator, Fixed Output 3.6V, TO-220/TO-263
 K Voltage Regulator Fixed 1.5A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1086ffs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1086ffs.pdf
 $ENDCMP
 #
 $CMP LT1086-5.0
 D 1.5A 20V LDO Linear Regulator, Fixed Output 5.V, TO-220/TO-263
 K Voltage Regulator Fixed 1.5A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1086ffs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1086ffs.pdf
 $ENDCMP
 #
 $CMP LT1086-ADJ
 D 1.5A 25V LDO Linear Regulator, Adjustable Output, TO-220/TO-263
 K Voltage Regulator Adjustable 1.5A Positive LDO
-F http://cds.linear.com/docs/en/datasheet/1086ffs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1086ffs.pdf
 $ENDCMP
 #
 $CMP LT1117-2.85
 D 800mA Low-Dropout Linear Regulator, 2.85V fixed output, SOT-223/TO-263
 K linear regulator ldo fixed positive
-F http://cds.linear.com/docs/en/datasheet/1117fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1117fd.pdf
 $ENDCMP
 #
 $CMP LT1117-3.3
 D 800mA Low-Dropout Linear Regulator, 3.3V fixed output, SOT-223/TO-263
 K linear regulator ldo fixed positive
-F http://cds.linear.com/docs/en/datasheet/1117fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1117fd.pdf
 $ENDCMP
 #
 $CMP LT1117-5.0
 D 800mA Low-Dropout Linear Regulator, 5.0V fixed output, SOT-223/TO-263
 K linear regulator ldo fixed positive
-F http://cds.linear.com/docs/en/datasheet/1117fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1117fd.pdf
 $ENDCMP
 #
 $CMP LT1117-ADJ
 D 800mA Low-Dropout Linear Regulator, adjustable output, SOT-223/TO-263
 K linear regulator ldo adjustable positive
-F http://cds.linear.com/docs/en/datasheet/1117fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1117fd.pdf
 $ENDCMP
 #
 $CMP LT1129-3.3_SO8
 D 700mA Micropower Low Dropout Linear Regulator, 3.3V output voltage, SO-8
 K LDO Linear Regulator positive fixed
-F http://cds.linear.com/docs/en/datasheet/112935ff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/112935ff.pdf
 $ENDCMP
 #
 $CMP LT1129-3.3_SOT223
 D 700mA Micropower Low drop-out regulator, Fixed Output 3.3V, SOT-223
 K REGULATOR LDO fixed positive
-F http://cds.linear.com/docs/en/datasheet/112935ff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/112935ff.pdf
 $ENDCMP
 #
 $CMP LT1129-3.3_TO220_TO263
 D 700mA Micropower Low Dropout Linear Regulator, 3.3V output voltage, TO-220-5/TO-263-5
 K LDO Linear Regulator positive fixed
-F http://cds.linear.com/docs/en/datasheet/112935ff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/112935ff.pdf
 $ENDCMP
 #
 $CMP LT1129-5.0_SO8
 D 700mA Micropower Low Dropout Linear Regulator, 5.0V output voltage, SO-8
 K LDO Linear Regulator positive fixed
-F http://cds.linear.com/docs/en/datasheet/112935ff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/112935ff.pdf
 $ENDCMP
 #
 $CMP LT1129-5.0_SOT223
 D 700mA Micropower Low drop-out regulator, Fixed Output 5.0V, SOT-223
 K REGULATOR LDO Fixed Positive
-F http://cds.linear.com/docs/en/datasheet/112935ff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/112935ff.pdf
 $ENDCMP
 #
 $CMP LT1129-5.0_TO220_TO263
 D 700mA Micropower Low Dropout Linear Regulator, 5.0V output voltage, TO-220-5/TO-263-5
 K LDO Linear Regulator positive fixed
-F http://cds.linear.com/docs/en/datasheet/112935ff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/112935ff.pdf
 $ENDCMP
 #
 $CMP LT1129-ADJ_SO8
 D 700mA Micropower Low Dropout Linear Regulator, adjustable output voltage, SO-8
 K LDO Linear Regulator positive adjustable
-F http://cds.linear.com/docs/en/datasheet/112935ff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/112935ff.pdf
 $ENDCMP
 #
 $CMP LT1129-ADJ_TO220_TO263
 D 700mA Micropower Low Dropout Linear Regulator, adjustable output voltage, TO-220-5/TO-263-5
 K LDO Linear Regulator positive adjustable
-F http://cds.linear.com/docs/en/datasheet/112935ff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/112935ff.pdf
 $ENDCMP
 #
 $CMP LT1175-5_SO8_DIP8
 D 500mA Negative Low Dropout Micropower Regulator, fixed output voltage -5V, SO-8/DIP-8
 K linear regulator LDO negative fixed
-F http://cds.linear.com/docs/en/datasheet/1175ff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1175ff.pdf
 $ENDCMP
 #
 $CMP LT1175-5_SOT223
 D 500mA Negative Low Dropout Micropower Regulator, fixed output voltage -5V, SOT-223
 K linear regulator LDO negative fixed
-F http://cds.linear.com/docs/en/datasheet/1175ff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1175ff.pdf
 $ENDCMP
 #
 $CMP LT1175-5_TO263_TO220
 D 500mA Negative Low Dropout Micropower Regulator, fixed output voltage -5V, TO-220-5/TO-263
 K linear regulator LDO negative fixed
-F http://cds.linear.com/docs/en/datasheet/1175ff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1175ff.pdf
 $ENDCMP
 #
 $CMP LT1175-ADJ_SO8_DIP8
 D 500mA Negative Low Dropout Micropower Regulator, adjustable output voltage, SO-8/DIP-8
 K linear regulator LDO negative adjustable
-F http://cds.linear.com/docs/en/datasheet/1175ff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1175ff.pdf
 $ENDCMP
 #
 $CMP LT1175-ADJ_SOT223
 D 500mA Negative Low Dropout Micropower Regulator, adjustable output voltage, SOT-223
 K linear regulator LDO negative adjustable
-F http://cds.linear.com/docs/en/datasheet/1175ff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1175ff.pdf
 $ENDCMP
 #
 $CMP LT1175-ADJ_TO263_TO220
 D 500mA Negative Low Dropout Micropower Regulator, adjustable output voltage, TO-220-5/TO-263
 K linear regulator LDO negative adjustable
-F http://cds.linear.com/docs/en/datasheet/1175ff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1175ff.pdf
 $ENDCMP
 #
 $CMP LT1584-3.3
 D Positive 7A 35V Low Dropout Fast Response Linear Regulator, Fixed Output 3.3V, TO-220/TO-263
 K Voltage Regulator 7A Positive Fixed
-F http://cds.linear.com/docs/en/datasheet/158457a.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/158457a.pdf
 $ENDCMP
 #
 $CMP LT1584-3.38
 D Positive 7A 35V Low Dropout Fast Response Linear Regulator, Fixed Output 3.38V, TO-220/TO-263
 K Voltage Regulator 7A Positive Fixed
-F http://cds.linear.com/docs/en/datasheet/158457a.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/158457a.pdf
 $ENDCMP
 #
 $CMP LT1584-3.45
 D Positive 7A 35V Low Dropout Fast Response Linear Regulator, Fixed Output 3.45V, TO-220/TO-263
 K Voltage Regulator 7A Positive Fixed
-F http://cds.linear.com/docs/en/datasheet/158457a.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/158457a.pdf
 $ENDCMP
 #
 $CMP LT1584-3.6
 D Positive 7A 35V Low Dropout Fast Response Linear Regulator, Fixed Output 3.6V, TO-220/TO-263
 K Voltage Regulator 7A Positive Fixed
-F http://cds.linear.com/docs/en/datasheet/158457a.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/158457a.pdf
 $ENDCMP
 #
 $CMP LT1584-ADJ
 D Positive 7A 35V Low Dropout Fast Response Linear Regulator, Adjustable Output, TO-220
 K Voltage Regulator 7A Positive Adjustable
-F http://cds.linear.com/docs/en/datasheet/158457a.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/158457a.pdf
 $ENDCMP
 #
 $CMP LT1585-3.3
 D Positive 4.6A 35V Low Dropout Fast Response Linear Regulator, Fixed Output 3.3V, TO-220/TO-263
 K Voltage Regulator 4.6A Positive Fixed
-F http://cds.linear.com/docs/en/datasheet/158457a.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/158457a.pdf
 $ENDCMP
 #
 $CMP LT1585-3.38
 D Positive 4.6A 35V Low Dropout Fast Response Linear Regulator, Fixed Output 3.38V, TO-220/TO-263
 K Voltage Regulator 4.6A Positive Fixed
-F http://cds.linear.com/docs/en/datasheet/158457a.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/158457a.pdf
 $ENDCMP
 #
 $CMP LT1585-3.45
 D Positive 4.6A 35V Low Dropout Fast Response Linear Regulator, Fixed Output 3.45V, TO-220/TO-263
 K Voltage Regulator 4.6A Positive Fixed
-F http://cds.linear.com/docs/en/datasheet/158457a.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/158457a.pdf
 $ENDCMP
 #
 $CMP LT1585-3.6
 D Positive 4.6A 35V Low Dropout Fast Response Linear Regulator, Fixed Output 3.6V, TO-220/TO-263
 K Voltage Regulator 4.6A Positive Fixed
-F http://cds.linear.com/docs/en/datasheet/158457a.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/158457a.pdf
 $ENDCMP
 #
 $CMP LT1585-ADJ
 D Positive 4.6A 35V Low Dropout Fast Response Linear Regulator, Adjustable Output, TO-220/TO-263
 K Voltage Regulator 4.6A Positive Adjustable
-F http://cds.linear.com/docs/en/datasheet/158457a.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/158457a.pdf
 $ENDCMP
 #
 $CMP LT1587-3.3
 D Positive 3A 35V Low Dropout Fast Response Linear Regulator, Fixed Output 3.3V, TO-220/TO-263
 K Voltage Regulator 3A Positive Fixed
-F http://cds.linear.com/docs/en/datasheet/158457a.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/158457a.pdf
 $ENDCMP
 #
 $CMP LT1587-3.45
 D Positive 3A 35V Low Dropout Fast Response Linear Regulator, Fixed Output 3.45V, TO-220/TO-263
 K Voltage Regulator 3A Positive Fixed
-F http://cds.linear.com/docs/en/datasheet/158457a.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/158457a.pdf
 $ENDCMP
 #
 $CMP LT1587-3.6
 D Positive 3A 35V Low Dropout Fast Response Linear Regulator, Fixed Output 3.6V, TO-220/TO-263
 K Voltage Regulator 3A Positive Fixed
-F http://cds.linear.com/docs/en/datasheet/158457a.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/158457a.pdf
 $ENDCMP
 #
 $CMP LT1587-ADJ
 D Positive 3A 35V Low Dropout Fast Response Linear Regulator, Adjustable Output, TO-220/TO-263
 K Voltage Regulator 3A Positive Adjustable
-F http://cds.linear.com/docs/en/datasheet/158457a.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/158457a.pdf
 $ENDCMP
 #
 $CMP LT1761-1.2
 D MICROPOWER Low Noise 1.2V 100mA LDO regulator, TSOT-23-5
 K REGULATOR POWER LDO POSITIVE
-F http://cds.linear.com/docs/en/datasheet/1761sff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1761sff.pdf
 $ENDCMP
 #
 $CMP LT1761-1.5
 D MICROPOWER Low Noise 1.5V 100mA LDO regulator, TSOT-23-5
 K POWER LDO REGULATOR POSITIVE
-F http://cds.linear.com/docs/en/datasheet/1761sff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1761sff.pdf
 $ENDCMP
 #
 $CMP LT1761-1.8
 D MICROPOWER Low Noise 1.8V 100mA LDO regulator, TSOT-23-5
 K REGULATOR POSITIVE POWER LDO
-F http://cds.linear.com/docs/en/datasheet/1761sff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1761sff.pdf
 $ENDCMP
 #
 $CMP LT1761-2
 D MICROPOWER Low Noise 2V 100mA LDO regulator, TSOT-23-5
 K REGULATOR POSITIVE POWER LDO
-F http://cds.linear.com/docs/en/datasheet/1761sff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1761sff.pdf
 $ENDCMP
 #
 $CMP LT1761-2.5
 D MICROPOWER Low Noise 2.5V 100mA LDO regulator, TSOT-23-5
 K REGULATOR POSITIVE POWER LDO
-F http://cds.linear.com/docs/en/datasheet/1761sff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1761sff.pdf
 $ENDCMP
 #
 $CMP LT1761-2.8
 D MICROPOWER Low Noise 2.8V 100mA LDO regulator, TSOT-23-5
 K REGULATOR POSITIVE POWER LDO
-F http://cds.linear.com/docs/en/datasheet/1761sff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1761sff.pdf
 $ENDCMP
 #
 $CMP LT1761-3
 D MICROPOWER Low Noise 3V 100mA LDO regulator, TSOT-23-5
 K REGULATOR POSITIVE POWER LDO
-F http://cds.linear.com/docs/en/datasheet/1761sff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1761sff.pdf
 $ENDCMP
 #
 $CMP LT1761-3.3
 D MICROPOWER Low Noise 3.3V 100mA LDO regulator, TSOT-23-5
 K REGULATOR POSITIVE POWER LDO
-F http://cds.linear.com/docs/en/datasheet/1761sff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1761sff.pdf
 $ENDCMP
 #
 $CMP LT1761-5
 D MICROPOWER Low Noise 5V 100mA LDO regulator, TSOT-23-5
 K REGULATOR POSITIVE POWER LDO
-F http://cds.linear.com/docs/en/datasheet/1761sff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1761sff.pdf
 $ENDCMP
 #
 $CMP LT1761-BYP
 D MICROPOWER 100mA LDO adjustable regulator, TSOT-23-5
 K REGULATOR POSITIVE POWER LDO adjustable
-F http://cds.linear.com/docs/en/datasheet/1761sff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1761sff.pdf
 $ENDCMP
 #
 $CMP LT1761-SD
 D MICROPOWER 100mA LDO adjustable regulator, TSOT-23-5
 K REGULATOR POSITIVE POWER LDO adjustable
-F http://cds.linear.com/docs/en/datasheet/1761sff.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1761sff.pdf
 $ENDCMP
 #
 $CMP LT1762
@@ -3555,43 +3555,43 @@ $ENDCMP
 $CMP LT1962
 D 300mA, Adjustable, Low Noise, Micropower LDO Regulator, MSOP-8
 K LDO ADJ
-F http://cds.linear.com/docs/en/datasheet/1962fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1962fb.pdf
 $ENDCMP
 #
 $CMP LT1962-1.5
 D 1.5V, 300mA, Low Noise, Micropower LDO Regulator
 K LDO 1.5V
-F http://cds.linear.com/docs/en/datasheet/1962fb.pdf, MSOP-8
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1962fb.pdf, MSOP-8
 $ENDCMP
 #
 $CMP LT1962-1.8
 D 1.8V, 300mA, Low Noise, Micropower LDO Regulator, MSOP-8
 K LDO 1.8V
-F http://cds.linear.com/docs/en/datasheet/1962fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1962fb.pdf
 $ENDCMP
 #
 $CMP LT1962-2.5
 D 2.5V, 300mA, Low Noise, Micropower LDO Regulator, MSOP-8
 K LDO 2.5V
-F http://cds.linear.com/docs/en/datasheet/1962fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1962fb.pdf
 $ENDCMP
 #
 $CMP LT1962-3
 D 3.0V, 300mA, Low Noise, Micropower LDO Regulator, MSOP-8
 K LDO 3V
-F http://cds.linear.com/docs/en/datasheet/1962fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1962fb.pdf
 $ENDCMP
 #
 $CMP LT1962-3.3
 D 3.3V, 300mA, Low Noise, Micropower LDO Regulator, MSOP-8
 K LDO 3.3V
-F http://cds.linear.com/docs/en/datasheet/1962fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1962fb.pdf
 $ENDCMP
 #
 $CMP LT1962-5
 D 5.0V, 300mA, Low Noise, Micropower LDO Regulator, MSOP-8
 K LDO 5V
-F http://cds.linear.com/docs/en/datasheet/1962fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1962fb.pdf
 $ENDCMP
 #
 $CMP LT1963AEQ
@@ -3657,19 +3657,19 @@ $ENDCMP
 $CMP LT1964-5
 D MICROPOWER 200mA Low Noise LDO negative regulator, fixed output -5V, TSOT-23-5
 K REGULATOR POSITIVE POWER LDO fixed
-F http://cds.linear.com/docs/en/datasheet/1964fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1964fb.pdf
 $ENDCMP
 #
 $CMP LT1964-BYP
 D MICROPOWER 200mA Low Noise LDO negative regulator, adjustable output, TSOT-23-5
 K REGULATOR POSITIVE POWER LDO adjustable
-F http://cds.linear.com/docs/en/datasheet/1964fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1964fb.pdf
 $ENDCMP
 #
 $CMP LT1964-SD
 D MICROPOWER 200mA Low Noise LDO negative regulator, adjustable output, TSOT-23-5
 K REGULATOR POSITIVE POWER LDO adjustable
-F http://cds.linear.com/docs/en/datasheet/1964fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1964fb.pdf
 $ENDCMP
 #
 $CMP LT3010-5
@@ -3729,31 +3729,31 @@ $ENDCMP
 $CMP LT3080xDD
 D Adjustable 1.1A Single Resistor Low Dropout Regulator, DFN-8
 K Adjustable 1.1A Low Dropout Regulator
-F http://cds.linear.com/docs/en/datasheet/3080fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3080fc.pdf
 $ENDCMP
 #
 $CMP LT3080xMS8E
 D Adjustable 1.1A Single Resistor Low Dropout Regulator, MSOP-8
 K Adjustable 1.1A Low Dropout Regulator
-F http://cds.linear.com/docs/en/datasheet/3080fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3080fc.pdf
 $ENDCMP
 #
 $CMP LT3080xQ
 D Adjustable 1.1A Single Resistor Low Dropout Regulator, TO-220
 K Adjustable 1.1A Low Dropout Regulator
-F http://cds.linear.com/docs/en/datasheet/3080fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3080fc.pdf
 $ENDCMP
 #
 $CMP LT3080xST
 D Adjustable 1.1A Single Resistor Low Dropout Regulator, SOT-223
 K Adjustable 1.1A Low Dropout Regulator
-F http://cds.linear.com/docs/en/datasheet/3080fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3080fc.pdf
 $ENDCMP
 #
 $CMP LT3080xT
 D Adjustable 1.1A Single Resistor Low Dropout Regulator, TO-220
 K Adjustable 1.1A Low Dropout Regulator
-F http://cds.linear.com/docs/en/datasheet/3080fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3080fc.pdf
 $ENDCMP
 #
 $CMP MAX1658ESA

--- a/Regulator_SwitchedCapacitor.dcm
+++ b/Regulator_SwitchedCapacitor.dcm
@@ -39,31 +39,31 @@ $ENDCMP
 $CMP LT1054
 D Switched-Capacitor Voltage Converter with Regulator, output current 100mA, operating range 3.5V to 15V, low loss 1.1V at 100mA, DIP-8/SO-8
 K monolithic bipolar switched capacitor voltage converter regulator inverter doubler shutdown
-F http://cds.linear.com/docs/en/datasheet/1054lfh.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1054lfh.pdf
 $ENDCMP
 #
 $CMP LT1054L
 D Switched-Capacitor Voltage Converter with Regulator, output current 125mA, operating range 3.5V to 15V, low loss 1.1V at 100mA, DIP-8/SO-8
 K monolithic bipolar switched capacitor voltage converter regulator inverter doubler shutdown
-F http://cds.linear.com/docs/en/datasheet/1054lfh.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1054lfh.pdf
 $ENDCMP
 #
 $CMP LT1054xSW
 D Switched-Capacitor Voltage Converter with Regulator, output current 100mA, operating range 3.5V to 15V, low loss 1.1V at 100mA, SO-16
 K monolithic bipolar switched capacitor voltage converter regulator inverter doubler shutdown
-F http://cds.linear.com/docs/en/datasheet/1054lfh.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1054lfh.pdf
 $ENDCMP
 #
 $CMP LTC1044
 D Switched Capacitor Voltage Converter, 1.5V to 9V supply operation, 200uA Max No Load Supply Current at 5V, DIP-8/TO-99
 K monolithic CMOS switched capacitor voltage converter invert double divide multiply boost
-F http://cds.linear.com/docs/en/datasheet/lt1044.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt1044.pdf
 $ENDCMP
 #
 $CMP LTC660
 D Monolithic CMOS switched-capacitor from 1.5V to 5.5V up to 100mA, SO-8/DIP-8
 K monolithic CMOS switched capacitor voltage converter invert double divide multiply boost
-F http://cds.linear.com/docs/en/datasheet/660fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/660fa.pdf
 $ENDCMP
 #
 $CMP MAX1044

--- a/Regulator_Switching.dcm
+++ b/Regulator_Switching.dcm
@@ -2229,385 +2229,385 @@ $ENDCMP
 $CMP LT1073CN
 D Micropower DC/DC Converter Adjustable Output Voltage, DIP-8
 K Micropower DC/DC Converter
-F http://cds.linear.com/docs/en/datasheet/1073fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1073fa.pdf
 $ENDCMP
 #
 $CMP LT1073CN-12
 D Micropower DC/DC Converter, Fixed 12V Output Voltage, DIP-8
 K Micropower DC/DC Converter
-F http://cds.linear.com/docs/en/datasheet/1073fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1073fa.pdf
 $ENDCMP
 #
 $CMP LT1073CN-5
 D Micropower DC/DC Converter, Fixed 5V Output Voltage, DIP-8
 K Micropower DC/DC Converter
-F http://cds.linear.com/docs/en/datasheet/1073fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1073fa.pdf
 $ENDCMP
 #
 $CMP LT1073CS
 D Micropower DC/DC Converter Adjustable Output Voltage, SO-8
 K Micropower DC/DC Converter
-F http://cds.linear.com/docs/en/datasheet/1073fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1073fa.pdf
 $ENDCMP
 #
 $CMP LT1073CS-12
 D Micropower DC/DC Converter, Fixed 12V Output Voltage, SO-8
 K Micropower DC/DC Converter
-F http://cds.linear.com/docs/en/datasheet/1073fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1073fa.pdf
 $ENDCMP
 #
 $CMP LT1073CS-5
 D Micropower DC/DC Converter, Fixed 5V Output Voltage, SO-8
 K Micropower DC/DC Converter
-F http://cds.linear.com/docs/en/datasheet/1073fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1073fa.pdf
 $ENDCMP
 #
 $CMP LT1108CN
 D Micropower DC-DC conveter, step-up or step-down operation, 2V-30Vin, adjustable output voltage, DIP-8
 K switching buck boost converter step-down step-up
-F http://cds.linear.com/docs/en/datasheet/lt1108.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt1108.pdf
 $ENDCMP
 #
 $CMP LT1108CN-12
 D Micropower DC-DC conveter, step-up or step-down operation, 2V-30Vin, fixed 12V output voltage, DIP-8
 K switching buck boost converter step-down step-up
-F http://cds.linear.com/docs/en/datasheet/lt1108.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt1108.pdf
 $ENDCMP
 #
 $CMP LT1108CN-5
 D Micropower DC-DC conveter, step-up or step-down operation, 2V-30Vin, fixed 5V output voltage, DIP-8
 K switching buck boost converter step-down step-up
-F http://cds.linear.com/docs/en/datasheet/lt1108.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt1108.pdf
 $ENDCMP
 #
 $CMP LT1108CS
 D Micropower DC-DC conveter, step-up or step-down operation, 2V-30Vin, adjustable output voltage, SO-8
 K switching buck boost converter step-down step-up
-F http://cds.linear.com/docs/en/datasheet/lt1108.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt1108.pdf
 $ENDCMP
 #
 $CMP LT1108CS-12
 D Micropower DC-DC conveter, step-up or step-down operation, 2V-30Vin, fixed 12V output voltage, SO-8
 K switching buck boost converter step-down step-up
-F http://cds.linear.com/docs/en/datasheet/lt1108.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt1108.pdf
 $ENDCMP
 #
 $CMP LT1108CS-5
 D Micropower DC-DC conveter, step-up or step-down operation, 2V-30Vin, fixed 5V output voltage, SO-8
 K switching buck boost converter step-down step-up
-F http://cds.linear.com/docs/en/datasheet/lt1108.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt1108.pdf
 $ENDCMP
 #
 $CMP LT1301
 D Micropower High Efficiency 5V/12V Step-Up DC/DC Converter for Flash Memory, DIP-8/SOIC-8
 K 5v 12v dc converter boost
-F http://www.linear.com/docs/3451
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3451
 $ENDCMP
 #
 $CMP LT1307BCMS8
 D Single Cell Micropower 600kHz PWM DC/DC Converter, 10µA Quiescent Current, MSOP-8
 K Micropower PWM DC/DC Converter
-F http://cds.linear.com/docs/en/datasheet/1307fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1307fa.pdf
 $ENDCMP
 #
 $CMP LT1307BCS8
 D Single Cell Micropower 600kHz PWM DC/DC Converter, 10µA Quiescent Current, SO-8
 K Micropower PWM DC/DC Converter
-F http://cds.linear.com/docs/en/datasheet/1307fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1307fa.pdf
 $ENDCMP
 #
 $CMP LT1307CMS8
 D Single Cell Micropower 600kHz PWM DC/DC Converter, 50µA Quiescent Current, MSOP-8
 K Micropower PWM DC/DC Converter
-F http://cds.linear.com/docs/en/datasheet/1307fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1307fa.pdf
 $ENDCMP
 #
 $CMP LT1307CN8
 D Single Cell Micropower 600kHz PWM DC/DC Converter, 50µA Quiescent Current, DIP-8
 K Micropower PWM DC/DC Converter
-F http://cds.linear.com/docs/en/datasheet/1307fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1307fa.pdf
 $ENDCMP
 #
 $CMP LT1307CS8
 D Single Cell Micropower 600kHz PWM DC/DC Converter, 50µA Quiescent Current, SO-8
 K Micropower PWM DC/DC Converter
-F http://cds.linear.com/docs/en/datasheet/1307fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1307fa.pdf
 $ENDCMP
 #
 $CMP LT1372CN8
 D 1.5A High Efficiency Switching Regulators, 500kHz, 35V Switch Voltage, Adjustable Output Voltage, DIP-8
 K Switching Regulator Adjustable
-F http://cds.linear.com/docs/en/datasheet/13727fbs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/13727fbs.pdf
 $ENDCMP
 #
 $CMP LT1372CS8
 D 1.5A High Efficiency Switching Regulators, 500kHz, 35V Switch Voltage, Adjustable Output Voltage, SO-8
 K Switching Regulator Adjustable
-F http://cds.linear.com/docs/en/datasheet/13727fbs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/13727fbs.pdf
 $ENDCMP
 #
 $CMP LT1372HVCN8
 D 1.5A High Efficiency Switching Regulators, 500kHz, 42V Switch Voltage, Adjustable Output Voltage, DIP-8
 K Switching Regulator Adjustable
-F http://cds.linear.com/docs/en/datasheet/13727fbs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/13727fbs.pdf
 $ENDCMP
 #
 $CMP LT1372HVCS8
 D 1.5A High Efficiency Switching Regulators, 500kHz, 42V Switch Voltage, Adjustable Output Voltage, SO-8
 K Switching Regulator Adjustable
-F http://cds.linear.com/docs/en/datasheet/13727fbs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/13727fbs.pdf
 $ENDCMP
 #
 $CMP LT1373CN8
 D 1.5A Low Supply Current High Efficiency Switching Regulators, 250kHz, 35V Switch Voltage, Adjustable Output Voltage, DIP-8
 K Switching Regulator Adjustable
-F http://cds.linear.com/docs/en/datasheet/1373fbs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1373fbs.pdf
 $ENDCMP
 #
 $CMP LT1373CS8
 D 1.5A Low Supply Current High Efficiency Switching Regulators, 250kHz, 35V Switch Voltage, Adjustable Output Voltage, SO-8
 K Switching Regulator Adjustable
-F http://cds.linear.com/docs/en/datasheet/1373fbs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1373fbs.pdf
 $ENDCMP
 #
 $CMP LT1373HVCN8
 D 1.5A Low Supply Current High Efficiency Switching Regulators, 250kHz, 42V Switch Voltage, Adjustable Output Voltage, DIP-8
 K Switching Regulator Adjustable
-F http://cds.linear.com/docs/en/datasheet/1373fbs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1373fbs.pdf
 $ENDCMP
 #
 $CMP LT1373HVCS8
 D 1.5A Low Supply Current High Efficiency Switching Regulators, 250kHz, 42V Switch Voltage, Adjustable Output Voltage, SO-8
 K Switching Regulator Adjustable
-F http://cds.linear.com/docs/en/datasheet/1373fbs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1373fbs.pdf
 $ENDCMP
 #
 $CMP LT1377CN8
 D 1.5A High Efficiency Switching Regulators, 1MHz, 35V Switch Voltage, Adjustable Output Voltage, DIP-8
 K Switching Regulator Adjustable
-F http://cds.linear.com/docs/en/datasheet/13727fbs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/13727fbs.pdf
 $ENDCMP
 #
 $CMP LT1377CS8
 D 1.5A High Efficiency Switching Regulators, 1MHz, 35V Switch Voltage, Adjustable Output Voltage, SO-8
 K Switching Regulator Adjustable
-F http://cds.linear.com/docs/en/datasheet/13727fbs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/13727fbs.pdf
 $ENDCMP
 #
 $CMP LT1945
 D Dual Micropower DC/DC Converter with Positive and Negative Outputs, MSOP-10
 K switched voltage converter regulator inverter double shutdown  positive negative
-F https://cds.linear.com/docs/en/datasheet/1945fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1945fa.pdf
 $ENDCMP
 #
 $CMP LT3430
 D 3A High Voltage 200kHz Step-Down Switching Regulator, TSSOP-16
 K Step-Down Switching Regulator
-F http://cds.linear.com/docs/en/datasheet/34301fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/34301fa.pdf
 $ENDCMP
 #
 $CMP LT3430-1
 D 3A High Voltage 100kHz Step-Down Switching Regulator, TSSOP-16
 K Step-Down Switching Regulator
-F http://cds.linear.com/docs/en/datasheet/34301fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/34301fa.pdf
 $ENDCMP
 #
 $CMP LT3439
 D 1A Slew Rate Controlled Ultralow Noise Isolated DC/DC Transformer Driver, TSSOP-16
 K Isolated DC/DC Transformer Driver
-F http://cds.linear.com/docs/en/datasheet/3439fs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3439fs.pdf
 $ENDCMP
 #
 $CMP LT3472
 D Boost and Inverting DC/DC Converter for CCD Bias, DFN-10
 K DC/DC converter CCD Bias Boost
-F http://cds.linear.com/docs/en/datasheet/3472f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3472f.pdf
 $ENDCMP
 #
 $CMP LT3757AEDD
 D Boost, flyback, SEPIC and inverting regulator, improved load transient performance, DFN-10
 K Boost flyback SEPIC inverting DC/DC regulator
-F http://cds.linear.com/docs/en/datasheet/3757Afe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3757Afe.pdf
 $ENDCMP
 #
 $CMP LT3757AEMSE
 D Boost, flyback, SEPIC and inverting regulator, improved load transient performance, MSOP-10
 K Boost flyback SEPIC inverting DC/DC regulator
-F http://cds.linear.com/docs/en/datasheet/3757Afe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3757Afe.pdf
 $ENDCMP
 #
 $CMP LT3757EDD
 D Boost, flyback, SEPIC and inverting regulator. DFN-10
 K Boost flyback SEPIC inverting DC/DC regulator
-F http://cds.linear.com/docs/en/datasheet/3757Afe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3757Afe.pdf
 $ENDCMP
 #
 $CMP LT3757EMSE
 D Boost, flyback, SEPIC and inverting regulator. MSOP-10
 K Boost flyback SEPIC inverting DC/DC regulator
-F http://cds.linear.com/docs/en/datasheet/3757Afe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3757Afe.pdf
 $ENDCMP
 #
 $CMP LT8610
 D 42V, 2.5A Synchronous Step-Down Regulator with 2.5uA Quiescent Current, MSOP-16
 K high efficiency speed synchronous monolithic buck step-down switching regulator 42V 2.5A
-F http://cds.linear.com/docs/en/datasheet/8610fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/8610fa.pdf
 $ENDCMP
 #
 $CMP LT8610AC
 D 42V, 3.5A Synchronous Step-Down Regulator with 2.5uA Quiescent Current, 0.8V Feedback Voltage, 3.0V Minimum Vin, MSOP-16
 K high efficiency speed synchronous monolithic buck step-down switching regulator 42V 3.5A lower feedback voltage minimum vin
-F http://cds.linear.com/docs/en/datasheet/8610acfa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/8610acfa.pdf
 $ENDCMP
 #
 $CMP LT8610AC-1
 D 42V, 3.5A Synchronous Step-Down Regulator with 2.5uA Quiescent Current, Internal Compensation for Improved Transient, Soft-Start at Dropout and Brownout, MSOP-16
 K high efficiency speed synchronous monolithic buck step-down switching regulator 42V 3.5A lower feedback voltage minimum vin internal compensation soft-start
-F http://cds.linear.com/docs/en/datasheet/8610acfa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/8610acfa.pdf
 $ENDCMP
 #
 $CMP LTC1436A
 D High Efficiency Low Noise Synchronous Step-Down Switching Regulators, SSOP-24
 K buck controller 36V
-F http://cds.linear.com/docs/en/datasheet/14367afb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/14367afb.pdf
 $ENDCMP
 #
 $CMP LTC1436A-PLL
 D High Efficiency Low Noise Synchronous Step-Down Switching Regulators, SSOP-24
 K buck controller 36V
-F http://cds.linear.com/docs/en/datasheet/14367afb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/14367afb.pdf
 $ENDCMP
 #
 $CMP LTC1437A
 D High Efficiency Low Noise Synchronous Step-Down Switching Regulators, SSOP-28
 K buck controller 36V
-F http://cds.linear.com/docs/en/datasheet/14367afb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/14367afb.pdf
 $ENDCMP
 #
 $CMP LTC1878EMS8
 D High Efficiency Monolithic Synchronous Step-Down Regulator, MSOP-8
 K Synchronous Step-Down Regulator
-F http://cds.linear.com/docs/en/datasheet/1878f.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/1878f.pdf
 $ENDCMP
 #
 $CMP LTC3406AES5
 D 600mA Synchronous Step-Down Regulator, 1.5MHz, Fixed 1.2V Output Voltage, Low Ripple Burst Mode, ThinSOT-23
 K Regulator step-down
-F http://cds.linear.com/docs/en/datasheet/3406afa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3406afa.pdf
 $ENDCMP
 #
 $CMP LTC3406B-2ES5
 D 600mA Synchronous Step-Down Regulator, 2.25MHz, Adjustable Output Voltage,ThinSOT-23
 K Regulator step-down
-F http://cds.linear.com/docs/en/datasheet/3406b2fs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3406b2fs.pdf
 $ENDCMP
 #
 $CMP LTC3406BES5-1.2
 D 600mA Synchronous Step-Down Regulator, 1.5MHz, Fixed 1.2V Output Voltage, Burst Mode Disabled, ThinSOT-23
 K Regulator step-down
-F http://cds.linear.com/docs/en/datasheet/3406b12fs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3406b12fs.pdf
 $ENDCMP
 #
 $CMP LTC3406ES5
 D 600mA Synchronous Step-Down Regulator, 1.5MHz, Adjustable Output Voltage, Burst Mode, ThinSOT-23
 K Regulator step-down
-F http://cds.linear.com/docs/en/datasheet/3406b12fs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3406b12fs.pdf
 $ENDCMP
 #
 $CMP LTC3406ES5-1.2
 D 600mA Synchronous Step-Down Regulator, 1.5MHz, Fixed 1.2V Output Voltage, Burst Mode, ThinSOT-23
 K Regulator step-down
-F http://cds.linear.com/docs/en/datasheet/3406b12fs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3406b12fs.pdf
 $ENDCMP
 #
 $CMP LTC3406ES5-1.5
 D 600mA Synchronous Step-Down Regulator, 1.5MHz, Fixed 1.5V Output Voltage, Burst Mode, ThinSOT-23
 K Regulator step-down
-F http://cds.linear.com/docs/en/datasheet/3406b12fs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3406b12fs.pdf
 $ENDCMP
 #
 $CMP LTC3406ES5-1.8
 D 600mA Synchronous Step-Down Regulator, 1.5MHz, Fixed 1.8V Output Voltage, Burst Mode, ThinSOT-23
 K Regulator step-down
-F http://cds.linear.com/docs/en/datasheet/3406b12fs.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3406b12fs.pdf
 $ENDCMP
 #
 $CMP LTC3429
 D 600mA, 500kHz Micropower Synchronous Boost Converter with Output Disconnect, TSOT-23-6
 K boost step-up DC/DC synchronous
-F http://cds.linear.com/docs/en/datasheet/3429fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3429fa.pdf
 $ENDCMP
 #
 $CMP LTC3429B
 D 600mA, 500kHz Micropower Synchronous Boost Converter with Output Disconnect, Continuous Switching at Light Loads, TSOT-23-6
 K boost step-up DC/DC synchronous
-F http://cds.linear.com/docs/en/datasheet/3429fa.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3429fa.pdf
 $ENDCMP
 #
 $CMP LTC3442
 D Micropower Synchronous Buck-Boost DC/DC Converter with Automatic Burst Mode Operation, DFN-12
 K Micropower Synchronous Buck-Boost DC/DC Converter
-F http://cds.linear.com/docs/en/datasheet/3442fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3442fb.pdf
 $ENDCMP
 #
 $CMP LTC3525
 D 400mA Micropower Synchronous Step-Up DC/DC Converter with Output Disconnect, SC-70-6
 K boost step-up DC/DC synchronous
-F http://cds.linear.com/docs/en/datasheet/3525fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3525fc.pdf
 $ENDCMP
 #
 $CMP LTC3525-3
 D Fixed 3V, 400mA Micropower Synchronous Step-Up DC/DC Converter with Output Disconnect, SC-70-6
 K fixed boost step-up DC/DC synchronous
-F http://cds.linear.com/docs/en/datasheet/3525fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3525fc.pdf
 $ENDCMP
 #
 $CMP LTC3525-3.3
 D Fixed 3V3, 400mA Micropower Synchronous Step-Up DC/DC Converter with Output Disconnect, SC-70-6
 K fixed boost step-up DC/DC synchronous
-F http://cds.linear.com/docs/en/datasheet/3525fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3525fc.pdf
 $ENDCMP
 #
 $CMP LTC3525-5
 D Fixed 5V, 400mA Micropower Synchronous Step-Up DC/DC Converter with Output Disconnect, SC-70-6
 K fixed boost step-up DC/DC synchronous
-F http://cds.linear.com/docs/en/datasheet/3525fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3525fc.pdf
 $ENDCMP
 #
 $CMP LTC3525D-3.3
 D Fixed 3V3, 400mA Micropower Synchronous Step-Up DC/DC Converter with Pass Through Mode, SC-70-6
 K fixed boost step-up DC/DC synchronous
-F http://cds.linear.com/docs/en/datasheet/3525d33fb.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3525d33fb.pdf
 $ENDCMP
 #
 $CMP LTC3525L-3
 D Fixed 3V, 400mA Micropower Synchronous Step-Up DC/DC Converter with Output Disconnect, SC-70-6
 K fixed boost step-up DC/DC synchronous
-F http://cds.linear.com/docs/en/datasheet/3525laf.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3525laf.pdf
 $ENDCMP
 #
 $CMP LTC3630ADHC
 D High efficiency 76V 500mA synchronous step-down converter, DFN-16
 K buck dc-dc switcher switching
-F http://cds.linear.com/docs/en/datasheet/3630afc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3630afc.pdf
 $ENDCMP
 #
 $CMP LTC3630AMSE
 D High efficiency 76V 500mA synchronous step-down converter, MSOP-16(12)
 K buck dc-dc switcher switching
-F http://cds.linear.com/docs/en/datasheet/3630afc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3630afc.pdf
 $ENDCMP
 #
 $CMP LTC3630DHC
 D 500mA High efficiency 65V synchronous step-down converter, DFN-16
 K buck dc-dc switcher switching
-F http://cds.linear.com/docs/en/datasheet/3630fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3630fd.pdf
 $ENDCMP
 #
 $CMP LTC3630MSE
 D 500mA High efficiency 65V synchronous step-down converter, MSOP-16(12)
 K buck dc-dc switcher switching
-F http://cds.linear.com/docs/en/datasheet/3630fd.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3630fd.pdf
 $ENDCMP
 #
 $CMP LTC3638
@@ -2619,7 +2619,7 @@ $ENDCMP
 $CMP LTC3886
 D 60V dual output buck output with digital power system management, UKG52(46)
 K step down switch manager I2C telemetry fault current sense
-F http://cds.linear.com/docs/en/datasheet/3886fe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/3886fe.pdf
 $ENDCMP
 #
 $CMP MAX15062A

--- a/Regulator_Switching.dcm
+++ b/Regulator_Switching.dcm
@@ -2301,7 +2301,7 @@ $ENDCMP
 $CMP LT1301
 D Micropower High Efficiency 5V/12V Step-Up DC/DC Converter for Flash Memory, DIP-8/SOIC-8
 K 5v 12v dc converter boost
-F https://www.analog.com/media/en/technical-documentation/data-sheets/3451
+F https://www.analog.com/media/en/technical-documentation/data-sheets/lt1301.pdf
 $ENDCMP
 #
 $CMP LT1307BCMS8
@@ -2619,7 +2619,7 @@ $ENDCMP
 $CMP LTC3886
 D 60V dual output buck output with digital power system management, UKG52(46)
 K step down switch manager I2C telemetry fault current sense
-F https://www.analog.com/media/en/technical-documentation/data-sheets/3886fe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/LTC3886-3886-1.pdf
 $ENDCMP
 #
 $CMP MAX15062A

--- a/Sensor.dcm
+++ b/Sensor.dcm
@@ -51,7 +51,7 @@ $ENDCMP
 $CMP LTC2990
 D Temperature Voltage and Current Monitor, I2C Interface, MSOP-10
 K Temperature Voltage Current Monitor I2C AFE
-F https://www.analog.com/media/en/technical-documentation/data-sheets/2990fe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/ltc2990.pdf
 $ENDCMP
 #
 $CMP MAX30102

--- a/Sensor.dcm
+++ b/Sensor.dcm
@@ -51,7 +51,7 @@ $ENDCMP
 $CMP LTC2990
 D Temperature Voltage and Current Monitor, I2C Interface, MSOP-10
 K Temperature Voltage Current Monitor I2C AFE
-F http://cds.linear.com/docs/en/datasheet/2990fe.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/2990fe.pdf
 $ENDCMP
 #
 $CMP MAX30102

--- a/Sensor_Temperature.dcm
+++ b/Sensor_Temperature.dcm
@@ -237,7 +237,7 @@ $ENDCMP
 $CMP LTC2983
 D Multi-Sensor Temperature Measurement System, High Accuracy, LQFP-48 (7x7mm)
 K Flexible Temperature Measurement RTD NTC Cold Junction Termocouple
-F http://cds.linear.com/docs/en/datasheet/2983fc.pdf
+F https://www.analog.com/media/en/technical-documentation/data-sheets/2983fc.pdf
 $ENDCMP
 #
 $CMP MAX31820


### PR DESCRIPTION
Analog bought linear some time ago, thankfully they maintained all
datasheets and have easy to generate URLs. For all datasheet URLs the
HEAD was downloaded and checked for a "200 OK" status code. Those which
had errors (only a couple) were fixed manually.

This fixes issue #1547.