### PR TITLE
Fix LM339 / LMV339 / LM2901 DS links

### DIFF
--- a/Comparator.dcm
+++ b/Comparator.dcm
@@ -27,7 +27,7 @@ $ENDCMP
 $CMP LM2901
 D Quad Differential Comparators, DIP-14/SOIC-14/SSOP-14
 K quad comparator
-F http://www.ti.com/lit/ds/symlink/lm339.pdf
+F https://www.st.com/resource/en/datasheet/lm2901.pdf
 $ENDCMP
 #
 $CMP LM2903
@@ -57,7 +57,7 @@ $ENDCMP
 $CMP LM339
 D Quad Differential Comparators, DIP-14/SOIC-14/SSOP-14
 K quad comparator
-F http://www.ti.com/lit/ds/symlink/lm339.pdf
+F https://www.st.com/resource/en/datasheet/lm139.pdf
 $ENDCMP
 #
 $CMP LM393
@@ -81,7 +81,7 @@ $ENDCMP
 $CMP LMV339
 D Quad General-Purpose Low-Voltage Comparator, SOIC-14/TSSOP-14
 K quad comparator
-F http://www.ti.com/lit/ds/symlink/lmv331.pdf
+F https://www.st.com/resource/en/datasheet/lmv331.pdf
 $ENDCMP
 #
 $CMP LMV393


### PR DESCRIPTION
Fixes https://github.com/KiCad/kicad-symbols/issues/2105

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the symbol(s) you are contributing
- [ ] An example screenshot image is very helpful
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
  - A new fitting footprint must be submitted if the library does not yet contain one.
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.
