### PR TITLE
THAT2181: Description typo

### DIFF
--- a/Amplifier_Audio.dcm
+++ b/Amplifier_Audio.dcm
@@ -445,7 +445,7 @@ F http://www.thatcorp.com/datashts/THAT_2180-Series_Datasheet.pdf
 $ENDCMP
 #
 $CMP THAT2181
-D Blackmer Pre-Trimmed IC Voltage Controlled Amplifiers, SIP-8/SOIC-8
+D Blackmer Trimmable IC Voltage Controlled Amplifiers, SIP-8/SOIC-8
 K audio vca
 F http://www.thatcorp.com/datashts/THAT_2181-Series_Datasheet.pdf
 $ENDCMP


### PR DESCRIPTION
THAT2181: Description typo

Description is copied from THAT2180 which is pre-trimmed. This is not the case
for THAT2181.

http://www.thatcorp.com/datashts/THAT_2181-Series_Datasheet.pdf

![kicad-that2181](https://user-images.githubusercontent.com/6368949/56084230-5b9d7e00-5e30-11e9-80a9-03f86a38cf90.png)

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)


Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [x] Provide a URL to a datasheet for the symbol(s) you are contributing
- [x] An example screenshot image is very helpful
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
  - A new fitting footprint must be submitted if the library does not yet contain one.
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.
