### PR TITLE
Clearer descriptions for power symbols

### DIFF
--- a/power.dcm
+++ b/power.dcm
@@ -1,496 +1,496 @@
 EESchema-DOCLIB  Version 2.0
 #
 $CMP +10V
-D Power flag
+D Power symbol creates a global label with name "+10V"
 K power-flag
 $ENDCMP
 #
 $CMP +12C
-D Power flag
+D Power symbol creates a global label with name "+12C"
 K power-flag
 $ENDCMP
 #
 $CMP +12L
-D Power flag
+D Power symbol creates a global label with name "+12L"
 K power-flag
 $ENDCMP
 #
 $CMP +12LF
-D Power flag
+D Power symbol creates a global label with name "+12LF"
 K power-flag
 $ENDCMP
 #
 $CMP +12P
-D Power flag
+D Power symbol creates a global label with name "+12P"
 K power-flag
 $ENDCMP
 #
 $CMP +12V
-D Power flag
+D Power symbol creates a global label with name "+12V"
 K power-flag
 $ENDCMP
 #
 $CMP +12VA
-D Power flag
+D Power symbol creates a global label with name "+12VA"
 K power-flag
 $ENDCMP
 #
 $CMP +15V
-D Power flag
+D Power symbol creates a global label with name "+15V"
 K power-flag
 $ENDCMP
 #
 $CMP +1V0
-D Power flag
+D Power symbol creates a global label with name "+1V0"
 K power-flag
 $ENDCMP
 #
 $CMP +1V1
-D Power flag
+D Power symbol creates a global label with name "+1V1"
 K power-flag
 $ENDCMP
 #
 $CMP +1V2
-D Power flag
+D Power symbol creates a global label with name "+1V2"
 K power-flag
 $ENDCMP
 #
 $CMP +1V35
-D Power flag
+D Power symbol creates a global label with name "+1V35"
 K power-flag
 $ENDCMP
 #
 $CMP +1V5
-D Power flag
+D Power symbol creates a global label with name "+1V5"
 K power-flag
 $ENDCMP
 #
 $CMP +1V8
-D Power flag
+D Power symbol creates a global label with name "+1V8"
 K power-flag
 $ENDCMP
 #
 $CMP +24V
-D Power flag
+D Power symbol creates a global label with name "+24V"
 K power-flag
 $ENDCMP
 #
 $CMP +28V
-D Power flag
+D Power symbol creates a global label with name "+28V"
 K power-flag
 $ENDCMP
 #
 $CMP +2V5
-D Power flag
+D Power symbol creates a global label with name "+2V5"
 K power-flag
 $ENDCMP
 #
 $CMP +2V8
-D Power flag
+D Power symbol creates a global label with name "+2V8"
 K power-flag
 $ENDCMP
 #
 $CMP +3.3V
-D Power flag
+D Power symbol creates a global label with name "+3.3V"
 K power-flag
 $ENDCMP
 #
 $CMP +3.3VA
-D Power flag
+D Power symbol creates a global label with name "+3.3VA"
 K power-flag
 $ENDCMP
 #
 $CMP +3.3VADC
-D Power flag
+D Power symbol creates a global label with name "+3.3VADC"
 K power-flag
 $ENDCMP
 #
 $CMP +3.3VDAC
-D Power flag
+D Power symbol creates a global label with name "+3.3VDAC"
 K power-flag
 $ENDCMP
 #
 $CMP +3.3VP
-D Power flag
+D Power symbol creates a global label with name "+3.3VP"
 K power-flag
 $ENDCMP
 #
 $CMP +36V
-D Power flag
+D Power symbol creates a global label with name "+36V"
 K power-flag
 $ENDCMP
 #
 $CMP +3V0
-D Power flag
+D Power symbol creates a global label with name "+3V0"
 K power-flag
 $ENDCMP
 #
 $CMP +3V3
-D Power flag
+D Power symbol creates a global label with name "+3V3"
 K power-flag
 $ENDCMP
 #
 $CMP +3V8
-D Power flag
+D Power symbol creates a global label with name "+3V8"
 K power-flag
 $ENDCMP
 #
 $CMP +48V
-D Power flag
+D Power symbol creates a global label with name "+48V"
 K power-flag
 $ENDCMP
 #
 $CMP +4V
-D Power flag
+D Power symbol creates a global label with name "+4V"
 K power-flag
 $ENDCMP
 #
 $CMP +5C
-D Power flag
+D Power symbol creates a global label with name "+5C"
 K power-flag
 $ENDCMP
 #
 $CMP +5F
-D Power flag
+D Power symbol creates a global label with name "+5F"
 K power-flag
 $ENDCMP
 #
 $CMP +5P
-D Power flag
+D Power symbol creates a global label with name "+5P"
 K power-flag
 $ENDCMP
 #
 $CMP +5V
-D Power flag
+D Power symbol creates a global label with name "+5V"
 K power-flag
 $ENDCMP
 #
 $CMP +5VA
