### PR TITLE
Fix 'Inductor' description.

### DIFF
--- a/pspice.dcm
+++ b/pspice.dcm
@@ -25,7 +25,7 @@ F ~
 $ENDCMP
 #
 $CMP INDUCTOR
-D Capacitor symbol for simulation only
+D Inductor symbol for simulation only
 K simulation
 F ~
 $ENDCMP


### PR DESCRIPTION
Fix reference to 'Capacitor' in 'Inductor' description.
