### PR TITLE
Make component descriptions consistent

### DIFF
--- a/74xx.dcm
+++ b/74xx.dcm
@@ -199,7 +199,7 @@ F https://assets.nexperia.com/documents/data-sheet/74HC_HCT595.pdf
 $ENDCMP
 #
 $CMP 74LCX07
-D CMOS hex buffer (open drain) with 5 V tolerant inputs
+D CMOS hex buffer (open drain) with 5V tolerant inputs
 K CMOS hex buffer
 F www.st.com/resource/en/datasheet/74lcx07.pdf
 $ENDCMP

--- a/Amplifier_Audio.dcm
+++ b/Amplifier_Audio.dcm
@@ -319,7 +319,7 @@ F http://www.st.com/resource/en/datasheet/cd00000123.pdf
 $ENDCMP
 #
 $CMP TDA2005
-D 20 W Bridge/Stereo Amplifier for Car Radio, TO-220-11
+D 20W Bridge/Stereo Amplifier for Car Radio, TO-220-11
 K audio amplifier
 F http://www.st.com/resource/en/datasheet/cd00000124.pdf
 $ENDCMP
@@ -337,13 +337,13 @@ F http://www.st.com/resource/en/datasheet/cd00000131.pdf
 $ENDCMP
 #
 $CMP TDA7052A
-D 1 W BTL mono audio amplifier with DC volume control, DIP-8/SOIC-8
+D 1W BTL mono audio amplifier with DC volume control, DIP-8/SOIC-8
 K audio amplifier
 F http://www.nxp.com/docs/en/data-sheet/TDA7052A_AT.pdf
 $ENDCMP
 #
 $CMP TDA7264
-D 25 W + 25 W stereo amplifier with mute and standby, TO-220-8
+D 25W + 25W stereo amplifier with mute and standby, TO-220-8
 K audio amplifier 2ch
 F http://www.st.com/resource/en/datasheet/tda7264.pdf
 $ENDCMP
@@ -391,7 +391,7 @@ F http://www.st.com/resource/en/datasheet/tda7269a.pdf
 $ENDCMP
 #
 $CMP TDA7292
-D 40 W + 40 W stereo amplifier with mute and standby, TO-220-11
+D 40W + 40W stereo amplifier with mute and standby, TO-220-11
 K audio amplifier 2ch
 F http://www.st.com/resource/en/datasheet/tda7292.pdf
 $ENDCMP

--- a/Amplifier_Current.dcm
+++ b/Amplifier_Current.dcm
@@ -133,37 +133,37 @@ F http://www.ti.com/lit/ds/symlink/ina181.pdf
 $ENDCMP
 #
 $CMP INA193
-D Current Shunt Monitor −16 V to +80 V Common-Mode Range, 20V/V, SOT-23-5
+D Current Shunt Monitor −16V to +80V Common-Mode Range, 20V/V, SOT-23-5
 K current sense shunt monitor
 F http://www.ti.com/lit/ds/symlink/ina193.pdf
 $ENDCMP
 #
 $CMP INA194
-D Current Shunt Monitor −16 V to +80 V Common-Mode Range, 50V/V, SOT-23-5
+D Current Shunt Monitor −16V to +80V Common-Mode Range, 50V/V, SOT-23-5
 K current sense shunt monitor
 F http://www.ti.com/lit/ds/symlink/ina193.pdf
 $ENDCMP
 #
 $CMP INA195
-D Current Shunt Monitor −16 V to +80 V Common-Mode Range, 100V/V, SOT-23-5
+D Current Shunt Monitor −16V to +80V Common-Mode Range, 100V/V, SOT-23-5
 K current sense shunt monitor
 F http://www.ti.com/lit/ds/symlink/ina193.pdf
 $ENDCMP
 #
 $CMP INA196
-D Current Shunt Monitor −16 V to +80 V Common-Mode Range, 20V/V, SOT-23-5
+D Current Shunt Monitor −16V to +80V Common-Mode Range, 20V/V, SOT-23-5
 K current sense shunt monitor
 F http://www.ti.com/lit/ds/symlink/ina193.pdf
 $ENDCMP
 #
 $CMP INA197
-D Current Shunt Monitor −16 V to +80 V Common-Mode Range, 50V/V, SOT-23-5
+D Current Shunt Monitor −16V to +80V Common-Mode Range, 50V/V, SOT-23-5
 K current sense shunt monitor
 F http://www.ti.com/lit/ds/symlink/ina193.pdf
 $ENDCMP
 #
 $CMP INA198
-D Current Shunt Monitor −16 V to +80 V Common-Mode Range, 100V/V, SOT-23-5
+D Current Shunt Monitor −16V to +80V Common-Mode Range, 100V/V, SOT-23-5
 K current sense shunt monitor
 F http://www.ti.com/lit/ds/symlink/ina193.pdf
 $ENDCMP

--- a/Amplifier_Instrumentation.dcm
+++ b/Amplifier_Instrumentation.dcm
@@ -73,7 +73,7 @@ F https://www.analog.com/media/en/technical-documentation/data-sheets/AD623.pdf
 $ENDCMP
 #
 $CMP AD8230
-D 16 V Rail-to-Rail, Zero-Drift, Precision Instrumentation Amplifier, SOIC-8
+D 16V Rail-to-Rail, Zero-Drift, Precision Instrumentation Amplifier, SOIC-8
 K single instrumentation amplifier
 F https://www.analog.com/media/en/technical-documentation/data-sheets/AD8230.pdf
 $ENDCMP

--- a/Amplifier_Operational.dcm
+++ b/Amplifier_Operational.dcm
@@ -7,13 +7,13 @@ F https://www.analog.com/media/en/technical-documentation/data-sheets/AD797.pdf
 $ENDCMP
 #
 $CMP AD8001AN
-D Current Feedback Amplifier, 800 MHz, 50 mW, DIP-8
+D Current Feedback Amplifier, 800 MHz, 50mW, DIP-8
 K single opamp
 F https://www.analog.com/media/en/technical-documentation/data-sheets/ad8001.pdf
 $ENDCMP
 #
 $CMP AD8001AR
-D Current Feedback Amplifier, 800 MHz, 50 mW, SOIC-8
+D Current Feedback Amplifier, 800 MHz, 50mW, SOIC-8
 K single opamp
 F https://www.analog.com/media/en/technical-documentation/data-sheets/ad8001.pdf
 $ENDCMP
@@ -547,13 +547,13 @@ F https://www.onsemi.com/pub/Collateral/MC33078-D.PDF
 $ENDCMP
 #
 $CMP MC33172
-D Dual Single Supply 3.0 V to 44 V, Low Power Operational Amplifiers, DIP-8/SOIC-8
+D Dual Single Supply 3.0V to 44V, Low Power Operational Amplifiers, DIP-8/SOIC-8
 K dual opamp
 F http://www.onsemi.com/pub/Collateral/MC33171-D.PDF
 $ENDCMP
 #
 $CMP MC33174
-D Quad Single Supply 3.0 V to 44 V, Low Power Operational Amplifiers, DIP-14/SOIC-14/TSSOP-14
+D Quad Single Supply 3.0V to 44V, Low Power Operational Amplifiers, DIP-14/SOIC-14/TSSOP-14
 K quad opamp
 F http://www.onsemi.com/pub/Collateral/MC33171-D.PDF
 $ENDCMP
@@ -1357,13 +1357,13 @@ F http://www.ti.com/lit/ds/symlink/tlv6001.pdf
 $ENDCMP
 #
 $CMP TS881xCx
-D Rail-to-rail 0.9 V nanopower comparator, SC-70-5
+D Rail-to-rail 0.9V nanopower comparator, SC-70-5
 K single comparator
 F http://www.st.com/content/ccc/resource/technical/document/datasheet/a2/60/3e/5d/b2/c1/4a/e9/DM00057901.pdf/files/DM00057901.pdf/jcr:content/translations/en.DM00057901.pdf
 $ENDCMP
 #
 $CMP TS881xLx
-D Rail-to-rail 0.9 V nanopower comparator, SOT-23-5
+D Rail-to-rail 0.9V nanopower comparator, SOT-23-5
 K single comparator
 F www.st.com/resource/en/datasheet/ts881.pdf
 $ENDCMP

--- a/Analog_DAC.dcm
+++ b/Analog_DAC.dcm
@@ -265,13 +265,13 @@ F https://www.analog.com/static/imported-files/data_sheets/AD7228.pdf
 $ENDCMP
 #
 $CMP AD7304
-D 3 V/5 V, Rail-to-Rail, Quad, 8-Bit DAC, SPI Interface, SOIC-16/TSSOP-16
+D 3V/5V, Rail-to-Rail, Quad, 8-Bit DAC, SPI Interface, SOIC-16/TSSOP-16
 K dac 4ch 8bit spi
 F https://www.analog.com/media/en/technical-documentation/data-sheets/AD7304_7305.pdf
 $ENDCMP
 #
 $CMP AD7305
-D 3 V/5 V, Rail-to-Rail, Quad, 8-Bit DAC, Parallel Interface, SOIC-20/TSSOP-20
+D 3V/5V, Rail-to-Rail, Quad, 8-Bit DAC, Parallel Interface, SOIC-20/TSSOP-20
 K dac 4ch 8bit parallel
 F https://www.analog.com/media/en/technical-documentation/data-sheets/AD7304_7305.pdf
 $ENDCMP

--- a/Battery_Management.dcm
+++ b/Battery_Management.dcm
@@ -193,25 +193,25 @@ F https://www.analog.com/media/en/technical-documentation/data-sheets/3652fe.pdf
 $ENDCMP
 #
 $CMP LTC3553
-D Micropower USB Power Manager With Li-Ion Charger, LDO and Buck Regulator, 4.2 V float, QFN-20
+D Micropower USB Power Manager With Li-Ion Charger, LDO and Buck Regulator, 4.2V float, QFN-20
 K USB PMIC
 F https://www.analog.com/media/en/technical-documentation/data-sheets/3553fc.pdf
 $ENDCMP
 #
 $CMP LTC3555
-D High Efficiency USB Power Manager + Triple Step-Down DC/DC, 4.2 V float, QFN-28
+D High Efficiency USB Power Manager + Triple Step-Down DC/DC, 4.2V float, QFN-28
 K USB PMIC
 F https://www.analog.com/media/en/technical-documentation/data-sheets/3555fe.pdf
 $ENDCMP
 #
 $CMP LTC3555-1
-D High Efficiency USB Power Manager + Triple Step-Down DC/DC, instant-on power, 4.2 V float, QFN-28
+D High Efficiency USB Power Manager + Triple Step-Down DC/DC, instant-on power, 4.2V float, QFN-28
 K USB PMIC
 F https://www.analog.com/media/en/technical-documentation/data-sheets/3555fe.pdf
 $ENDCMP
 #
 $CMP LTC3555-3
-D High Efficiency USB Power Manager + Triple Step-Down DC/DC, instant-on power, 4.1 V float, QFN-28
+D High Efficiency USB Power Manager + Triple Step-Down DC/DC, instant-on power, 4.1V float, QFN-28
 K USB PMIC
 F https://www.analog.com/media/en/technical-documentation/data-sheets/3555fe.pdf
 $ENDCMP

--- a/Diode_Laser.dcm
+++ b/Diode_Laser.dcm
@@ -25,7 +25,7 @@ F http://www.osram-os.com/Graphics/XPic2/00227065_0.pdf/PLT5%20510.pdf
 $ENDCMP
 #
 $CMP SPL_PL90
-D Pulsed Laser Diode in Plastic Package 25 W Peak Power
+D Pulsed Laser Diode in Plastic Package 25W Peak Power
 K opto laserdiode
 F http://www.osram-os.com/Graphics/XPic0/00194565_0.pdf/SPL%20PL90.pdf
 $ENDCMP

--- a/Display_Character.dcm
+++ b/Display_Character.dcm
@@ -553,7 +553,7 @@ F http://www.newhavendisplay.com/specs/NHD-0420H1Z-FSW-GBW-33V3.pdf
 $ENDCMP
 #
 $CMP RC1602A
-D LCD 16x2 Alphanumeric gray backlight, 3 or 5 V VDD
+D LCD 16x2 Alphanumeric gray backlight, 3 or 5V VDD
 K display LCD dot-matrix
 F http://www.raystar-optronics.com/down.php?ProID=18
 $ENDCMP

--- a/Driver_FET.dcm
+++ b/Driver_FET.dcm
@@ -811,13 +811,13 @@ F http://www.psemi.com/pdf/datasheets/pe29102ds.pdf
 $ENDCMP
 #
 $CMP PM8834
-D 4 A dual low-side MOSFET driver, SOIC-8
+D 4A dual low-side MOSFET driver, SOIC-8
 K mosfet driver
 F http://www.st.com/resource/en/datasheet/pm8834.pdf
 $ENDCMP
 #
 $CMP PM8834M
-D 4 A dual low-side MOSFET driver, MSOP-8
+D 4A dual low-side MOSFET driver, MSOP-8
 K mosfet driver
 F http://www.st.com/resource/en/datasheet/pm8834.pdf
 $ENDCMP

--- a/Interface.dcm
+++ b/Interface.dcm
@@ -88,7 +88,7 @@ F http://jap.hu/electronic/8255.pdf
 $ENDCMP
 #
 $CMP AD9834
-D 10 bit 75 MHz Complete Direct Digital Synthesizer, 2.3 V to 5.5 V, 20 mW, TSSOP-20
+D 10 bit 75 MHz Complete Direct Digital Synthesizer, 2.3V to 5.5V, 20mW, TSSOP-20
 K Direct Digital Synthesizer DDS
 F https://www.analog.com/static/imported-files/data_sheets/AD9834.pdf
 $ENDCMP
@@ -106,7 +106,7 @@ F https://www.analog.com/media/en/technical-documentation/data-sheets/AD9851.pdf
 $ENDCMP
 #
 $CMP AD9910
-D 1 GSPS, 14-Bit, 3.3 V CMOS, Direct Digital Synthesizer, QFP-100
+D 1 GSPS, 14-Bit, 3.3V CMOS, Direct Digital Synthesizer, QFP-100
 K dds direct digital synthesizer
 F https://www.analog.com/media/en/technical-documentation/data-sheets/AD9910.pdf
 $ENDCMP

--- a/Isolator.dcm
+++ b/Isolator.dcm
@@ -79,85 +79,85 @@ F http://www.onsemi.com/pub/Collateral/HCPL2731-D.pdf
 $ENDCMP
 #
 $CMP ADuM1200AR