-D Power flag
+D Power symbol creates a global label with name "+5VA"
 K power-flag
 $ENDCMP
 #
 $CMP +5VD
-D Power flag
+D Power symbol creates a global label with name "+5VD"
 K power-flag
 $ENDCMP
 #
 $CMP +5VL
-D Power flag
+D Power symbol creates a global label with name "+5VL"
 K power-flag
 $ENDCMP
 #
 $CMP +5VP
-D Power flag
+D Power symbol creates a global label with name "+5VP"
 K power-flag
 $ENDCMP
 #
 $CMP +6V
-D Power flag
+D Power symbol creates a global label with name "+6V"
 K power-flag
 $ENDCMP
 #
 $CMP +7.5V
-D Power flag
+D Power symbol creates a global label with name "+7.5V"
 K power-flag
 $ENDCMP
 #
 $CMP +8V
-D Power flag
+D Power symbol creates a global label with name "+8V"
 K power-flag
 $ENDCMP
 #
 $CMP +9V
-D Power flag
+D Power symbol creates a global label with name "+9V"
 K power-flag
 $ENDCMP
 #
 $CMP +9VA
-D Power flag
+D Power symbol creates a global label with name "+9VA"
 K power-flag
 $ENDCMP
 #
 $CMP +BATT
-D Power flag
+D Power symbol creates a global label with name "+BATT"
 K power-flag battery
 $ENDCMP
 #
 $CMP +VDC
-D Power flag
+D Power symbol creates a global label with name "+VDC"
 K power-flag
 $ENDCMP
 #
 $CMP +VSW
-D Power flag
+D Power symbol creates a global label with name "+VSW"
 K power-flag
 $ENDCMP
 #
 $CMP -10V
-D Power flag
+D Power symbol creates a global label with name "-10V"
 K power-flag
 $ENDCMP
 #
 $CMP -12V
-D Power flag
+D Power symbol creates a global label with name "-12V"
 K power-flag
 $ENDCMP
 #
 $CMP -12VA
-D Power flag
+D Power symbol creates a global label with name "-12VA"
 K power-flag
 $ENDCMP
 #
 $CMP -15V
-D Power flag
+D Power symbol creates a global label with name "-15V"
 K power-flag
 $ENDCMP
 #
 $CMP -24V
-D Power flag
+D Power symbol creates a global label with name "-24V"
 K power-flag
 $ENDCMP
 #
 $CMP -2V5
-D Power flag
+D Power symbol creates a global label with name "-2V5"
 K power-flag
 $ENDCMP
 #
 $CMP -36V
-D Power flag
+D Power symbol creates a global label with name "-36V"
 K power-flag
 $ENDCMP
 #
 $CMP -3V3
-D Power flag
+D Power symbol creates a global label with name "-3V3"
 K power-flag
 $ENDCMP
 #
 $CMP -48V
-D Power flag
+D Power symbol creates a global label with name "-48V"
 K power-flag
 $ENDCMP
 #
 $CMP -5V
-D Power flag
+D Power symbol creates a global label with name "-5V"
 K power-flag
 $ENDCMP
 #
 $CMP -5VA
-D Power flag
+D Power symbol creates a global label with name "-5VA"
 K power-flag
 $ENDCMP
 #
 $CMP -6V
-D Power flag
+D Power symbol creates a global label with name "-6V"
 K power-flag
 $ENDCMP
 #
 $CMP -8V
-D Power flag
+D Power symbol creates a global label with name "-8V"
 K power-flag
 $ENDCMP
 #
 $CMP -9V
-D Power flag
+D Power symbol creates a global label with name "-9V"
 K power-flag
 $ENDCMP
 #
 $CMP -9VA
-D Power flag
+D Power symbol creates a global label with name "-9VA"
 K power-flag
 $ENDCMP
 #
 $CMP -BATT
-D Power flag
+D Power symbol creates a global label with name "-BATT"
 K power-flag battery
 $ENDCMP
 #
 $CMP -VDC
-D Power flag
+D Power symbol creates a global label with name "-VDC"
 K power-flag
 $ENDCMP
 #
 $CMP -VSW
-D Power flag
+D Power symbol creates a global label with name "-VSW"
 K power-flag
 $ENDCMP
 #
 $CMP AC
-D Power flag
+D Power symbol creates a global label with name "AC"
 K power-flag
 $ENDCMP
 #
 $CMP Earth
-D Power flag, earth
+D Power symbol creates a global label with name "Earth"
 K power-flag ground gnd
 F ~
 $ENDCMP
 #
 $CMP Earth_Clean
-D Power flag, clean earth
+D Power symbol creates a global label with name "Earth_Clean"
 K power-flag ground gnd clean signal
 F ~
 $ENDCMP
 #
 $CMP Earth_Protective
