### PR TITLE
Fix LM4810

### DIFF
--- a/Amplifier_Audio.dcm
+++ b/Amplifier_Audio.dcm
@@ -147,7 +147,7 @@ $ENDCMP
 $CMP LM4810
 D Boomer Dual 105mW Headphone Amplifier with Active-High Shutdown Mode, VSSOP-8
 K audio amplifier headphone
-F http://www.ti.com/lit/ds/symlink/lm4811.pdf
+F http://www.ti.com/lit/ds/symlink/lm4810.pdf
 $ENDCMP
 #
 $CMP LM4811


### PR DESCRIPTION
* Update DS link

Fixes #2062 
DS http://www.ti.com/lit/ds/symlink/lm4810.pdf

![lm4810-0](https://user-images.githubusercontent.com/40901018/63047691-3cddef80-bed5-11e9-81a4-0345b65a20e9.png)

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [x] Provide a URL to a datasheet for the symbol(s) you are contributing
- [x] An example screenshot image is very helpful
- [x] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
  - A new fitting footprint must be submitted if the library does not yet contain one.
- [x] If there are matching footprint PRs, provide link(s) as appropriate
- [x] Check the output of the Travis automated check scripts - fix any errors as required
- [x] Give a reason behind any intentional library convention rule violation.