-D Dual-channel digital isolator, Bidirectional communication, 3 V/5 V level translation, SOIC-8
+D Dual-channel digital isolator, Bidirectional communication, 3V/5V level translation, SOIC-8
 K Dual-channel digital isolator
 F https://www.analog.com/media/en/technical-documentation/data-sheets/ADuM1200_1201.pdf
 $ENDCMP
 #
 $CMP ADuM1200BR
-D Dual-Channel Digital Isolator, 10Mbps 50ns, bidirectional communication, 3 V/5 V level translation, SOIC-8
+D Dual-Channel Digital Isolator, 10Mbps 50ns, bidirectional communication, 3V/5V level translation, SOIC-8
 K 2Ch Dual Digital Isolator 10Mbps
 F https://www.analog.com/static/imported-files/data_sheets/ADuM1200_1201.pdf
 $ENDCMP
 #
 $CMP ADuM1200CR
-D Dual-Channel Digital Isolator, 25Mbps 45ns, bidirectional communication, 3 V/5 V level translation, SOIC-8
+D Dual-Channel Digital Isolator, 25Mbps 45ns, bidirectional communication, 3V/5V level translation, SOIC-8
 K 2Ch Dual Digital Isolator 25Mbps
 F https://www.analog.com/static/imported-files/data_sheets/ADuM1200_1201.pdf
 $ENDCMP
 #
 $CMP ADuM1200WS
-D Dual-Channel Digital Isolator, 1Mbps 150ns, Highest Tem. Grade, bidirectional communication, 3 V/5 V level translation, SOIC-8
+D Dual-Channel Digital Isolator, 1Mbps 150ns, Highest Tem. Grade, bidirectional communication, 3V/5V level translation, SOIC-8
 K 2Ch Dual Digital Isolator 1Mbps
 F https://www.analog.com/static/imported-files/data_sheets/ADuM1200_1201.pdf
 $ENDCMP
 #
 $CMP ADuM1200WT
-D Dual-Channel Digital Isolator, 10Mbps 50ns, Highest Tem. Grade, bidirectional communication, 3 V/5 V level translation, SOIC-8
+D Dual-Channel Digital Isolator, 10Mbps 50ns, Highest Tem. Grade, bidirectional communication, 3V/5V level translation, SOIC-8
 K 2Ch Dual Digital Isolator 10Mbps
 F https://www.analog.com/static/imported-files/data_sheets/ADuM1200_1201.pdf
 $ENDCMP
 #
 $CMP ADuM1200WU
-D Dual-Channel Digital Isolator, 25Mbps 45ns, Highest Tem. Grade, bidirectional communication, 3 V/5 V level translation, SOIC-8
+D Dual-Channel Digital Isolator, 25Mbps 45ns, Highest Tem. Grade, bidirectional communication, 3V/5V level translation, SOIC-8
 K 2Ch Dual Digital Isolator 25Mbps
 F https://www.analog.com/static/imported-files/data_sheets/ADuM1200_1201.pdf
 $ENDCMP
 #
 $CMP ADuM1201AR
-D Dual-channel digital isolator, bidirectional communication, 3 V/5 V level translation, SOIC-8
+D Dual-channel digital isolator, bidirectional communication, 3V/5V level translation, SOIC-8
 K Dual-channel digital isolator
 F https://www.analog.com/media/en/technical-documentation/data-sheets/ADuM1200_1201.pdf
 $ENDCMP
 #
 $CMP ADuM1201BR
-D Dual-Channel Digital Isolator, 10Mbps 50ns, bidirectional communication, 3 V/5 V level translation, SOIC-8
+D Dual-Channel Digital Isolator, 10Mbps 50ns, bidirectional communication, 3V/5V level translation, SOIC-8
 K 2Ch Dual Digital Isolator 10Mbps
 F https://www.analog.com/static/imported-files/data_sheets/ADuM1200_1201.pdf
 $ENDCMP
 #
 $CMP ADuM1201CR
-D Dual-Channel Digital Isolator, 25Mbps 45ns, bidirectional communication, 3 V/5 V level translation, SOIC-8
+D Dual-Channel Digital Isolator, 25Mbps 45ns, bidirectional communication, 3V/5V level translation, SOIC-8
 K 2Ch Dual Digital Isolator 25Mbps
 F https://www.analog.com/static/imported-files/data_sheets/ADuM1200_1201.pdf
 $ENDCMP
 #
 $CMP ADuM1201WS
-D Dual-Channel Digital Isolator, 1Mbps 150ns, Highest Temp. Grade, bidirectional communication, 3 V/5 V level translation, SOIC-8
+D Dual-Channel Digital Isolator, 1Mbps 150ns, Highest Temp. Grade, bidirectional communication, 3V/5V level translation, SOIC-8
 K 2Ch Dual Digital Isolator 1Mbps
 F https://www.analog.com/static/imported-files/data_sheets/ADuM1200_1201.pdf
 $ENDCMP
 #
 $CMP ADuM1201WT
-D Dual-Channel Digital Isolator, 10Mbps 50ns, Hihgest Temp. Grade, bidirectional communication, 3 V/5 V level translation, SOIC-8
+D Dual-Channel Digital Isolator, 10Mbps 50ns, Hihgest Temp. Grade, bidirectional communication, 3V/5V level translation, SOIC-8
 K 2Ch Dual Digital Isolator 10Mbps
 F https://www.analog.com/static/imported-files/data_sheets/ADuM1200_1201.pdf
 $ENDCMP
 #
 $CMP ADuM1201WU
-D Dual-Channel Digital Isolator, 25Mbps 45ns, Highest Temp. Grade, bidirectional communication, 3 V/5 V level translation, SOIC-8
+D Dual-Channel Digital Isolator, 25Mbps 45ns, Highest Temp. Grade, bidirectional communication, 3V/5V level translation, SOIC-8
 K 2Ch Dual Digital Isolator 25Mbps
 F https://www.analog.com/static/imported-files/data_sheets/ADuM1200_1201.pdf
 $ENDCMP
 #
 $CMP ADuM120N
-D Dual-channel digital isolator,1.8 to 5 V, 150Mbs, 3kV
+D Dual-channel digital isolator,1.8 to 5V, 150Mbs, 3kV
 K Dual-channel digital isolator
 F https://www.analog.com/media/en/technical-documentation/data-sheets/ADuM120N_121N.pdf
 $ENDCMP
 #
 $CMP ADuM121N
-D Dual-channel digital isolator,1.8 to 5 V, 150Mbs, 3kV
+D Dual-channel digital isolator,1.8 to 5V, 150Mbs, 3kV
 K Dual-channel digital isolator
 F https://www.analog.com/media/en/technical-documentation/data-sheets/ADuM120N_121N.pdf
 $ENDCMP

--- a/Logic_LevelTranslator.dcm
+++ b/Logic_LevelTranslator.dcm
@@ -67,37 +67,37 @@ F http://www.ti.com/lit/ds/symlink/txb0102.pdf
 $ENDCMP
 #
 $CMP TXB0104D
-D 4-Bit Bidirectional Voltage-Level Translator, Auto Direction Sensing and ±15-kV ESD Protection, 1.2 - 3.6 V APort, 1.65 - 5.5 V BPort, SOIC-14
+D 4-Bit Bidirectional Voltage-Level Translator, Auto Direction Sensing and ±15-kV ESD Protection, 1.2 - 3.6V APort, 1.65 - 5.5V BPort, SOIC-14
 K Level-Shifter CMOS-TTL-Translation
 F http://www.ti.com/lit/ds/symlink/txb0104.pdf
 $ENDCMP
 #
 $CMP TXB0104PW
-D 4-Bit Bidirectional Voltage-Level Translator, Auto Direction Sensing and ±15-kV ESD Protection, 1.2 - 3.6 V APort, 1.65 - 5.5 V BPort, TSSOP-14
+D 4-Bit Bidirectional Voltage-Level Translator, Auto Direction Sensing and ±15-kV ESD Protection, 1.2 - 3.6V APort, 1.65 - 5.5V BPort, TSSOP-14
 K Level-Shifter CMOS-TTL-Translation
 F http://www.ti.com/lit/ds/symlink/txb0104.pdf
 $ENDCMP
 #
 $CMP TXB0104RGY
-D 4-Bit Bidirectional Voltage-Level Translator, Auto Direction Sensing and ±15-kV ESD Protection, 1.2 - 3.6 V APort, 1.65 - 5.5 V BPort, Texas_PVGFN-14
+D 4-Bit Bidirectional Voltage-Level Translator, Auto Direction Sensing and ±15-kV ESD Protection, 1.2 - 3.6V APort, 1.65 - 5.5V BPort, Texas_PVGFN-14
 K Level-Shifter CMOS-TTL-Translation
 F http://www.ti.com/lit/ds/symlink/txb0104.pdf
 $ENDCMP
 #
 $CMP TXB0104RUT
-D 4-Bit Bidirectional Voltage-Level Translator, Auto Direction Sensing and ±15-kV ESD Protection, 1.2 - 3.6 V APort, 1.65 - 5.5 V BPort, Texas_PUQFN-12
+D 4-Bit Bidirectional Voltage-Level Translator, Auto Direction Sensing and ±15-kV ESD Protection, 1.2 - 3.6V APort, 1.65 - 5.5V BPort, Texas_PUQFN-12
 K Level-Shifter CMOS-TTL-Translation
 F http://www.ti.com/lit/ds/symlink/txb0104.pdf
 $ENDCMP
 #
 $CMP TXB0104YZT
-D 4-Bit Bidirectional Voltage-Level Translator, Auto Direction Sensing and ±15-kV ESD Protection, 1.2 - 3.6 V APort, 1.65 - 5.5 V BPort, DSBGA-12
+D 4-Bit Bidirectional Voltage-Level Translator, Auto Direction Sensing and ±15-kV ESD Protection, 1.2 - 3.6V APort, 1.65 - 5.5V BPort, DSBGA-12
 K Level-Shifter CMOS-TTL-Translation
 F http://www.ti.com/lit/ds/symlink/txb0104.pdf
 $ENDCMP
 #
 $CMP TXB0104ZXU
-D 4-Bit Bidirectional Voltage-Level Translator, Auto Direction Sensing and ±15-kV ESD Protection, 1.2 - 3.6 V APort, 1.65 - 5.5 V BPort, Texas_Junior-12
+D 4-Bit Bidirectional Voltage-Level Translator, Auto Direction Sensing and ±15-kV ESD Protection, 1.2 - 3.6V APort, 1.65 - 5.5V BPort, Texas_Junior-12
 K Level-Shifter CMOS-TTL-Translation
 F http://www.ti.com/lit/ds/symlink/txb0104.pdf
 $ENDCMP

--- a/Reference_Voltage.dcm
+++ b/Reference_Voltage.dcm
@@ -1,31 +1,31 @@
 EESchema-DOCLIB  Version 2.0
 #
 $CMP AD586
-D High Precision, 5 V Reference, DIP-8, SO-8
+D High Precision, 5V Reference, DIP-8, SO-8
 K voltage reference
 F https://www.analog.com/media/en/technical-documentation/data-sheets/AD586.pdf
 $ENDCMP
 #
 $CMP ADR420ARMZ
-D 2.048 V Voltage Reference, Ultraprecision, Low Noise, MSOP-8
+D 2.048V Voltage Reference, Ultraprecision, Low Noise, MSOP-8
 K voltage reference Ultraprecision Low Noise
 F https://www.analog.com/media/en/technical-documentation/data-sheets/adr420_421_423_425.pdf
 $ENDCMP
 #
 $CMP ADR421ARMZ
-D 2.50 V Voltage Reference, Ultraprecision, Low Noise, MSOP-8
-K 2.5 V voltage reference
+D 2.50V Voltage Reference, Ultraprecision, Low Noise, MSOP-8
+K 2.5V voltage reference
 F https://www.analog.com/media/en/technical-documentation/data-sheets/adr420_421_423_425.pdf
 $ENDCMP
 #
 $CMP ADR423ARMZ
-D 3.00 V Voltage Reference, Ultraprecision, Low Noise, MSOP-8
+D 3.00V Voltage Reference, Ultraprecision, Low Noise, MSOP-8
 K 3V voltage reference
 F https://www.analog.com/media/en/technical-documentation/data-sheets/adr420_421_423_425.pdf
 $ENDCMP
 #
 $CMP ADR425ARMZ
-D 5.00 V Voltage Reference, Ultraprecision, Low Noise, MSOP-8
+D 5.00V Voltage Reference, Ultraprecision, Low Noise, MSOP-8
 K 5V voltage reference
 F https://www.analog.com/media/en/technical-documentation/data-sheets/adr420_421_423_425.pdf
 $ENDCMP

--- a/Regulator_Linear.dcm
+++ b/Regulator_Linear.dcm
@@ -1,19 +1,19 @@
 EESchema-DOCLIB  Version 2.0
 #
 $CMP ADP3336ARMZ
-D High Accuracy Ultralow IQ, 500 mA anyCAP Adjustable Low Dropout Regulator, MSOP-8
+D High Accuracy Ultralow IQ, 500mA anyCAP Adjustable Low Dropout Regulator, MSOP-8
 K linear regulator ldo adjustable positive
 F https://www.analog.com/media/en/technical-documentation/data-sheets/ADP3336.pdf
 $ENDCMP
 #
 $CMP ADP7142AUZJ
-D 40 V, 200 mA, Low Noise, CMOS LDO Linear Regulator, TSOT-23-5
+D 40V, 200mA, Low Noise, CMOS LDO Linear Regulator, TSOT-23-5
 K linear regulator ldo adjustable positive
 F https://www.analog.com/media/en/technical-documentation/data-sheets/ADP7142.pdf
 $ENDCMP
 #
 $CMP ADP7182AUZJ
-D -28 V, -200 mA, Low Noise, Linear Regulator, TSOT-23-5
+D -28V, -200mA, Low Noise, Linear Regulator, TSOT-23-5
 K linear regulator ldo adjustable negative
 F https://www.analog.com/media/en/technical-documentation/data-sheets/ADP7182.pdf
 $ENDCMP