-D Power flag, protective earth
+D Power symbol creates a global label with name "Earth_Protective"
 K power-flag ground gnd clean
 F ~
 $ENDCMP
 #
 $CMP GND
-D Power flag, ground
+D Power symbol creates a global label with name "GND" , ground
 K power-flag
 $ENDCMP
 #
 $CMP GNDA
-D Power flag, analog ground
+D Power symbol creates a global label with name "GNDA" , analog ground
 K power-flag
 $ENDCMP
 #
 $CMP GNDD
-D Power flag, digital ground
+D Power symbol creates a global label with name "GNDD" , digital ground
 K power-flag
 $ENDCMP
 #
 $CMP GNDPWR
-D Power flag, power ground
+D Power symbol creates a global label with name "GNDPWR" , power ground
 K power-flag
 $ENDCMP
 #
 $CMP GNDREF
-D Power flag, reference supply ground
+D Power symbol creates a global label with name "GNDREF" , reference supply ground
 K power-flag
 $ENDCMP
 #
 $CMP GNDS
-D Power flag, signal ground
+D Power symbol creates a global label with name "GNDS" , signal ground
 K power-flag
 $ENDCMP
 #
 $CMP HT
-D Power flag
+D Power symbol creates a global label with name "HT"
 K power-flag
 $ENDCMP
 #
 $CMP LINE
-D Power flag
+D Power symbol creates a global label with name "LINE"
 K power-flag
 $ENDCMP
 #
 $CMP NEUT
-D Power flag
+D Power symbol creates a global label with name "NEUT"
 K power-flag
 $ENDCMP
 #
 $CMP PRI_HI
-D Power flag
+D Power symbol creates a global label with name "PRI_HI"
 K power-flag
 $ENDCMP
 #
 $CMP PRI_LO
-D Power flag
+D Power symbol creates a global label with name "PRI_LO"
 K power-flag
 $ENDCMP
 #
 $CMP PRI_MID
-D Power flag
+D Power symbol creates a global label with name "PRI_MID"
 K power-flag
 $ENDCMP
 #
 $CMP PWR_FLAG
-D Power flag
+D Special symbol for telling ERC where power comes from
 K power-flag
 F ~
 $ENDCMP
 #
 $CMP VAA
-D Power flag
+D Power symbol creates a global label with name "VAA"
 K power-flag
 $ENDCMP
 #
 $CMP VAC
-D Power flag
+D Power symbol creates a global label with name "VAC"
 K power-flag
 $ENDCMP
 #
 $CMP VBUS
-D Power flag
+D Power symbol creates a global label with name "VBUS"
 K power-flag
 $ENDCMP
 #
 $CMP VCC
-D Power flag
+D Power symbol creates a global label with name "VCC"
 K power-flag
 $ENDCMP
 #
 $CMP VCCQ
-D Power flag
+D Power symbol creates a global label with name "VCCQ"
 K power-flag
 $ENDCMP
 #
 $CMP VCOM
-D Power flag
+D Power symbol creates a global label with name "VCOM"
 K power-flag
 $ENDCMP
 #
 $CMP VD
-D Power flag
+D Power symbol creates a global label with name "VD"
 K power-flag
 $ENDCMP
 #
 $CMP VDC
-D Power flag
+D Power symbol creates a global label with name "VDC"
 K power-flag
 $ENDCMP
 #
 $CMP VDD
-D Power flag
+D Power symbol creates a global label with name "VDD"
 K power-flag
 $ENDCMP
 #
 $CMP VDDA
-D Power flag
+D Power symbol creates a global label with name "VDDA"
 K power-flag
 $ENDCMP
 #
 $CMP VDDF
-D Power flag
+D Power symbol creates a global label with name "VDDF"
 K power-flag
 $ENDCMP
 #
 $CMP VEE
-D Power flag
+D Power symbol creates a global label with name "VEE"
 K power-flag
 $ENDCMP
 #
 $CMP VMEM
-D Power flag
+D Power symbol creates a global label with name "VMEM"
 K power-flag
 $ENDCMP
 #
 $CMP VPP
-D Power flag
+D Power symbol creates a global label with name "VPP"
 K power-flag
 $ENDCMP
 #
 $CMP VS
-D Power flag
+D Power symbol creates a global label with name "VS"
 K power-flag
 $ENDCMP
 #
 $CMP VSS
-D Power flag
+D Power symbol creates a global label with name "VSS"
 K power-flag
 $ENDCMP
 #
 $CMP VSSA
-D Power flag
+D Power symbol creates a global label with name "VSSA"
 K power-flag
 $ENDCMP
 #
 $CMP Vdrive
-D Power flag
+D Power symbol creates a global label with name "Vdrive"
 K power-flag
 $ENDCMP
 #


### PR DESCRIPTION
All power symbols where reffered to as power flags in their description. I made it clear that they create global labels and added a special descritpion to the PWR_FLAG symbol to tell users that this one is to be used to tell ERC where power comes from.