@@ -559,721 +559,721 @@ F https://www.diodes.com/assets/Datasheets/AP7361C.pdf
 $ENDCMP
 #
 $CMP APE8865N-12-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-15-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-16-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.6V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.6V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-17-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.7V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.7V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-18-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-19-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.9V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.9V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-20-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.0V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.0V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-21-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.1V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.1V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-22-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.2V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.2V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-23-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.3V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.3V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-24-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.4V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.4V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-25-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-26-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.6V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.6V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-27-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.7V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.7V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-28-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-29-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.9V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.9V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-30-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-31-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.1V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.1V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-32-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.2V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.2V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865N-33-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-12-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-15-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-16-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.6V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.6V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-17-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.7V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.7V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-18-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-19-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.9V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.9V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-20-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.0V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.0V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-21-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.1V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.1V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-22-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.2V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.2V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-23-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.3V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.3V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-24-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.4V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.4V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-25-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-26-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.6V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.6V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-27-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.7V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.7V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-28-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-29-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.9V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.9V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-30-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-31-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.1V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.1V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-32-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.2V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.2V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NL-33-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-12-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-15-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-16-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.6V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.6V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-17-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.7V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.7V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-18-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-19-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.9V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.9V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-20-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.0V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.0V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-21-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.1V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.1V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-22-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.2V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.2V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-23-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.3V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.3V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-24-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.4V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.4V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-25-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-26-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.6V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.6V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-27-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.7V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.7V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-28-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-29-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.9V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.9V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-30-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-31-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.1V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.1V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-32-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.2V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.2V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865NR-33-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-12-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-15-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-16-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.6V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.6V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-17-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.7V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.7V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-18-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-19-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.9V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.9V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-20-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.0V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.0V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-21-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.1V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.1V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-22-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.2V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.2V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-23-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.3V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.3V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-24-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.4V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.4V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-25-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-26-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.6V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.6V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-27-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.7V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.7V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-28-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-29-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.9V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.9V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-30-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-31-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.1V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.1V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-32-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.2V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.2V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U4-33-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SC-70-4
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SC-70-4
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-12-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-15-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-16-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.6V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.6V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-17-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.7V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.7V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-18-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-19-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.9V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.9V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-20-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.0V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.0V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-21-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.1V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.1V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-22-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.2V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.2V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-23-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.3V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.3V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-24-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.4V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.4V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-25-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-26-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.6V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.6V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-27-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.7V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.7V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-28-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-29-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.9V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.9V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-30-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-31-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.1V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.1V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-32-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.2V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.2V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865U5-33-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SC-70-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SC-70-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-12-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-15-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-16-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.6V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.6V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-17-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.7V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.7V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-18-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-19-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.9V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.9V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-20-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.0V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.0V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-21-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.1V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.1V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-22-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.2V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.2V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-23-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.3V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.3V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-24-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.4V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.4V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-25-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-26-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.6V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.6V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-27-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.7V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.7V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-28-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-29-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.9V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.9V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-30-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-31-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.1V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.1V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-32-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.2V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.2V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
 #
 $CMP APE8865Y5-33-HF-3
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.tme.eu/fr/Document/ced3461ed31ea70a3c416fb648e0cde7/APE8865-3.pdf
 $ENDCMP
@@ -1753,163 +1753,163 @@ F http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datas
 $ENDCMP
 #
 $CMP LD39015M08R
-D 150 mA low quiescent current low noise voltage regulator, Fixed Output 0.8V, SOT-23-5
+D 150mA low quiescent current low noise voltage regulator, Fixed Output 0.8V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/resource/en/datasheet/ld39015.pdf
 $ENDCMP
 #
 $CMP LD39015M10R
-D 150 mA low quiescent current low noise voltage regulator, Fixed Output 1.0V, SOT-23-5
+D 150mA low quiescent current low noise voltage regulator, Fixed Output 1.0V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/resource/en/datasheet/ld39015.pdf
 $ENDCMP
 #
 $CMP LD39015M125R
-D 150 mA low quiescent current low noise voltage regulator, Fixed Output 1.25V, SOT-23-5
+D 150mA low quiescent current low noise voltage regulator, Fixed Output 1.25V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/resource/en/datasheet/ld39015.pdf
 $ENDCMP
 #
 $CMP LD39015M12R
-D 150 mA low quiescent current low noise voltage regulator, Fixed Output 1.2V, SOT-23-5
+D 150mA low quiescent current low noise voltage regulator, Fixed Output 1.2V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/resource/en/datasheet/ld39015.pdf
 $ENDCMP
 #
 $CMP LD39015M15R
-D 150 mA low quiescent current low noise voltage regulator, Fixed Output 1.5V, SOT-23-5
+D 150mA low quiescent current low noise voltage regulator, Fixed Output 1.5V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/resource/en/datasheet/ld39015.pdf
 $ENDCMP
 #
 $CMP LD39015M18R
-D 150 mA low quiescent current low noise voltage regulator, Fixed Output 1.8V, SOT-23-5
+D 150mA low quiescent current low noise voltage regulator, Fixed Output 1.8V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/resource/en/datasheet/ld39015.pdf
 $ENDCMP
 #
 $CMP LD39015M25R
-D 150 mA low quiescent current low noise voltage regulator, Fixed Output 2.5V, SOT-23-5
+D 150mA low quiescent current low noise voltage regulator, Fixed Output 2.5V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/resource/en/datasheet/ld39015.pdf
 $ENDCMP
 #
 $CMP LD39015M33R
-D 150 mA low quiescent current low noise voltage regulator, Fixed Output 3.3V, SOT-23-5
+D 150mA low quiescent current low noise voltage regulator, Fixed Output 3.3V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/resource/en/datasheet/ld39015.pdf
 $ENDCMP
 #
 $CMP LD3985G122R_TSOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 1.22V, TSOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 1.22V, TSOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985G18R_TSOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 1.8V, TSOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 1.8V, TSOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985G25R_TSOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 2.5V, TSOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 2.5V, TSOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985G26R_TSOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 2.6V, TSOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 2.6V, TSOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985G27R_TSOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 2.7V, TSOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 2.7V, TSOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985G28R_TSOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 2.8V, TSOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 2.8V, TSOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985G30R_TSOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 3.0V, TSOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 3.0V, TSOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985G33R_TSOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 3.3V, TSOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 3.3V, TSOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985G47R_TSOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 4.7V, TSOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 4.7V, TSOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985M122R_SOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 1.22V, SOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 1.22V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985M18R_SOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985M25R_SOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985M26R_SOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 2.6V, SOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 2.6V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985M27R_SOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 2.7V, SOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 2.7V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985M28R_SOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985M29R_SOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985M30R_SOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985M33R_SOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
 #
 $CMP LD3985M47R_SOT23
-D 150 mA Low Dropout Voltage Regulator, Fixed Output 4.7V, SOT-23-5
+D 150mA Low Dropout Voltage Regulator, Fixed Output 4.7V, SOT-23-5
 K 150mA LDO Regulator Fixed Positive
 F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASHEET/CD00003395.pdf
 $ENDCMP
@@ -4225,163 +4225,163 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/20001826D.pdf
 $ENDCMP
 #
 $CMP MCP1703A-1202_SOT223
-D Low Quiescent Current LDO Regulator, 1.2V, 250 mA, Vin<=16V, SOT-223
+D Low Quiescent Current LDO Regulator, 1.2V, 250mA, Vin<=16V, SOT-223
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-1202_SOT23
-D Low Quiescent Current LDO Regulator, 1.2V, 250 mA, Vin<=16V, SOT-23
+D Low Quiescent Current LDO Regulator, 1.2V, 250mA, Vin<=16V, SOT-23
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-1202_SOT89
-D Low Quiescent Current LDO Regulator, 1.2V, 250 mA, Vin<=16V, SOT-89
+D Low Quiescent Current LDO Regulator, 1.2V, 250mA, Vin<=16V, SOT-89
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-1502_SOT223
-D Low Quiescent Current LDO Regulator, 1.5V, 250 mA, Vin<=16V, SOT-223
+D Low Quiescent Current LDO Regulator, 1.5V, 250mA, Vin<=16V, SOT-223
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-1502_SOT23
-D Low Quiescent Current LDO Regulator, 1.5V, 250 mA, Vin<=16V, SOT-23
+D Low Quiescent Current LDO Regulator, 1.5V, 250mA, Vin<=16V, SOT-23
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-1502_SOT89
-D Low Quiescent Current LDO Regulator, 1.5V, 250 mA, Vin<=16V, SOT-89
+D Low Quiescent Current LDO Regulator, 1.5V, 250mA, Vin<=16V, SOT-89
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-1802_SOT223
-D Low Quiescent Current LDO Regulator, 1.8V, 250 mA, Vin<=16V, SOT-223
+D Low Quiescent Current LDO Regulator, 1.8V, 250mA, Vin<=16V, SOT-223
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-1802_SOT23
-D Low Quiescent Current LDO Regulator, 1.8V, 250 mA, Vin<=16V, SOT-23
+D Low Quiescent Current LDO Regulator, 1.8V, 250mA, Vin<=16V, SOT-23
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-1802_SOT89
-D Low Quiescent Current LDO Regulator, 1.8V, 250 mA, Vin<=16V, SOT-89
+D Low Quiescent Current LDO Regulator, 1.8V, 250mA, Vin<=16V, SOT-89
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-2502_SOT223
-D Low Quiescent Current LDO Regulator, 2.5V, 250 mA, Vin<=16V, SOT-223
+D Low Quiescent Current LDO Regulator, 2.5V, 250mA, Vin<=16V, SOT-223
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-2502_SOT23
-D Low Quiescent Current LDO Regulator, 2.5V, 250 mA, Vin<=16V, SOT-23
+D Low Quiescent Current LDO Regulator, 2.5V, 250mA, Vin<=16V, SOT-23
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-2502_SOT89
-D Low Quiescent Current LDO Regulator, 2.5V, 250 mA, Vin<=16V, SOT-89
+D Low Quiescent Current LDO Regulator, 2.5V, 250mA, Vin<=16V, SOT-89
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-2802_SOT223
-D Low Quiescent Current LDO Regulator, 2.8V, 250 mA, Vin<=16V, SOT-223
+D Low Quiescent Current LDO Regulator, 2.8V, 250mA, Vin<=16V, SOT-223
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-2802_SOT23
-D Low Quiescent Current LDO Regulator, 2.8V, 250 mA, Vin<=16V, SOT-23
+D Low Quiescent Current LDO Regulator, 2.8V, 250mA, Vin<=16V, SOT-23
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-2802_SOT89
-D Low Quiescent Current LDO Regulator, 2.8V, 250 mA, Vin<=16V, SOT-89
+D Low Quiescent Current LDO Regulator, 2.8V, 250mA, Vin<=16V, SOT-89
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-3002_SOT223
-D Low Quiescent Current LDO Regulator, 3.0V, 250 mA, Vin<=16V, SOT-223
+D Low Quiescent Current LDO Regulator, 3.0V, 250mA, Vin<=16V, SOT-223
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-3002_SOT23
-D Low Quiescent Current LDO Regulator, 3.0V, 250 mA, Vin<=16V, SOT-23
+D Low Quiescent Current LDO Regulator, 3.0V, 250mA, Vin<=16V, SOT-23
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-3002_SOT89
-D Low Quiescent Current LDO Regulator, 3.0V, 250 mA, Vin<=16V, SOT-89
+D Low Quiescent Current LDO Regulator, 3.0V, 250mA, Vin<=16V, SOT-89
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-3302_SOT223
-D Low Quiescent Current LDO Regulator, 3.3V, 250 mA, Vin<=16V, SOT-223
+D Low Quiescent Current LDO Regulator, 3.3V, 250mA, Vin<=16V, SOT-223
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-3302_SOT23
-D Low Quiescent Current LDO Regulator, 3.3V, 250 mA, Vin<=16V, SOT-23
+D Low Quiescent Current LDO Regulator, 3.3V, 250mA, Vin<=16V, SOT-23
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-3302_SOT89
-D Low Quiescent Current LDO Regulator, 3.3V, 250 mA, Vin<=16V, SOT-89
+D Low Quiescent Current LDO Regulator, 3.3V, 250mA, Vin<=16V, SOT-89
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-4002_SOT223
-D Low Quiescent Current LDO Regulator, 4.0V, 250 mA, Vin<=16V, SOT-223
+D Low Quiescent Current LDO Regulator, 4.0V, 250mA, Vin<=16V, SOT-223
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-4002_SOT23
-D Low Quiescent Current LDO Regulator, 4.0V, 250 mA, Vin<=16V, SOT-23
+D Low Quiescent Current LDO Regulator, 4.0V, 250mA, Vin<=16V, SOT-23
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-4002_SOT89
-D Low Quiescent Current LDO Regulator, 4.0V, 250 mA, Vin<=16V, SOT-89
+D Low Quiescent Current LDO Regulator, 4.0V, 250mA, Vin<=16V, SOT-89
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-5002_SOT223
-D Low Quiescent Current LDO Regulator, 5.0V, 250 mA, Vin<=16V, SOT-223
+D Low Quiescent Current LDO Regulator, 5.0V, 250mA, Vin<=16V, SOT-223
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-5002_SOT23
-D Low Quiescent Current LDO Regulator, 5.0V, 250 mA, Vin<=16V, SOT-23
+D Low Quiescent Current LDO Regulator, 5.0V, 250mA, Vin<=16V, SOT-23
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
 #
 $CMP MCP1703A-5002_SOT89
-D Low Quiescent Current LDO Regulator, 5.0V, 250 mA, Vin<=16V, SOT-89
+D Low Quiescent Current LDO Regulator, 5.0V, 250mA, Vin<=16V, SOT-89
 K REGULATOR LDO
 F http://ww1.microchip.com/downloads/en/DeviceDoc/20005122B.pdf
 $ENDCMP
@@ -4573,13 +4573,13 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/20002200D.pdf
 $ENDCMP
 #
 $CMP MCP1825S
-D 500 mA, Low-Voltage, Low Quiescent Current LDO Regulator, SOT-223, TO-220, TO-263
+D 500mA, Low-Voltage, Low Quiescent Current LDO Regulator, SOT-223, TO-220, TO-263
 K regulator linear ldo
 F http://ww1.microchip.com/downloads/en/devicedoc/22056b.pdf
 $ENDCMP
 #
 $CMP MCP1826S
-D 1000 mA, Low-Voltage, Low Quiescent Current LDO Regulator, SOT-223, TO-220, TO-263
+D 1000mA, Low-Voltage, Low Quiescent Current LDO Regulator, SOT-223, TO-220, TO-263
 K regulator linear ldo
 F http://ww1.microchip.com/downloads/en/DeviceDoc/22057B.pdf
 $ENDCMP
@@ -5149,85 +5149,85 @@ F http://www.onsemi.com/pub/Collateral/NCP133-D.PDF
 $ENDCMP
 #
 $CMP NCV8114ASN120T1G
-D 300 mA, Low Noise, Linear Regulator with output active discharge function, 1.7-5.5V input voltage range, 1.2V fixed positive output, TSOT-23-5
+D 300mA, Low Noise, Linear Regulator with output active discharge function, 1.7-5.5V input voltage range, 1.2V fixed positive output, TSOT-23-5
 K linear regulator ldo fixed positive
 F https://ru.mouser.com/datasheet/2/308/NCV8114-D-1107616.pdf
 $ENDCMP
 #
 $CMP NCV8114ASN150T1G
-D 300 mA, Low Noise, Linear Regulator with output active discharge function, 1.7-5.5V input voltage range, 1.5V fixed positive output, TSOT-23-5
+D 300mA, Low Noise, Linear Regulator with output active discharge function, 1.7-5.5V input voltage range, 1.5V fixed positive output, TSOT-23-5
 K linear regulator ldo fixed positive
 F https://ru.mouser.com/datasheet/2/308/NCV8114-D-1107616.pdf
 $ENDCMP
 #
 $CMP NCV8114ASN165T1G
-D 300 mA, Low Noise, Linear Regulator with output active discharge function, 1.7-5.5V input voltage range, 1.65V fixed positive output, TSOT-23-5
+D 300mA, Low Noise, Linear Regulator with output active discharge function, 1.7-5.5V input voltage range, 1.65V fixed positive output, TSOT-23-5
 K linear regulator ldo fixed positive
 F https://ru.mouser.com/datasheet/2/308/NCV8114-D-1107616.pdf
 $ENDCMP
 #
 $CMP NCV8114ASN180T1G
-D 300 mA, Low Noise, Linear Regulator with output active discharge function, 1.7-5.5V input voltage range, 1.8V fixed positive output, TSOT-23-5
+D 300mA, Low Noise, Linear Regulator with output active discharge function, 1.7-5.5V input voltage range, 1.8V fixed positive output, TSOT-23-5
 K linear regulator ldo fixed positive
 F https://ru.mouser.com/datasheet/2/308/NCV8114-D-1107616.pdf
 $ENDCMP
 #
 $CMP NCV8114ASN250T1G
-D 300 mA, Low Noise, Linear Regulator with output active discharge function, 1.7-5.5V input voltage range, 2.5V fixed positive output, TSOT-23-5
+D 300mA, Low Noise, Linear Regulator with output active discharge function, 1.7-5.5V input voltage range, 2.5V fixed positive output, TSOT-23-5
 K linear regulator ldo fixed positive
 F https://ru.mouser.com/datasheet/2/308/NCV8114-D-1107616.pdf
 $ENDCMP
 #
 $CMP NCV8114ASN280T1G
-D 300 mA, Low Noise, Linear Regulator with output active discharge function, 1.7-5.5V input voltage range, 2.8V fixed positive output, TSOT-23-5
+D 300mA, Low Noise, Linear Regulator with output active discharge function, 1.7-5.5V input voltage range, 2.8V fixed positive output, TSOT-23-5
 K linear regulator ldo fixed positive
 F https://ru.mouser.com/datasheet/2/308/NCV8114-D-1107616.pdf
 $ENDCMP
 #
 $CMP NCV8114ASN300T1G
-D 300 mA, Low Noise, Linear Regulator with output active discharge function, 1.7-5.5V input voltage range, 3.0V fixed positive output, TSOT-23-5
+D 300mA, Low Noise, Linear Regulator with output active discharge function, 1.7-5.5V input voltage range, 3.0V fixed positive output, TSOT-23-5
 K linear regulator ldo fixed positive
 F https://ru.mouser.com/datasheet/2/308/NCV8114-D-1107616.pdf
 $ENDCMP
 #
 $CMP NCV8114ASN330T1G
-D 300 mA, Low Noise, Linear Regulator with output active discharge function, 1.7-5.5V input voltage range, 3.3V fixed positive output, TSOT-23-5
+D 300mA, Low Noise, Linear Regulator with output active discharge function, 1.7-5.5V input voltage range, 3.3V fixed positive output, TSOT-23-5
 K linear regulator ldo fixed positive
 F https://ru.mouser.com/datasheet/2/308/NCV8114-D-1107616.pdf
 $ENDCMP
 #
 $CMP NCV8114BSN120T1G
-D 300 mA, Low Noise, Linear Regulator without output active discharge function, 1.7-5.5V input voltage range, 1.2V fixed positive output, TSOT-23-5
+D 300mA, Low Noise, Linear Regulator without output active discharge function, 1.7-5.5V input voltage range, 1.2V fixed positive output, TSOT-23-5
 K linear regulator ldo fixed positive
 F https://ru.mouser.com/datasheet/2/308/NCV8114-D-1107616.pdf
 $ENDCMP
 #
 $CMP NCV8114BSN150T1G
-D 300 mA, Low Noise, Linear Regulator without output active discharge function, 1.7-5.5V input voltage range, 1.5V fixed positive output, TSOT-23-5
+D 300mA, Low Noise, Linear Regulator without output active discharge function, 1.7-5.5V input voltage range, 1.5V fixed positive output, TSOT-23-5
 K linear regulator ldo fixed positive
 F https://ru.mouser.com/datasheet/2/308/NCV8114-D-1107616.pdf
 $ENDCMP
 #
 $CMP NCV8114BSN180T1G
-D 300 mA, Low Noise, Linear Regulator without output active discharge function, 1.7-5.5V input voltage range, 1.8V fixed positive output, TSOT-23-5
+D 300mA, Low Noise, Linear Regulator without output active discharge function, 1.7-5.5V input voltage range, 1.8V fixed positive output, TSOT-23-5
 K linear regulator ldo fixed positive
 F https://ru.mouser.com/datasheet/2/308/NCV8114-D-1107616.pdf
 $ENDCMP
 #
 $CMP NCV8114BSN280T1G
-D 300 mA, Low Noise, Linear Regulator without output active discharge function, 1.7-5.5V input voltage range, 2.8V fixed positive output, TSOT-23-5
+D 300mA, Low Noise, Linear Regulator without output active discharge function, 1.7-5.5V input voltage range, 2.8V fixed positive output, TSOT-23-5
 K linear regulator ldo fixed positive
 F https://ru.mouser.com/datasheet/2/308/NCV8114-D-1107616.pdf
 $ENDCMP
 #
 $CMP NCV8114BSN300T1G
-D 300 mA, Low Noise, Linear Regulator without output active discharge function, 1.7-5.5V input voltage range, 3.0V fixed positive output, TSOT-23-5
+D 300mA, Low Noise, Linear Regulator without output active discharge function, 1.7-5.5V input voltage range, 3.0V fixed positive output, TSOT-23-5
 K linear regulator ldo fixed positive
 F https://ru.mouser.com/datasheet/2/308/NCV8114-D-1107616.pdf
 $ENDCMP
 #
 $CMP NCV8114BSN330T1G
-D 300 mA, Low Noise, Linear Regulator without output active discharge function, 1.7-5.5V input voltage range, 3.3V fixed positive output, TSOT-23-5
+D 300mA, Low Noise, Linear Regulator without output active discharge function, 1.7-5.5V input voltage range, 3.3V fixed positive output, TSOT-23-5
 K linear regulator ldo fixed positive
 F https://ru.mouser.com/datasheet/2/308/NCV8114-D-1107616.pdf
 $ENDCMP
@@ -5335,19 +5335,19 @@ F https://www.exar.com/content/document.ashx?id=22106&languageid=1033&type=Datas
 $ENDCMP
 #
 $CMP TC1017-xCT
-D 150 mA, Tiny CMOS LDO With Shutdown, SOT-23-5
+D 150mA, Tiny CMOS LDO With Shutdown, SOT-23-5
 K LDO Linear Voltage Regulator
 F http://ww1.microchip.com/downloads/en/DeviceDoc/21813F.pdf
 $ENDCMP
 #
 $CMP TC1017-xLT
-D 150 mA, Tiny CMOS LDO With Shutdown, SC-70-5
+D 150mA, Tiny CMOS LDO With Shutdown, SC-70-5
 K LDO Linear Voltage Regulator
 F http://ww1.microchip.com/downloads/en/DeviceDoc/21813F.pdf
 $ENDCMP
 #
 $CMP TC1017R-xLT
-D 150 mA, Tiny CMOS LDO With Shutdown, SC-70-5
+D 150mA, Tiny CMOS LDO With Shutdown, SC-70-5
 K LDO Linear Voltage Regulator
 F http://ww1.microchip.com/downloads/en/DeviceDoc/21813F.pdf
 $ENDCMP
@@ -5437,295 +5437,295 @@ F http://www.ti.com/lit/ds/symlink/tlv1117.pdf
 $ENDCMP
 #
 $CMP TLV70012_SOT23-5
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23-5
+D 200mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23-5
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70012_SOT353
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23-5/SC-70-5/SOT-353
+D 200mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23-5/SC-70-5/SOT-353
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70012_WSON6
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 1.2V, WSON6
+D 200mA Low Dropout Voltage Regulator, Fixed Output 1.2V, WSON6
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70013_SOT23-5
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 1.3V, SOT-23-5
+D 200mA Low Dropout Voltage Regulator, Fixed Output 1.3V, SOT-23-5
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70015_SOT23-5
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SOT-23-5
+D 200mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SOT-23-5
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70015_SOT353
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SOT-23-5/SC-70-5/SOT-353
+D 200mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SOT-23-5/SC-70-5/SOT-353
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70015_WSON6
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 1.5V, WSON6
+D 200mA Low Dropout Voltage Regulator, Fixed Output 1.5V, WSON6
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70018_SOT23-5
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SOT-23-5
+D 200mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SOT-23-5
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70018_SOT353
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SC70-5
+D 200mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SC70-5
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70018_WSON6
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 1.8V, WSON6
+D 200mA Low Dropout Voltage Regulator, Fixed Output 1.8V, WSON6
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70019_SOT23-5
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 1.9V, SOT-23-5
+D 200mA Low Dropout Voltage Regulator, Fixed Output 1.9V, SOT-23-5
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70025_SOT23-5
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SOT-23-5
+D 200mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SOT-23-5
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70025_SOT353
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SC70-5
+D 200mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SC70-5
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70025_WSON6
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 2.5V, WSON6
+D 200mA Low Dropout Voltage Regulator, Fixed Output 2.5V, WSON6
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70028_SOT353
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SC70-5
+D 200mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SC70-5
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70028_WSON6
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 2.8V, WSON6
+D 200mA Low Dropout Voltage Regulator, Fixed Output 2.8V, WSON6
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70029_WSON6
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 2.9V, WSON6
+D 200mA Low Dropout Voltage Regulator, Fixed Output 2.9V, WSON6
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70030_SOT23-5
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SOT-23-5
+D 200mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SOT-23-5
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70030_SOT353
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 3V, SC70-5
+D 200mA Low Dropout Voltage Regulator, Fixed Output 3V, SC70-5
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70030_WSON6
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 3V, WSON6
+D 200mA Low Dropout Voltage Regulator, Fixed Output 3V, WSON6
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70031_WSON6
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 3.1V, WSON6
+D 200mA Low Dropout Voltage Regulator, Fixed Output 3.1V, WSON6
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70032_SOT23-5
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 3.2V, SOT-23-5
+D 200mA Low Dropout Voltage Regulator, Fixed Output 3.2V, SOT-23-5
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70033_SOT23-5
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23-5
+D 200mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23-5
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70033_SOT353
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SC70-5
+D 200mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SC70-5
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70033_WSON6
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 3.3V, WSON6
+D 200mA Low Dropout Voltage Regulator, Fixed Output 3.3V, WSON6
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70036_SOT23-5
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 3.6V, SOT-23-5
+D 200mA Low Dropout Voltage Regulator, Fixed Output 3.6V, SOT-23-5
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70036_WSON6
-D 200 mA Low Dropout Voltage Regulator, Fixed Output 3.6V, WSON6
+D 200mA Low Dropout Voltage Regulator, Fixed Output 3.6V, WSON6
 K 200mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv700.pdf
 $ENDCMP
 #
 $CMP TLV70212_SOT23-5
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70215_SOT23-5
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70218_SOT23-5
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70225_SOT23-5
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70225_WSON6
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.5V, WSON6
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.5V, WSON6
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70228_SOT23-5
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70228_WSON6
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.8V, WSON6
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.8V, WSON6
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70229_WSON6
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 2.9V, WSON6
+D 300mA Low Dropout Voltage Regulator, Fixed Output 2.9V, WSON6
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70230_SOT23-5
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70231_SOT23-5
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.1V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.1V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70233_SOT23-5
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70233_WSON6
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.3V, WSON6
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.3V, WSON6
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70235_SOT23-5
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.5V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.5V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70236_WSON6
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.6V, WSON6
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.6V, WSON6
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70237_SOT23-5
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.7V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.7V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70237_WSON6
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 3.7V, WSON6
+D 300mA Low Dropout Voltage Regulator, Fixed Output 3.7V, WSON6
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70242PDSE
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 4.2V, WSON6
+D 300mA Low Dropout Voltage Regulator, Fixed Output 4.2V, WSON6
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV70245_SOT23-5
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 4.5V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 4.5V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV702475_SOT23-5
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 4.75V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 4.75V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv702.pdf
 $ENDCMP
 #
 $CMP TLV71209_SOT23-5
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 0.9V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 0.9V, SOT-23-5
 K LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv712.pdf
 $ENDCMP
 #
 $CMP TLV71210_SOT23-5
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.0V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.0V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv712.pdf
 $ENDCMP
 #
 $CMP TLV71211_SOT23-5
-D 300 mA Low Dropout Voltage Regulator, Fixed Output 1.1V, SOT-23-5
+D 300mA Low Dropout Voltage Regulator, Fixed Output 1.1V, SOT-23-5
 K 300mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv712.pdf
 $ENDCMP
@@ -5797,67 +5797,67 @@ F http://www.ti.com/lit/ds/symlink/tlv713p.pdf
 $ENDCMP
 #
 $CMP TLV75509PDBV
-D 500 mA Low IQ Small Size Low Dropout Voltage Regulator, Fixed Output 0.9V, SOT-23-5
+D 500mA Low IQ Small Size Low Dropout Voltage Regulator, Fixed Output 0.9V, SOT-23-5
 K LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv755p.pdf
 $ENDCMP
 #
 $CMP TLV75510PDBV
-D 500 mA Low IQ Small Size Low Dropout Voltage Regulator, Fixed Output 1.0V, SOT-23-5
+D 500mA Low IQ Small Size Low Dropout Voltage Regulator, Fixed Output 1.0V, SOT-23-5
 K LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv755p.pdf
 $ENDCMP
 #
 $CMP TLV75512PDBV
-D 500 mA Low IQ Small Size Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23-5
+D 500mA Low IQ Small Size Low Dropout Voltage Regulator, Fixed Output 1.2V, SOT-23-5
 K LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv755p.pdf
 $ENDCMP
 #
 $CMP TLV75515PDBV
-D 500 mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SOT-23-5
+D 500mA Low Dropout Voltage Regulator, Fixed Output 1.5V, SOT-23-5
 K LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv755p.pdf
 $ENDCMP
 #
 $CMP TLV75518PDBV
-D 500 mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SOT-23-5
+D 500mA Low Dropout Voltage Regulator, Fixed Output 1.8V, SOT-23-5
 K LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv755p.pdf
 $ENDCMP
 #
 $CMP TLV75519PDBV
-D 500 mA Low Dropout Voltage Regulator, Fixed Output 1.9V, SOT-23-5
+D 500mA Low Dropout Voltage Regulator, Fixed Output 1.9V, SOT-23-5
 K LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv755p.pdf
 $ENDCMP
 #
 $CMP TLV75525PDBV
-D 500 mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SOT-23-5
+D 500mA Low Dropout Voltage Regulator, Fixed Output 2.5V, SOT-23-5
 K LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv755p.pdf
 $ENDCMP
 #
 $CMP TLV75528PDBV
-D 500 mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23-5
+D 500mA Low Dropout Voltage Regulator, Fixed Output 2.8V, SOT-23-5
 K LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv755p.pdf
 $ENDCMP
 #
 $CMP TLV75529PDBV
-D 500 mA Low Dropout Voltage Regulator, Fixed Output 2.9V, SOT-23-5
+D 500mA Low Dropout Voltage Regulator, Fixed Output 2.9V, SOT-23-5
 K LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv755p.pdf
 $ENDCMP
 #
 $CMP TLV75530PDBV
-D 500 mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SOT-23-5
+D 500mA Low Dropout Voltage Regulator, Fixed Output 3.0V, SOT-23-5
 K LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv755p.pdf
 $ENDCMP
 #
 $CMP TLV75533PDBV
-D 500 mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23-5
+D 500mA Low Dropout Voltage Regulator, Fixed Output 3.3V, SOT-23-5
 K LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tlv755p.pdf
 $ENDCMP
@@ -6313,121 +6313,121 @@ F http://www.ti.com/lit/ds/symlink/tps769.pdf
 $ENDCMP
 #
 $CMP TPS77701_HTSSOP20
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Adjustable Output 1.5-5.5V, HTSSOP20
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Adjustable Output 1.5-5.5V, HTSSOP20
 K 750mA LDO Regulator Adjustable Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77701_SO8
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Adjustable Output 1.5-5.5V, SO-8
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Adjustable Output 1.5-5.5V, SO-8
 K 750mA LDO Regulator Adjustable Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77715_HTSSOP20
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 1.5V, HTSSOP20
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 1.5V, HTSSOP20
 K 750mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77715_SO8
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 1.5V, SO-8
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 1.5V, SO-8
 K 750mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77718_HTSSOP20
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 1.8V, HTSSOP20
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 1.8V, HTSSOP20
 K 750mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77718_SO8
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 1.8V, SO-8
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 1.8V, SO-8
 K 750mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77725_HTSSOP20
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 2.5V, HTSSOP20
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 2.5V, HTSSOP20
 K 750mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77725_SO8
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 2.5V, SO-8
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 2.5V, SO-8
 K 750mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77733_HTSSOP20
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 3.3V, HTSSOP20
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 3.3V, HTSSOP20
 K 750mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77733_SO8
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 3.3V, SO-8
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 3.3V, SO-8
 K 750mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77801_HTSSOP20
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Adjustable Output 1.2-5.5V, HTSSOP20
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Adjustable Output 1.2-5.5V, HTSSOP20
 K 750mA LDO Regulator Adjustable Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77801_SO8
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Adjustable Output 1.2-5.5V, SO-8
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Adjustable Output 1.2-5.5V, SO-8
 K 750mA LDO Regulator Adjustable Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77815_HTSSOP20
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 1.5V, HTSSOP20
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 1.5V, HTSSOP20
 K 750mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77815_SO8
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 1.5V, SO-8
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 1.5V, SO-8
 K 750mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77818_HTSSOP20
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 1.8V, HTSSOP20
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 1.8V, HTSSOP20
 K 750mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77818_SO8
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 1.8V, SO-8
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 1.8V, SO-8
 K 750mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77825_HTSSOP20
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 2.5V, HTSSOP20
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 2.5V, HTSSOP20
 K 750mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77825_SO8
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 2.5V, SO-8
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 2.5V, SO-8
 K 750mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77833_HTSSOP20
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 3.3V, HTSSOP20
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 3.3V, HTSSOP20
 K 750mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP
 #
 $CMP TPS77833_SO8
-D 750 mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 3.3V, SO-8
+D 750mA Fast-Transient Low Dropout Voltage Regulator, Fixed Output 3.3V, SO-8
 K 750mA LDO Regulator Fixed Positive
 F http://www.ti.com/lit/ds/symlink/tps777.pdf
 $ENDCMP

--- a/Regulator_SwitchedCapacitor.dcm
+++ b/Regulator_SwitchedCapacitor.dcm
@@ -7,7 +7,7 @@ F http://datasheets.maximintegrated.com/en/ds/ICL7660-MAX1044.pdf
 $ENDCMP
 #
 $CMP LM2776
-D Switched capacitor inverter, inverts positive voltage +2.7 to +5.5V to negative, 200 mA, SOT-23-6
+D Switched capacitor inverter, inverts positive voltage +2.7 to +5.5V to negative, 200mA, SOT-23-6
 K Switched capacitor inverter
 F http://www.ti.com/lit/ds/symlink/lm2776.pdf
 $ENDCMP

--- a/Regulator_Switching.dcm
+++ b/Regulator_Switching.dcm
@@ -175,13 +175,13 @@ F https://www.analog.com/media/en/technical-documentation/data-sheets/ADP5054.pd
 $ENDCMP
 #
 $CMP ADP5070AREZ
-D 1 A/0.6 A DC-to-DC Switching Regulator with Independent Positive and Negative Outputs
+D 1A/0.6A DC-to-DC Switching Regulator with Independent Positive and Negative Outputs
 K voltage regulator switching inverter double positive negative
 F https://www.analog.com/media/en/technical-documentation/data-sheets/ADP5070.pdf
 $ENDCMP
 #
 $CMP ADP5071AREZ
-D 2 A/1.2 A DC-to-DC Switching Regulator with Independent Positive and Negative Outputs
+D 2A/1.2A DC-to-DC Switching Regulator with Independent Positive and Negative Outputs
 K voltage regulator switching inverter double positive negative
 F https://www.analog.com/media/en/technical-documentation/data-sheets/ADP5071.pdf
 $ENDCMP
@@ -1219,49 +1219,49 @@ F http://www.ti.com/lit/ds/symlink/lm2672.pdf
 $ENDCMP
 #
 $CMP LM2674M-12
-D 12V, 500 mA Step-Down Voltage Regulator, SO-8
+D 12V, 500mA Step-Down Voltage Regulator, SO-8
 K Step-Down Voltage Regulator 12V 500mA
 F http://www.ti.com/lit/ds/symlink/lm2674.pdf
 $ENDCMP
 #
 $CMP LM2674M-3.3
-D 3.3V, 500 mA Step-Down Voltage Regulator, SO-8
+D 3.3V, 500mA Step-Down Voltage Regulator, SO-8
 K Step-Down Voltage Regulator
 F http://www.ti.com/lit/ds/symlink/lm2674.pdf
 $ENDCMP
 #
 $CMP LM2674M-5.0
-D 5V, 500 mA Step-Down Voltage Regulator, SO-8
+D 5V, 500mA Step-Down Voltage Regulator, SO-8
 K Step-Down Voltage Regulator
 F http://www.ti.com/lit/ds/symlink/lm2674.pdf
 $ENDCMP
 #
 $CMP LM2674M-ADJ
-D Adjustable Output Voltage, 500 mA Step-Down Voltage Regulator, SO-8
+D Adjustable Output Voltage, 500mA Step-Down Voltage Regulator, SO-8
 K Step-Down Voltage Regulator
 F http://www.ti.com/lit/ds/symlink/lm2674.pdf
 $ENDCMP
 #
 $CMP LM2674N-12
-D 12V, 500 mA Step-Down Voltage Regulator, DIP-8
+D 12V, 500mA Step-Down Voltage Regulator, DIP-8
 K Step-Down Voltage Regulator 12V 500mA
 F http://www.ti.com/lit/ds/symlink/lm2674.pdf
 $ENDCMP
 #
 $CMP LM2674N-3.3
-D 3.3V, 500 mA Step-Down Voltage Regulator, DIP-8
+D 3.3V, 500mA Step-Down Voltage Regulator, DIP-8
 K Step-Down Voltage Regulator
 F http://www.ti.com/lit/ds/symlink/lm2674.pdf
 $ENDCMP
 #
 $CMP LM2674N-5.0
-D 5V, 500 mA Step-Down Voltage Regulator, DIP-8
+D 5V, 500mA Step-Down Voltage Regulator, DIP-8
 K Step-Down Voltage Regulator
 F http://www.ti.com/lit/ds/symlink/lm2674.pdf
 $ENDCMP
 #
 $CMP LM2674N-ADJ
-D Adjustable Output Voltage, 500 mA Step-Down Voltage Regulator, DIP-8
+D Adjustable Output Voltage, 500mA Step-Down Voltage Regulator, DIP-8
 K Step-Down Voltage Regulator
 F http://www.ti.com/lit/ds/symlink/lm2674.pdf
 $ENDCMP
@@ -1423,55 +1423,55 @@ F http://www.ti.com/lit/ds/symlink/lm5001.pdf
 $ENDCMP
 #
 $CMP LM5006MM
-D 600 mA, 80V Constant On-Time Buck Switching Regulator, MSOP-10
+D 600mA, 80V Constant On-Time Buck Switching Regulator, MSOP-10
 K Constant On-Time Buck Switching Regulator
 F http://www.ti.com/lit/ds/symlink/lm5006.pdf
 $ENDCMP
 #
 $CMP LM5007MM
-D 700 mA, High Voltage (80V) Step-Down Switching Regulator, Adjustable Output Voltage, MSOP-8
+D 700mA, High Voltage (80V) Step-Down Switching Regulator, Adjustable Output Voltage, MSOP-8
 K Step-Down Switching Regulator
 F http://www.ti.com/lit/ds/symlink/lm5007.pdf
 $ENDCMP
 #
 $CMP LM5007SD
-D 700 mA, High Voltage (80V) Step-Down Switching Regulator, Adjustable Output Voltage, WSON-8
+D 700mA, High Voltage (80V) Step-Down Switching Regulator, Adjustable Output Voltage, WSON-8
 K Step-Down Switching Regulator
 F http://www.ti.com/lit/ds/symlink/lm5007.pdf
 $ENDCMP
 #
 $CMP LM5008MM
-D 500 mA, High Voltage (100V) Step-Down Switching Regulator, Adjustable Output Voltage, MSOP-8
+D 500mA, High Voltage (100V) Step-Down Switching Regulator, Adjustable Output Voltage, MSOP-8
 K Step-Down Switching Regulator
 F http://www.ti.com/lit/ds/symlink/lm5008.pdf
 $ENDCMP
 #
 $CMP LM5008SD
-D 500 mA, High Voltage (100V) Step-Down Switching Regulator, Adjustable Output Voltage, WSON-8
+D 500mA, High Voltage (100V) Step-Down Switching Regulator, Adjustable Output Voltage, WSON-8
 K Step-Down Switching Regulator
 F http://www.ti.com/lit/ds/symlink/lm5008.pdf
 $ENDCMP
 #
 $CMP LM5009MM
-D 150 mA, High Voltage (80V) Step-Down Switching Regulator, Adjustable Output Voltage, MSOP-8
+D 150mA, High Voltage (80V) Step-Down Switching Regulator, Adjustable Output Voltage, MSOP-8
 K Step-Down Switching Regulator
 F http://www.ti.com/lit/ds/symlink/lm5009.pdf
 $ENDCMP
 #
 $CMP LM5009SD
-D 500 mA, High Voltage (80V) Step-Down Switching Regulator, Adjustable Output Voltage, WSON-8
+D 500mA, High Voltage (80V) Step-Down Switching Regulator, Adjustable Output Voltage, WSON-8
 K Step-Down Switching Regulator
 F http://www.ti.com/lit/ds/symlink/lm5009.pdf
 $ENDCMP
 #
 $CMP LM5017MR
-D 600 mA, 100V Step-Down Switching Regulator, PowerSO-8
+D 600mA, 100V Step-Down Switching Regulator, PowerSO-8
 K Step-Down Switching Regulator High Voltage
 F http://www.ti.com/lit/ds/symlink/lm5017.pdf
 $ENDCMP
 #
 $CMP LM5017SD
-D 600 mA, 100V Step-Down Switching Regulator, WSON-8
+D 600mA, 100V Step-Down Switching Regulator, WSON-8
 K Step-Down Switching Regulator High Voltage
 F http://www.ti.com/lit/ds/symlink/lm5017.pdf
 $ENDCMP
@@ -3817,13 +3817,13 @@ F http://www.st.com/internet/com/TECHNICAL_RESOURCES/TECHNICAL_LITERATURE/DATASH
 $ENDCMP
 #
 $CMP TL497
-D 500 mA step up/step down/inverting switching voltage regulator, SIP-14/SOIC-14(W)
+D 500mA step up/step down/inverting switching voltage regulator, SIP-14/SOIC-14(W)
 K buck regulator
 F http://www.ti.com/lit/ds/symlink/tl497a.pdf
 $ENDCMP
 #
 $CMP TL497A
-D 500 mA step up/step down switching regulator
+D 500mA step up/step down switching regulator
 K buck regulator
 F http://www.ti.com/lit/ds/symlink/tl497a.pdf
 $ENDCMP

--- a/Relay.dcm
+++ b/Relay.dcm
@@ -73,13 +73,13 @@ F http://gfinder.findernet.com/assets/Series/355/S32EN.pdf
 $ENDCMP
 #
 $CMP FINDER-34.51
-D Ultra-slim 1 Pole - 6 A SPDT relay
+D Ultra-slim 1 Pole - 6A SPDT relay
 K Single Pole Relay SPDT
 F https://gfinder.findernet.com/public/attachments/34/EN/S34USAEN.pdf
 $ENDCMP
 #
 $CMP FINDER-34.51.7xxx.x019
-D Ultra-slim 1 Pole - 6 A SPDT relay
+D Ultra-slim 1 Pole - 6A SPDT relay
 K Single Pole Relay SPDT
 F https://gfinder.findernet.com/public/attachments/34/EN/S34USAEN.pdf
 $ENDCMP

--- a/Relay_SolidState.dcm
+++ b/Relay_SolidState.dcm
@@ -1,19 +1,19 @@
 EESchema-DOCLIB  Version 2.0
 #
 $CMP 34.81-7048
-D Ultra-Slim Solid-State Relay, 0.1 A, 48 V DC output switching
+D Ultra-Slim Solid-State Relay, 0.1A, 48V DC output switching
 K NPN DC Optocoupler
 F http://www.us.liteon.com/downloads/LTV-817-827-847.PDF
 $ENDCMP
 #
 $CMP 34.81-8240
-D Ultra-slim - Solid State Relay, 2A, 240 V AC output, Zero crossing switching
+D Ultra-slim - Solid State Relay, 2A, 240V AC output, Zero crossing switching
 K Photo-Triac Opto Triac
 F https://gfinder.findernet.com/public/attachments/34/EN/S34USAEN.pdf
 $ENDCMP
 #
 $CMP 34.81-9024
-D Ultra-Slim Solid-State Relay, 2 A, 24 V DC output switching
+D Ultra-Slim Solid-State Relay, 2A, 24V DC output switching
 K NPN DC Optocoupler
 F http://www.us.liteon.com/downloads/LTV-817-827-847.PDF
 $ENDCMP

--- a/Timer.dcm
+++ b/Timer.dcm
@@ -301,19 +301,19 @@ F http://www.ti.com/lit/ds/symlink/tlc555.pdf
 $ENDCMP
 #
 $CMP TPL5010
-D Timer, Nano Power, Watchdog, 35 nA, 100 ms to 7200 s, VDD 1.8 V to 5.5 V, Iout max 1 mA
+D Timer, Nano Power, Watchdog, 35 nA, 100 ms to 7200 s, VDD 1.8V to 5.5V, Iout max 1mA
 K timer watchdog nano wake done
 F http://www.ti.com/lit/ds/symlink/tpl5010.pdf
 $ENDCMP
 #
 $CMP TPL5110
-D Timer, Nano Power, Active-Low, 35 nA, 100 ms to 7200 s, VDD 1.8 V to 5.5 V, Iout max 1 mA, SOT-23-6
+D Timer, Nano Power, Active-Low, 35 nA, 100 ms to 7200 s, VDD 1.8V to 5.5V, Iout max 1mA, SOT-23-6
 K timer active-low nano wake done
 F http://www.ti.com/lit/ds/symlink/tpl5110.pdf
 $ENDCMP
 #
 $CMP TPL5111
-D Timer, Nano Power, Active-High, 35 nA, 100 ms to 7200 s, VDD 1.8 V to 5.5 V, Iout max 1 mA, SOT-23-6
+D Timer, Nano Power, Active-High, 35 nA, 100 ms to 7200 s, VDD 1.8V to 5.5V, Iout max 1mA, SOT-23-6
 K timer active-high nano wake done
 F http://www.ti.com/lit/ds/symlink/tpl5111.pdf
 $ENDCMP

--- a/Transistor_FET.dcm
+++ b/Transistor_FET.dcm
@@ -1,32 +1,32 @@
 EESchema-DOCLIB  Version 2.0
 #
 $CMP 2N7000
-D 200V Vds, N-Channel MOSFET, 2.6V Logic Level, TO-92
+D 0.2A Id, 200V Vds, N-Channel MOSFET, 2.6V Logic Level, TO-92
 K N-Channel MOSFET Logic-Level
 F https://www.fairchildsemi.com/datasheets/2N/2N7000.pdf
 $ENDCMP
 #
 $CMP 2N7002
-D 0.115A Id, 60V Vds, N-channel MOSFET, SOT-23
+D 0.115A Id, 60V Vds, N-Channel MOSFET, SOT-23
 K N-Channel Switching MOSFET
 F https://www.fairchildsemi.com/datasheets/2N/2N7002.pdf
 $ENDCMP
 #
 $CMP 2N7002E
-D 0.24 A Id, 60 V Vds, N-Channel MOSFET, SOT-23
+D 0.24A Id, 60V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ds30376.pdf
 $ENDCMP
 #
 $CMP 2N7002H
-D 0.21 A Id, 60 V Vds, N-Channel MOSFET, SOT-23
+D 0.21A Id, 60V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/2N7002H.pdf
 $ENDCMP
 #
 $CMP 3SK263
 D 30mA Id, 15V Vds, N-Channel Dual Gate MOSFET, SOT-143/343
-K NMOS Dual Gate
+K N-Channel MOSFET Dual Gate
 F http://www.onsemi.com/pub_link/Collateral/EN4423-D.PDF
 $ENDCMP
 #
@@ -103,7 +103,7 @@ F http://www.fairchildsemi.com/ds/BS/BS170.pdf
 $ENDCMP
 #
 $CMP BS170F
-D 0.15 A Id, 60 V Vds, N-Channel MOSFET, SOT-23
+D 0.15A Id, 60V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/BS170F.pdf
 $ENDCMP
@@ -115,7 +115,7 @@ F http://www.vishay.com/docs/70209/70209.pdf
 $ENDCMP
 #
 $CMP BS870
-D 0.25 A Id, 60 V Vds, N-Channel MOSFET, SOT-23
+D 0.25A Id, 60V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ds11302.pdf
 $ENDCMP
@@ -409,7 +409,7 @@ F https://www.infineon.com/dgdl/Infineon-BSF450NE7NH3-DS-v02_02-EN.pdf?fileId=db
 $ENDCMP
 #
 $CMP BSN20
-D 0.5 A Id, 50 V Vds, N-Channel MOSFET, SOT-23
+D 0.5A Id, 50V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ds31898.pdf
 $ENDCMP
@@ -421,25 +421,25 @@ F https://www.infineon.com/dgdl/Infineon-BSP129-DS-v01_42-en.pdf?fileId=db3a3043
 $ENDCMP
 #
 $CMP BSS123
-D 0.17 A Id, 100 V Vds, N-Channel MOSFET, SOT-23
+D 0.17A Id, 100V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ds30366.pdf
 $ENDCMP
 #
 $CMP BSS127S
-D 0.07 A Id, 600 V Vds, N-Channel MOSFET, SOT-23
+D 0.07A Id, 600V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/BSS127.pdf
 $ENDCMP
 #
 $CMP BSS138
-D 50V Vds, 0.22A Id, N-channel MOSFET, SOT-23
+D 50V Vds, 0.22A Id, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F https://www.fairchildsemi.com/datasheets/BS/BSS138.pdf
 $ENDCMP
 #
 $CMP BSS214NW
-D 20V Vds, 1.5A Id, N-channel MOSFET, SOT-323
+D 20V Vds, 1.5A Id, N-Channel MOSFET, SOT-323
 K N-Channel MOSFET
 F https://www.infineon.com/dgdl/Infineon-BSS214NW-DS-v02_02-en.pdf?fileId=db3a30431b3e89eb011b695aebc01bde
 $ENDCMP
@@ -703,127 +703,127 @@ F http://www.fairchildsemi.com/ds/BU/BUZ11.pdf
 $ENDCMP
 #
 $CMP C2M0025120D
-D 90A Id, 1200V Vds, 25mOhm, N-channel SiC MOSFET, TO-247
+D 90A Id, 1200V Vds, 25mOhm, N-Channel SiC MOSFET, TO-247
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/161/C2M0025120D.pdf
 $ENDCMP
 #
 $CMP C2M0040120D
-D 60A Id, 1200V Vds, 40mOhm, N-channel SiC MOSFET, TO-247
+D 60A Id, 1200V Vds, 40mOhm, N-Channel SiC MOSFET, TO-247
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/165/C2M0040120D.pdf
 $ENDCMP
 #
 $CMP C2M0045170D
-D 72A Id, 1700V Vds, 45mOhm, N-channel SiC MOSFET, TO-247
+D 72A Id, 1700V Vds, 45mOhm, N-Channel SiC MOSFET, TO-247
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/960/C2M0045170D.000.pdf
 $ENDCMP
 #
 $CMP C2M0080120D
-D 36A Id, 1200V Vds, 80mOhm, N-channel SiC MOSFET, TO-247
+D 36A Id, 1200V Vds, 80mOhm, N-Channel SiC MOSFET, TO-247
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/167/C2M0080120D.pdf
 $ENDCMP
 #
 $CMP C2M0160120D
-D 19A Id, 1200V Vds, 160mOhm, N-channel SiC MOSFET, TO-247
+D 19A Id, 1200V Vds, 160mOhm, N-Channel SiC MOSFET, TO-247
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/169/C2M0160120D.pdf
 $ENDCMP
 #
 $CMP C2M0280120D
-D 10A Id, 1200V Vds, 280mOhm, N-channel SiC MOSFET, TO-247
+D 10A Id, 1200V Vds, 280mOhm, N-Channel SiC MOSFET, TO-247
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/171/C2M0280120D.pdf
 $ENDCMP
 #
 $CMP C2M1000170D
-D 5A Id, 1700V Vds, 1000mOhm, N-channel SiC MOSFET, TO-247
+D 5A Id, 1700V Vds, 1000mOhm, N-Channel SiC MOSFET, TO-247
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/173/C2M1000170D.pdf
 $ENDCMP
 #
 $CMP C2M1000170J
-D 5.3A Id, 1700V Vds, 1000mOhm, N-channel SiC MOSFET, TO-263-7
+D 5.3A Id, 1700V Vds, 1000mOhm, N-Channel SiC MOSFET, TO-263-7
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/820/C2M1000170J.pdf
 $ENDCMP
 #
 $CMP C3M0030090K
-D 63A Id, 900V Vds, 30mOhm, N-channel SiC MOSFET, TO-247-4
+D 63A Id, 900V Vds, 30mOhm, N-Channel SiC MOSFET, TO-247-4
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/1185/C3M0030090K.pdf
 $ENDCMP
 #
 $CMP C3M0065090D
-D 36A Id, 900V Vds, 65mOhm, N-channel SiC MOSFET, TO-247
+D 36A Id, 900V Vds, 65mOhm, N-Channel SiC MOSFET, TO-247
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/176/C3M0065090D.pdf
 $ENDCMP
 #
 $CMP C3M0065090J
-D 35A Id, 900V Vds, 65mOhm, N-channel SiC MOSFET, TO-263-7
+D 35A Id, 900V Vds, 65mOhm, N-Channel SiC MOSFET, TO-263-7
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/145/C3M0065090J.pdf
 $ENDCMP
 #
 $CMP C3M0065100J
-D 35A Id, 1000V Vds, 65mOhm, N-channel SiC MOSFET, TO-263-7
+D 35A Id, 1000V Vds, 65mOhm, N-Channel SiC MOSFET, TO-263-7
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/958/C3M0065100J.pdf
 $ENDCMP
 #
 $CMP C3M0065100K
-D 35A Id, 1000V Vds, 65mOhm, N-channel SiC MOSFET, TO-247-4
+D 35A Id, 1000V Vds, 65mOhm, N-Channel SiC MOSFET, TO-247-4
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/961/C3M0065100K.pdf
 $ENDCMP
 #
 $CMP C3M0075120J
-D 30A Id, 1200V Vds, 75mOhm, N-channel SiC MOSFET, TO-263-7
+D 30A Id, 1200V Vds, 75mOhm, N-Channel SiC MOSFET, TO-263-7
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/997/C3M0075120J.pdf
 $ENDCMP
 #
 $CMP C3M0075120K
-D 30A Id, 1200V Vds, 75mOhm, N-channel SiC MOSFET, TO-247-4
+D 30A Id, 1200V Vds, 75mOhm, N-Channel SiC MOSFET, TO-247-4
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/959/c3m0075120k.pdf
 $ENDCMP
 #
 $CMP C3M0120090D
-D 23A Id, 900V Vds, 120mOhm, N-channel SiC MOSFET, TO-247
+D 23A Id, 900V Vds, 120mOhm, N-Channel SiC MOSFET, TO-247
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/824/C3M0120090D.pdf
 $ENDCMP
 #
 $CMP C3M0120090J
-D 22A Id, 900V Vds, 120mOhm, N-channel SiC MOSFET, TO-263-7
+D 22A Id, 900V Vds, 120mOhm, N-Channel SiC MOSFET, TO-263-7
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/834/C3M0120090J.pdf
 $ENDCMP
 #
 $CMP C3M0120100J
-D 22A Id, 1000V Vds, 120mOhm, N-channel SiC MOSFET, TO-263-7
+D 22A Id, 1000V Vds, 120mOhm, N-Channel SiC MOSFET, TO-263-7
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/957/C3M0120100J.pdf
 $ENDCMP
 #
 $CMP C3M0120100K
-D 22A Id, 1000V Vds, 120mOhm, N-channel SiC MOSFET, TO-247-4
+D 22A Id, 1000V Vds, 120mOhm, N-Channel SiC MOSFET, TO-247-4
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/962/C3M0120100K.pdf
 $ENDCMP
 #
 $CMP C3M0280090D
-D 11.5A Id, 900V Vds, 280mOhm, N-channel SiC MOSFET, TO-247
+D 11.5A Id, 900V Vds, 280mOhm, N-Channel SiC MOSFET, TO-247
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/825/C3M0280090D.pdf
 $ENDCMP
 #
 $CMP C3M0280090J
-D 11.5A Id, 900V Vds, 280mOhm, N-channel SiC MOSFET, TO-263-7
+D 11.5A Id, 900V Vds, 280mOhm, N-Channel SiC MOSFET, TO-263-7
 K N-Channel SiC MOSFET
 F https://www.wolfspeed.com/media/downloads/835/C3M0280090J.pdf
 $ENDCMP
@@ -1231,169 +1231,169 @@ F https://www.ti.com/lit/ds/slps234b/slps234b.pdf
 $ENDCMP
 #
 $CMP DMG2302U
-D 4.2 A Id, 20 V Vds, N-Channel MOSFET, SOT-23
+D 4.2A Id, 20V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMG2302U.pdf
 $ENDCMP
 #
 $CMP DMG3402L
-D 4 A Id, 30 V Vds, N-Channel MOSFET, SOT-23
+D 4A Id, 30V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMG3402L.pdf
 $ENDCMP
 #
 $CMP DMG3404L
-D 5.8 A Id, 30 V Vds, N-Channel MOSFET, SOT-23
+D 5.8A Id, 30V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMG3404L.pdf
 $ENDCMP
 #
 $CMP DMG3406L
-D 3.6 A Id, 30 V Vds, N-Channel MOSFET, SOT-23
+D 3.6A Id, 30V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMG3406L.pdf
 $ENDCMP
 #
 $CMP DMG3414U
-D 4.2 A Id, 20 V Vds, N-Channel MOSFET, SOT-23
+D 4.2A Id, 20V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ds31739.pdf
 $ENDCMP
 #
 $CMP DMG3418L
-D 4 A Id, 30 V Vds, N-Channel MOSFET, SOT-23
+D 4A Id, 30V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMG3418L.pdf
 $ENDCMP
 #
 $CMP DMN10H220L
-D 1.6 A Id, 100 V Vds, N-Channel MOSFET, SOT-23
+D 1.6A Id, 100V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMN10H220L.pdf
 $ENDCMP
 #
 $CMP DMN10H700S
-D 0.7 A Id, 100 V Vds, N-Channel MOSFET, SOT-23
+D 0.7A Id, 100V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMN10H700S.pdf
 $ENDCMP
 #
 $CMP DMN13H750S
-D 1 A Id, 130 V Vds, N-Channel MOSFET, SOT-23
+D 1A Id, 130V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMN13H750S.pdf
 $ENDCMP
 #
 $CMP DMN2041L
-D 6.4 A Id, 20 V Vds, N-Channel MOSFET, SOT-23
+D 6.4A Id, 20V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F https://www.diodes.com/assets/Datasheets/products_inactive_data/DMN2041L.pdf
 $ENDCMP
 #
 $CMP DMN2050L
-D 5.9 A Id, 20 V Vds, N-Channel MOSFET, SOT-23
+D 5.9A Id, 20V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ds31502.pdf
 $ENDCMP
 #
 $CMP DMN2056U
-D 4 A Id, 20 V Vds, N-Channel MOSFET, SOT-23
+D 4A Id, 20V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMN2056U.pdf
 $ENDCMP
 #
 $CMP DMN2058U
-D 4.6 A Id, 20 V Vds, N-Channel MOSFET, SOT-23
+D 4.6A Id, 20V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMN2058U.pdf
 $ENDCMP
 #
 $CMP DMN2075U
-D 4.2 A Id, 20 V Vds, N-Channel MOSFET, SOT-23
+D 4.2A Id, 20V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMN2075U.pdf
 $ENDCMP
 #
 $CMP DMN2230U
-D 2 A Id, 20 V Vds, N-Channel MOSFET, SOT-23
+D 2A Id, 20V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ds31180.pdf
 $ENDCMP
 #
 $CMP DMN24H11DS
-D 0.27 A Id, 240 V Vds, N-Channel MOSFET, SOT-23
+D 0.27A Id, 240V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMN24H11DS.pdf
 $ENDCMP
 #
 $CMP DMN24H3D5L
-D 0.48 A Id, 240 V Vds, N-Channel MOSFET, SOT-23
+D 0.48A Id, 240V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMN24H3D5L.pdf
 $ENDCMP
 #
 $CMP DMN3042L
-D 5.8 A Id, 30 V Vds, N-Channel MOSFET, SOT-23
+D 5.8A Id, 30V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMN3042L.pdf
 $ENDCMP
 #
 $CMP DMN3051L
-D 5.8 A Id, 30 V Vds, N-Channel MOSFET, SOT-23
+D 5.8A Id, 30V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ds31347.pdf
 $ENDCMP
 #
 $CMP DMN30H4D0L
-D 0.25 A Id, 300 V Vds, N-Channel MOSFET, SOT-23
+D 0.25A Id, 300V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMN30H4D0L.pdf
 $ENDCMP
 #
 $CMP DMN3110S
-D 3.3 A Id, 30 V Vds, N-Channel MOSFET, SOT-23
+D 3.3A Id, 30V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMN3110S.pdf
 $ENDCMP
 #
 $CMP DMN3150L
-D 3.8 A Id, 30 V Vds, N-Channel MOSFET, SOT-23
+D 3.8A Id, 30V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ds31126.pdf
 $ENDCMP
 #
 $CMP DMN3300U
-D 2 A Id, 30 V Vds, N-Channel MOSFET, SOT-23
+D 2A Id, 30V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ds31181.pdf
 $ENDCMP
 #
 $CMP DMN3404L
-D 5.8 A Id, 30 V Vds, N-Channel MOSFET, SOT-23
+D 5.8A Id, 30V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ds31787.pdf
 $ENDCMP
 #
 $CMP DMN6075S
-D 2.5 A Id, 60 V Vds, N-Channel MOSFET, SOT-23
+D 2.5A Id, 60V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMN6075S.pdf
 $ENDCMP
 #
 $CMP DMN6140L
-D 2.3 A Id, 60 V Vds, N-Channel MOSFET, SOT-23
+D 2.3A Id, 60V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMN6140L.pdf
 $ENDCMP
 #
 $CMP DMN67D7L
-D 0.21 A Id, 60 V Vds, N-Channel MOSFET, SOT-23
+D 0.21A Id, 60V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMN67D7L.pdf
 $ENDCMP
 #
 $CMP DMN67D8L
-D 0.21 A Id, 60 V Vds, N-Channel MOSFET, SOT-23
+D 0.21A Id, 60V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/DMN67D8L.pdf
 $ENDCMP
@@ -1424,127 +1424,127 @@ $ENDCMP
 #
 $CMP FDMS8050
 D 55A Id, 30V Vds, N-Channel PowerTrench MOSFET, 0.65mOhm Ron, 285nC Qgmax, -55 to 150 °C, 5x6mm SON8
-K powertrench mosfet fairchild
+K powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMS8050.pdf
 $ENDCMP
 #
 $CMP FDMS8050ET30
 D 55A Id, 30V Vds, N-Channel PowerTrench MOSFET, 0.65mOhm Ron, 285nC Qgmax, -55 to 175 °C, 5x6mm SON8
-K powertrench mosfet fairchild
+K powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMS8050ET30.pdf
 $ENDCMP
 #
 $CMP FDMS8350L
 D 47A Id, 40V Vds, N-Channel PowerTrench MOSFET, 0.85mOhm Ron, 242nC Qgmax, -55 to 150 °C, 5x6mm SON8
-K powertrench mosfet fairchild
+K powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMS8350L.pdf
 $ENDCMP
 #
 $CMP FDMS8350LET40
 D 49A Id, 40V Vds, N-Channel PowerTrench MOSFET, 0.85mOhm Ron, 242nC Qgmax, -55 to 175 °C, 5x6mm SON8
-K powertrench-mosfet mosfet fairchild
+K powertrench-MOSFET MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMS8350LET40.pdf
 $ENDCMP
 #
 $CMP FDMS86150
 D 16A Id, 100V Vds, N-Channel PowerTrench MOSFET, 4.85mOhm Ron, 62nC Qgmax, -55 to 150 °C, 5x6mm SON8
-K powertrench mosfet fairchild
+K powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMS86150.pdf
 $ENDCMP
 #
 $CMP FDMS86150ET100
 D 16A Id, 100V Vds, N-Channel PowerTrench MOSFET, 4.85mOhm Ron, 62nC Qgmax, -55 to 175 °C, 5x6mm SON8
-K powertrench-mosfet mosfet fairchild
+K powertrench-MOSFET MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMS86150ET100.pdf
 $ENDCMP
 #
 $CMP FDMS86152
 D 14A Id, 100V Vds, N-Channel PowerTrench MOSFET, 6mOhm Ron, 50nC Qgmax, -55 to 150 °C, 5x6mm SON8
-K powertrench mosfet fairchild
+K powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMS86152.pdf
 $ENDCMP
 #
 $CMP FDMS86202
 D 13.5A Id, 120V Vds, N-Channel Shielded Gate PowerTrench MOSFET, 7.2mOhm Ron, 64nC Qgmax, -55 to 150 °C, 5x6mm SON8
-K shielded-gate-powertrench mosfet fairchild
+K shielded-gate-powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMS86202.pdf
 $ENDCMP
 #
 $CMP FDMS86202ET120
 D 13.5A Id, 120V Vds, N-Channel Shielded Gate PowerTrench MOSFET, 7.2mOhm Ron, 64nC Qgmax, -55 to 175 °C, 5x6mm SON8
-K shielded-gate-powertrench mosfet fairchild
+K shielded-gate-powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMS86202ET120.pdf
 $ENDCMP
 #
 $CMP FDMS86255
 D 10A Id, 150V Vds, N-Channel Shielded Gate PowerTrench MOSFET, 12.4mOhm Ron, 63nC Qgmax, -55 to 150 °C, 5x6mm SON8
-K shielded-gate-powertrench-mosfet mosfet fairchild
+K shielded-gate-powertrench-MOSFET MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMS86255.pdf
 $ENDCMP
 #
 $CMP FDMS86255ET150
 D 10A Id, 150V Vds, N-Channel Shielded Gate PowerTrench MOSFET, 12.4mOhm Ron, 63nC Qgmax, -55 to 175 °C, 5x6mm SON8
-K shielded-gate-powertrench mosfet fairchild
+K shielded-gate-powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMS86255ET150.pdf
 $ENDCMP
 #
 $CMP FDMS86350
 D 25A Id, 80V Vds, N-Channel PowerTrench MOSFET, 2.4mOhm Ron, 155nC Qgmax, -55 to 150 °C, 5x6mm SON8
-K powertrench mosfet fairchild
+K powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMS86350.pdf
 $ENDCMP
 #
 $CMP FDMS86350ET80
 D 25A Id, 80V Vds, N-Channel PowerTrench MOSFET, 2.4mOhm Ron, 155nC Qgmax, -55 to 175 °C, 5x6mm SON8
-K powertrench mosfet fairchild
+K powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMS86350ET80.pdf
 $ENDCMP
 #
 $CMP FDMS86550
 D 32A Id, 60V Vds, N-Channel PowerTrench MOSFET, 1.65mOhm Ron, 154nC Qgmax, -55 to 150 °C, 5x6mm SON8
-K powertrench mosfet fairchild
+K powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMS86550.pdf
 $ENDCMP
 #
 $CMP FDMS86550ET60
 D 32A Id, 60V Vds, N-Channel PowerTrench MOSFET, 1.65mOhm Ron, 154nC Qgmax, -55 to 175 °C, 5x6mm SON8
-K powertrench mosfet fairchild
+K powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMS86550ET60.pdf
 $ENDCMP
 #
 $CMP FDMT800100DC
 D 24A Id, 100V Vds, N-Channel Dual Cool PowerTrench MOSFET, 2.95mOhm Ron, 111nC Qgmax, -55 to 150 °C, 5x6mm SON8
-K dual-cool-powertrench mosfet fairchild
+K dual-cool-powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMT800100DC.pdf
 $ENDCMP
 #
 $CMP FDMT800120DC
 D 20A Id, 120V Vds, N-Channel Dual cool 88 PowerTrench MOSFET, 4.2mOhm Ron, 107nC Qgmax, -55 to 150 °C, 5x6mm SON8
-K dual-cool-powertrench mosfet fairchild
+K dual-cool-powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMT800120DC.pdf
 $ENDCMP
 #
 $CMP FDMT800150DC
 D 15A Id, 150V Vds, N-Channel Dual cool PowerTrench MOSFET, 6.5mOhm Ron, 108nC Qgmax, -55 to 150 °C, 5x6mm SON8
-K dual-cool-powertrench mosfet fairchild
+K dual-cool-powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMT800150DC.pdf
 $ENDCMP
 #
 $CMP FDMT800152DC
 D 13A Id, 150V Vds, N-Channel Dual Cool PowerTrench MOSFET, 9.0mOhm Ron, 83nC Qgmax, -55 to 150 °C, 5x6mm SON8
-K dual-cool-powertrench mosfet fairchild
+K dual-cool-powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMT800152DC.pdf
 $ENDCMP
 #
 $CMP FDMT80060DC
 D 43A Id, 60V Vds, N-Channel Dual Cool PowerTrench MOSFET, 1.1mOhm Ron, 238nC Qgmax, -55 to 150 °C, 5x6mm SON8
-K dual-cool-powertrench mosfet fairchild
+K dual-cool-powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMT80060DC.pdf
 $ENDCMP
 #
 $CMP FDMT80080DC
 D 36A Id, 80V Vds, N-Channel Dual Cool PowerTrench MOSFET, 1.35mOhm Ron, 273nC Qgmax, -55 to 150 °C, 5x6mm SON8
-K dual-cool-powertrench mosfet fairchild
+K dual-cool-powertrench MOSFET fairchild
 F https://www.fairchildsemi.com/datasheets/FD/FDMT80080DC.pdf
 $ENDCMP
 #
@@ -1639,37 +1639,37 @@ F https://www.infineon.com/dgdl/IPx50R3K0CE_2_0.pdf?folderId=db3a3043163797a6011
 $ENDCMP
 #
 $CMP IPDD60R050G7
-D 47A Id, 600V Vds, 50mOhm, N-channel MOSFET, CoolMOS G7, PG-HDSOP-10-1 (DDPAK)
+D 47A Id, 600V Vds, 50mOhm, N-Channel MOSFET, CoolMOS G7, PG-HDSOP-10-1 (DDPAK)
 K N-Channel MOSFET
 F https://www.infineon.com/dgdl/Infineon-IPDD60R050G7-DS-v02_00-EN.pdf?fileId=5546d4626102d35a0161707eb2f97810
 $ENDCMP
 #
 $CMP IPDD60R080G7
-D 29A Id, 600V Vds, 80mOhm, N-channel MOSFET, CoolMOS G7, PG-HDSOP-10-1 (DDPAK)
+D 29A Id, 600V Vds, 80mOhm, N-Channel MOSFET, CoolMOS G7, PG-HDSOP-10-1 (DDPAK)
 K N-Channel MOSFET
 F https://www.infineon.com/dgdl/Infineon-IPDD60R080G7-DS-v02_00-EN.pdf?fileId=5546d4626102d35a016170882f757a07
 $ENDCMP
 #
 $CMP IPDD60R102G7
-D 23A Id, 600V Vds, 102mOhm, N-channel MOSFET, CoolMOS G7, PG-HDSOP-10-1 (DDPAK)
+D 23A Id, 600V Vds, 102mOhm, N-Channel MOSFET, CoolMOS G7, PG-HDSOP-10-1 (DDPAK)
 K N-Channel MOSFET
 F https://www.infineon.com/dgdl/Infineon-IPDD60R102G7-DS-v02_00-EN.pdf?fileId=5546d4626102d35a01617087ee7379ed
 $ENDCMP
 #
 $CMP IPDD60R125G7
-D 20A Id, 600V Vds, 125mOhm, N-channel MOSFET, CoolMOS G7, PG-HDSOP-10-1 (DDPAK)
+D 20A Id, 600V Vds, 125mOhm, N-Channel MOSFET, CoolMOS G7, PG-HDSOP-10-1 (DDPAK)
 K N-Channel MOSFET
 F https://www.infineon.com/dgdl/Infineon-IPDD60R125G7-DS-v02_00-EN.pdf?fileId=5546d4626102d35a0161706cba27778f
 $ENDCMP
 #
 $CMP IPDD60R150G7
-D 16A Id, 600V Vds, 150mOhm, N-channel MOSFET, CoolMOS G7, PG-HDSOP-10-1 (DDPAK)
+D 16A Id, 600V Vds, 150mOhm, N-Channel MOSFET, CoolMOS G7, PG-HDSOP-10-1 (DDPAK)
 K N-Channel MOSFET
 F https://www.infineon.com/dgdl/Infineon-IPDD60R150G7-DS-v02_00-EN.pdf?fileId=5546d4626102d35a016170806aa57863
 $ENDCMP
 #
 $CMP IPDD60R190G7
-D 13A Id, 600V Vds, 190mOhm, N-channel MOSFET, CoolMOS G7, PG-HDSOP-10-1 (DDPAK)
+D 13A Id, 600V Vds, 190mOhm, N-Channel MOSFET, CoolMOS G7, PG-HDSOP-10-1 (DDPAK)
 K N-Channel MOSFET
 F https://www.infineon.com/dgdl/Infineon-IPDD60R190G7-DS-v02_00-EN.pdf?fileId=5546d4626102d35a01617087dc0f79ea
 $ENDCMP
@@ -2101,14 +2101,14 @@ F https://www.infineon.com/dgdl/irf7580mpbf.pdf?fileId=5546d462533600a4015356038
 $ENDCMP
 #
 $CMP IRF7606PBF
-D -3.6A Id, -30V Vds, HexFET P-MOS Power Mosfet, Ronon 0.09R, Micro8
-K HexFET Power Mosfet P-MOS
+D -3.6A Id, -30V Vds, HexFET P-MOS Power MOSFET, Ronon 0.09R, Micro8
+K HexFET Power MOSFET P-MOS
 F http://www.irf.com/product-info/datasheets/data/irf7606pbf.pdf
 $ENDCMP
 #
 $CMP IRF7607PBF
-D 5.2A Id, 20V Vds, HexFET N-MOS Power Mosfet, Ronon 0.03R, Micro8
-K HexFET Power Mosfet N-MOS
+D 5.2A Id, 20V Vds, HexFET N-MOS Power MOSFET, Ronon 0.03R, Micro8
+K HexFET Power MOSFET N-MOS
 F http://www.irf.com/product-info/datasheets/data/irf7607pbf.pdf
 $ENDCMP
 #
@@ -2233,19 +2233,19 @@ F http://www.irf.com/product-info/datasheets/data/irf9540n.pdf
 $ENDCMP
 #
 $CMP IRFI4019H
-D 8.7A Id, 150V Vds, 80mOhm, Dual Half Bridge N-channel MOSFET, TO-220-5
+D 8.7A Id, 150V Vds, 80mOhm, Dual Half Bridge N-Channel MOSFET, TO-220-5
 K Dual N-Channel MOSFET
 F https://www.infineon.com/dgdl/irfi4019h-117p.pdf?fileId=5546d462533600a401535623d74d1f6f
 $ENDCMP
 #
 $CMP IRFI4020H
-D 9.1A Id, 200V Vds, 80mOhm, Dual Half Bridge N-channel MOSFET, TO-220-5
+D 9.1A Id, 200V Vds, 80mOhm, Dual Half Bridge N-Channel MOSFET, TO-220-5
 K Dual N-Channel MOSFET
 F https://www.infineon.com/dgdl/irfi4020h-117p.pdf?fileId=5546d462533600a401535623e7271f73
 $ENDCMP
 #
 $CMP IRFI4212H
-D 11A Id, 100V Vds, 58mOhm, Dual Half Bridge N-channel MOSFET, TO-220-5
+D 11A Id, 100V Vds, 58mOhm, Dual Half Bridge N-Channel MOSFET, TO-220-5
 K Dual N-Channel MOSFET
 F https://www.infineon.com/dgdl/irfi4212h-117p.pdf?fileId=5546d462533600a401535623fc841f7a
 $ENDCMP
@@ -2281,13 +2281,13 @@ F http://www.irf.com/product-info/datasheets/data/irliz44n.pdf
 $ENDCMP
 #
 $CMP IRLML2060
-D 1.2A Id, 60V Vds, N-channel MOSFET, 480mOhm Rds, SOT-23
-K N-channel MOSFET
+D 1.2A Id, 60V Vds, N-Channel MOSFET, 480mOhm Rds, SOT-23
+K N-Channel MOSFET
 F https://www.infineon.com/dgdl/irlml2060pbf.pdf?fileId=5546d462533600a401535664b7fb25ee
 $ENDCMP
 #
 $CMP IRLML6402
-D -3.7A Id, -20V Vds, P-channel MOSFET, 65mOhm Rds, SOT-23
+D -3.7A Id, -20V Vds, P-Channel MOSFET, 65mOhm Rds, SOT-23
 K P-Channel MOSFET
 F https://www.infineon.com/dgdl/irlml6402pbf.pdf?fileId=5546d462533600a401535668d5c2263c
 $ENDCMP
@@ -2305,7 +2305,7 @@ F http://www.irf.com/product-info/datasheets/data/irlz44n.pdf
 $ENDCMP
 #
 $CMP MMBF170
-D 60V Vds, 0.5 A Id, N-channel MOSFET, SOT-23
+D 0.5A Id, 60V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F https://www.diodes.com/assets/Datasheets/ds30104.pdf
 $ENDCMP
@@ -2317,13 +2317,13 @@ F http://www.onsemi.com/pub/Collateral/NTR2101P-D.PDF
 $ENDCMP
 #
 $CMP PGA26E07BA
-D 26A Id, 600V Vds, 56mOhm, N-channel GaN MOSFET, DFN-8
+D 26A Id, 600V Vds, 56mOhm, N-Channel GaN MOSFET, DFN-8
 K N-Channel GaN MOSFET
 F https://industrial.panasonic.com/content/data/SC/ds/ds4/PGA26E07BA_E.pdf
 $ENDCMP
 #
 $CMP PGA26E19BA
-D 13A Id, 600V Vds, 140mOhm, N-channel GaN MOSFET, DFN-8
+D 13A Id, 600V Vds, 140mOhm, N-Channel GaN MOSFET, DFN-8
 K N-Channel GaN MOSFET
 F https://industrial.panasonic.com/content/data/SC/ds/ds4/PGA26E19BA_E.pdf
 $ENDCMP
@@ -2335,7 +2335,7 @@ F https://assets.nexperia.com/documents/data-sheet/PSMN5R2-60YL.pdf
 $ENDCMP
 #
 $CMP QM6006D
-D 60V Id, 35A Vds, N-Channel Power MOSFET, 18mOhm Ron, 19.3nC Qg (typ), TO252
+D 35A Id, 60V Vds, N-Channel Power MOSFET, 18mOhm Ron, 19.3nC Qg (typ), TO252
 K N-Channel MOSFET
 F http://www.jaolen.com/images/pdf/QM6006D.pdf
 $ENDCMP
@@ -2349,7 +2349,7 @@ $ENDCMP
 $CMP STS2DNE60
 D 2A Id, 60V Vds, Dual N-Channel MOSFET, 180mOhm Ron, SO-8
 K Dual N-Channel MOSFET
-F www.st.com/resource/en/datasheet/CD00001537.pdf
+F https://www.st.com/resource/en/datasheet/CD00001537.pdf
 $ENDCMP
 #
 $CMP SUD08P06-155L
@@ -2401,8 +2401,8 @@ F https://www.vishay.com/docs/62504/sud50p10-43l-ge3.pdf
 $ENDCMP
 #
 $CMP Si1442DH
-D 12Vds Power N-Channel MOSFET, SC-70-6
-K NMOS n-mos n-mosfet transistor
+D 12V Vds, TrenchFET N-Channel Power MOSFET, SC-70-6
+K TrenchFET N-Channel Power MOSFET
 F http://www.vishay.com/docs/63772/si1442dh.pdf
 $ENDCMP
 #
@@ -2425,9 +2425,9 @@ F https://www.fairchildsemi.com/datasheets/SI/SI4542DY.pdf
 $ENDCMP
 #
 $CMP Si7336ADP
-D 30A Id, 30V Vds, 2.4 mOhm Ron, PowerPAK-8
+D 30A Id, 30V Vds, 2.4mOhm Ron, PowerPAK-8
 K N-Channel MOSFET
-F www.vishay.com/docs/73152/si7336adp.pdf
+F https://www.vishay.com/docs/73152/si7336adp.pdf
 $ENDCMP
 #
 $CMP SiA449DJ
@@ -2461,7 +2461,7 @@ F http://www.vishay.com/docs/70209/70209.pdf
 $ENDCMP
 #
 $CMP VN10LF
-D 0.15 A Id, 60 V Vds, N-Channel MOSFET, SOT-23
+D 0.15A Id, 60V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/VN10LF.pdf
 $ENDCMP
@@ -2479,115 +2479,115 @@ F http://www.vishay.com/docs/70209/70209.pdf
 $ENDCMP
 #
 $CMP ZVN3306F
-D 0.15 A Id, 60 V Vds, N-Channel MOSFET, SOT-23
+D 0.15A Id, 60V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZVN3306F.pdf
 $ENDCMP
 #
 $CMP ZVN3310F
-D 0.1 A Id, 100 V Vds, N-Channel MOSFET, SOT-23
+D 0.1A Id, 100V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZVN3310F.pdf
 $ENDCMP
 #
 $CMP ZVN3320F
-D 0.06 A Id, 200 V Vds, N-Channel MOSFET, SOT-23
+D 0.06A Id, 200V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZVN3320F.pdf
 $ENDCMP
 #
 $CMP ZVN4106F
-D 0.2 A Id, 60 V Vds, N-Channel MOSFET, SOT-23
+D 0.2A Id, 60V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZVN4106F.pdf
 $ENDCMP
 #
 $CMP ZXM61N02F
-D 1.7 A Id, 20 V Vds, N-Channel MOSFET, SOT-23
+D 1.7A Id, 20V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZXM61N02F.pdf
 $ENDCMP
 #
 $CMP ZXM61N03F
-D 1.4 A Id, 30 V Vds, N-Channel MOSFET, SOT-23
+D 1.4A Id, 30V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZXM61N03F.pdf
 $ENDCMP
 #
 $CMP ZXMN10A07F
-D 0.76 A Id, 100 V Vds, N-Channel MOSFET, SOT-23
+D 0.76A Id, 100V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZXMN10A07F.pdf
 $ENDCMP
 #
 $CMP ZXMN2A01F
-D 2.2 A Id, 20 V Vds, N-Channel MOSFET, SOT-23
+D 2.2A Id, 20V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZXMN2A01F.pdf
 $ENDCMP
 #
 $CMP ZXMN2A14F
-D 4.1 A Id, 20 V Vds, N-Channel MOSFET, SOT-23
+D 4.1A Id, 20V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZXMN2A14F.pdf
 $ENDCMP
 #
 $CMP ZXMN2B01F
-D 2.4 A Id, 20 V Vds, N-Channel MOSFET, SOT-23
+D 2.4A Id, 20V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZXMN2B01F.pdf
 $ENDCMP
 #
 $CMP ZXMN2B14FH
-D 4.3 A Id, 20 V Vds, N-Channel MOSFET, SOT-23
+D 4.3A Id, 20V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZXMN2B14FH.pdf
 $ENDCMP
 #
 $CMP ZXMN2F30FH
-D 4.9 A Id, 20 V Vds, N-Channel MOSFET, SOT-23
+D 4.9A Id, 20V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZXMN2F30FH.pdf
 $ENDCMP
 #
 $CMP ZXMN2F34FH
-D 4 A Id, 20 V Vds, N-Channel MOSFET, SOT-23
+D 4A Id, 20V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZXMN2F34FH.pdf
 $ENDCMP
 #
 $CMP ZXMN3A01F
-D 2 A Id, 30 V Vds, N-Channel MOSFET, SOT-23
+D 2A Id, 30V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZXMN3A01F.pdf
 $ENDCMP
 #
 $CMP ZXMN3A14F
-D 3.2 A Id, 30 V Vds, N-Channel MOSFET, SOT-23
+D 3.2A Id, 30V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZXMN3A14F.pdf
 $ENDCMP
 #
 $CMP ZXMN3B01F
-D 2 A Id, 30 V Vds, N-Channel MOSFET, SOT-23
+D 2A Id, 30V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZXMN3B01F.pdf
 $ENDCMP
 #
 $CMP ZXMN3B14F
-D 3.5 A Id, 30 V Vds, N-Channel MOSFET, SOT-23
+D 3.5A Id, 30V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZXMN3B14F.pdf
 $ENDCMP
 #
 $CMP ZXMN3F30FH
-D 4.6 A Id, 30 V Vds, N-Channel MOSFET, SOT-23
+D 4.6A Id, 30V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZXMN3F30FH.pdf
 $ENDCMP
 #
 $CMP ZXMN6A07F
-D 1.4 A Id, 60 V Vds, N-Channel MOSFET, SOT-23
+D 1.4A Id, 60V Vds, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
 F http://www.diodes.com/assets/Datasheets/ZXMN6A07F.pdf
 $ENDCMP

--- a/Triac_Thyristor.dcm
+++ b/Triac_Thyristor.dcm
@@ -25,7 +25,7 @@ F https://assets.nexperia.com/documents/data-sheet/BT138_SER_D_E.pdf
 $ENDCMP
 #
 $CMP BT138-800
-D 12A RMS, 800 V Off-State Voltage, Triac, TO-220
+D 12A RMS, 800V Off-State Voltage, Triac, TO-220
 K Triac
 F https://assets.nexperia.com/documents/data-sheet/BT138_SER_D_E.pdf
 $ENDCMP


### PR DESCRIPTION
- Remove spaces in front of "A" and "V", as well as some other inconsistencies as per #1615 
- Fix incorrect `Id` and `Vds` ratings for Si1442DH (they were swapped) as per [Datasheet](https://www.vishay.com/docs/63772/si1442dh.pdf)
- Add `0.2A Id` rating for 2N7000 as per [Wikipedia](https://en.wikipedia.org/wiki/2N7000) and [Datasheet](https://www.onsemi.com/pub/Collateral/2N7000-D.PDF)

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [x] Provide a URL to a datasheet for the symbol(s) you are contributing
- [ ] An example screenshot image is very helpful
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
  - A new fitting footprint must be submitted if the library does not yet contain one.
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.
