### PR TITLE
fix minicircuits ww2 library links

### DIFF
--- a/Oscillator.dcm
+++ b/Oscillator.dcm
@@ -123,13 +123,13 @@ $ENDCMP
 $CMP JTOS-25
 D Voltage Controlled Oscillator, 12.5 to 25 MHz, Mini-Circuits BK377
 K VCXO
-F https://ww2.minicircuits.com/pdfs/JTOS-25+.pdf
+F https://www.minicircuits.com/pdfs/JTOS-25+.pdf
 $ENDCMP
 #
 $CMP JTOS-50
 D Voltage Controlled Oscillator, 25 to 47 MHz, Mini-Circuits BK377
 K VCXO
-F https://ww2.minicircuits.com/pdfs/JTOS-50+.pdf
+F https://www.minicircuits.com/pdfs/JTOS-50+.pdf
 $ENDCMP
 #
 $CMP KT2520K-T

--- a/RF.dcm
+++ b/RF.dcm
@@ -3,7 +3,7 @@ EESchema-DOCLIB  Version 2.0
 $CMP ADC-10-1R
 D Directional Coupler, 5 to 900 MHz, 10 dB Coupling, 50 Ohm, Mini-Circuits CD542
 K Directional Coupler
-F https://ww2.minicircuits.com/pdfs/ADC-10-1R.pdf
+F https://www.minicircuits.com/pdfs/ADC-10-1R.pdf
 $ENDCMP
 #
 $CMP ADE-6
@@ -15,13 +15,13 @@ $ENDCMP
 $CMP ADP-2-1W
 D Power splitter combiner, 1 to 650 MHz, 2 way 0-degree, 50 ohm, Mini-Circuits CD636
 K splitter combiner
-F https://ww2.minicircuits.com/pdfs/ADP-2-1W.pdf
+F https://www.minicircuits.com/pdfs/ADP-2-1W.pdf
 $ENDCMP
 #
 $CMP AMK-2-13
 D 2x Frequency Multiplier, output 20 to 1000 MHz, 50 Ohm, Mini-Circuits CD542
 K frequency multiplier
-F https://ww2.minicircuits.com/pdfs/AMK-2-13+.pdf
+F https://www.minicircuits.com/pdfs/AMK-2-13+.pdf
 $ENDCMP
 #
 $CMP CC1000
@@ -69,13 +69,13 @@ $ENDCMP
 $CMP LAT-3
 D Attenuator, 3dB, 0.5W, DC to 2500 MHz, 50 Ohm, Mini-Circuits MMM168
 K attenuator rf
-F https://ww2.minicircuits.com/pdfs/LAT-3+.pdf
+F https://www.minicircuits.com/pdfs/LAT-3+.pdf
 $ENDCMP
 #
 $CMP LRPS-2-1
 D Power Splitter/Combiner, 5 to 500 MHz, 50 Ohm
 K power splitter combiner
-F https://ww2.minicircuits.com/pdfs/LRPS-2-1.pdf
+F https://www.minicircuits.com/pdfs/LRPS-2-1.pdf
 $ENDCMP
 #
 $CMP MAADSS0008
@@ -195,13 +195,13 @@ $ENDCMP
 $CMP RMK-3-451
 D 3x Frequency Multiplier, output 300 to 450 MHz, 50 Ohm, Mini-Circuits TT1224
 K frequency multiplier
-F https://ww2.minicircuits.com/pdfs/RMK-3-451+.pdf
+F https://www.minicircuits.com/pdfs/RMK-3-451+.pdf
 $ENDCMP
 #
 $CMP RMK-5-51
 D 5x Frequency Multiplier, Output 37.5 to 52.5 MHz, 50 Ohm, Mini-Circuits TT1224
 K frequency multiplier
-F https://ww2.minicircuits.com/pdfs/RMK-5-51+.pdf
+F https://www.minicircuits.com/pdfs/RMK-5-51+.pdf
 $ENDCMP
 #
 $CMP SE5004L
@@ -225,19 +225,19 @@ $ENDCMP
 $CMP SYPD-1
 D Phase Detector, 1 to 100 MHz, 50 Ohm, Mini-Cicuits TTT167
 K Phase Detector
-F https://ww2.minicircuits.com/pdfs/SYPD-1+.pdf
+F https://www.minicircuits.com/pdfs/SYPD-1+.pdf
 $ENDCMP
 #
 $CMP SYPD-2
 D Phase Detector, 10 to 200 MHz, 50 Ohm, Mini-Cicuits TTT167
 K phase detector
-F https://ww2.minicircuits.com/pdfs/SYPD-2.pdf
+F https://www.minicircuits.com/pdfs/SYPD-2.pdf
 $ENDCMP
 #
 $CMP SYPD-52
 D Phase Detector, 400 to 500 MHz, 50 Ohm, Mini-Cicuits TTT167
 K Phase Detector
-F https://ww2.minicircuits.com/pdfs/SYPD-52+.pdf
+F https://www.minicircuits.com/pdfs/SYPD-52+.pdf
 $ENDCMP
 #
 $CMP Si4460

--- a/RF_Switch.dcm
+++ b/RF_Switch.dcm
@@ -57,19 +57,19 @@ $ENDCMP
 $CMP KSW-2-46
 D SPDT DC-4.6GHz reflective switch, 50 Ohm, XX112
 K RF SPDT switch
-F https://ww2.minicircuits.com/pdfs/KSW-2-46+.pdf
+F https://www.minicircuits.com/pdfs/KSW-2-46+.pdf
 $ENDCMP
 #
 $CMP KSWA-2-46
 D SPDT DC-4.6GHz absorbative switch, 50 Ohm, XX112
 K RF SPDT switch
-F https://ww2.minicircuits.com/pdfs/KSWA-2-46+.pdf
+F https://www.minicircuits.com/pdfs/KSWA-2-46+.pdf
 $ENDCMP
 #
 $CMP KSWHA-1-20
 D SPST DC-2.0GHz absorbative switch, 50 Ohm, XX112
 K RF SPST switch
-F https://ww2.minicircuits.com/pdfs/KSWHA-1-20+.pdf
+F https://www.minicircuits.com/pdfs/KSWHA-1-20+.pdf
 $ENDCMP
 #
 $CMP MASW-007221
@@ -129,25 +129,25 @@ $ENDCMP
 $CMP MSW-2-20
 D SPDT DC-2.0GHz reflective switch, 50 Ohm, SOP-8
 K RF SPDT switch
-F https://ww2.minicircuits.com/pdfs/MSW-2-20+.pdf
+F https://www.minicircuits.com/pdfs/MSW-2-20+.pdf
 $ENDCMP
 #
 $CMP MSW2-50
 D SPDT DC-5.0GHz reflective switch, 50 Ohm, QFN-12
 K RF SPDT switch
-F https://ww2.minicircuits.com/pdfs/MSW2-50+.pdf
+F https://www.minicircuits.com/pdfs/MSW2-50+.pdf
 $ENDCMP
 #
 $CMP MSWA-2-20
 D SPDT DC-2.0GHz absorbative switch, 50 Ohm, SOP-8
 K RF SPDT switch
-F https://ww2.minicircuits.com/pdfs/MSWA-2-20+.pdf
+F https://www.minicircuits.com/pdfs/MSWA-2-20+.pdf
 $ENDCMP
 #
 $CMP MSWA2-50
 D SPDT DC-5.0GHz absorbative switch, 50 Ohm, QFN-12
 K RF SPDT switch
-F https://ww2.minicircuits.com/pdfs/MSWA2-50+.pdf
+F https://www.minicircuits.com/pdfs/MSWA2-50+.pdf
 $ENDCMP
 #
 #End Doc Library

--- a/Transformer.dcm
+++ b/Transformer.dcm
@@ -9,211 +9,211 @@ $ENDCMP
 $CMP ADT1-1
 D 0.15-400MHz 1:1 RF Transformer, Balanced to Balanced, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT1-1+.pdf
+F https://www.minicircuits.com/pdfs/ADT1-1+.pdf
 $ENDCMP
 #
 $CMP ADT1-1WT
 D 0.005-125MHz 1:1 RF Transformer, Unbalanced to Balanced Center Tap, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT1-1WT+.pdf
+F https://www.minicircuits.com/pdfs/ADT1-1WT+.pdf
 $ENDCMP
 #
 $CMP ADT1-1WT-1
 D 0.03-130MHz 1:1 RF Transformer, Unbalanced to Balanced Center Tap, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT1-1WT-1+.pdf
+F https://www.minicircuits.com/pdfs/ADT1-1WT-1+.pdf
 $ENDCMP
 #
 $CMP ADT1-6T
 D 0.06-160MHz 1:1 RF Transformer, Unbalanced to Balanced Center Tap, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT1-6T+.pdf
+F https://www.minicircuits.com/pdfs/ADT1-6T+.pdf
 $ENDCMP
 #
 $CMP ADT1.5-1
 D 0.06-250MHz 1:1.5 RF Transformer, Unbalanced to Balanced Center Tap, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT1.5-1+.pdf
+F https://www.minicircuits.com/pdfs/ADT1.5-1+.pdf
 $ENDCMP
 #
 $CMP ADT1.5-122
 D 20-1200MHz 1:1.5 RF Transformer, Balanced Transmission Line, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT1.5-122+.pdf
+F https://www.minicircuits.com/pdfs/ADT1.5-122+.pdf
 $ENDCMP
 #
 $CMP ADT1.5-17
 D 0.5-1700MHz 1:1.5 RF Transformer, Unbalanced to Unbalanced, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT1.5-17+.pdf
+F https://www.minicircuits.com/pdfs/ADT1.5-17+.pdf
 $ENDCMP
 #
 $CMP ADT1.5-2
 D 0.3-225MHz 1:1.5 RF Transformer, Balanced to Balanced, CD636
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT1.5-2+.pdf
+F https://www.minicircuits.com/pdfs/ADT1.5-2+.pdf
 $ENDCMP
 #
 $CMP ADT16-1T
 D 0.10-300MHz 1:16 RF Transformer, Unbalanced to Balanced Center Tap, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT16-1T+.pdf
+F https://www.minicircuits.com/pdfs/ADT16-1T+.pdf
 $ENDCMP
 #
 $CMP ADT16-6
 D 0.25-105MHz 1:16 RF Transformer, Balanced to Balanced, CD636
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT16-6+.pdf
+F https://www.minicircuits.com/pdfs/ADT16-6+.pdf
 $ENDCMP
 #
 $CMP ADT16-6T
 D 0.10-400MHz 1:16 RF Transformer, Unbalanced to Balanced Center Tap, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT16-6T+.pdf
+F https://www.minicircuits.com/pdfs/ADT16-6T+.pdf
 $ENDCMP
 #
 $CMP ADT2-1T
 D 0.30-400MHz 1:2 RF Transformer, Unbalanced to Balanced Center Tap, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT2-1T+.pdf
+F https://www.minicircuits.com/pdfs/ADT2-1T+.pdf
 $ENDCMP
 #
 $CMP ADT2-1T-1P
 D 0.40-450MHz 1:2 RF Transformer, Unbalanced to Balanced Center Tap, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT2-1T-1P+.pdf
+F https://www.minicircuits.com/pdfs/ADT2-1T-1P+.pdf
 $ENDCMP
 #
 $CMP ADT2-71T
 D 0.40-500MHz 1:2 RF Transformer, Unbalanced to Balanced Center Tap, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT2-71T+.pdf
+F https://www.minicircuits.com/pdfs/ADT2-71T+.pdf
 $ENDCMP
 #
 $CMP ADT3-1T
 D 0.50-500MHz 1:3 RF Transformer, Unbalanced to Balanced Center Tap, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT3-1T+.pdf
+F https://www.minicircuits.com/pdfs/ADT3-1T+.pdf
 $ENDCMP
 #
 $CMP ADT3-1T-75
 D 0.50-500MHz 1:3 RF Transformer, Unbalanced to Balanced Center Tap, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT3-1T-75+.pdf
+F https://www.minicircuits.com/pdfs/ADT3-1T-75+.pdf
 $ENDCMP
 #
 $CMP ADT3-6T
 D 1-600MHz 1:3 RF Transformer, Unbalanced to Balanced Center Tap, CD636
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT3-6T+.pdf
+F https://www.minicircuits.com/pdfs/ADT3-6T+.pdf
 $ENDCMP
 #
 $CMP ADT4-1T
 D 1-600MHz 1:4 RF Transformer, Unbalanced to Balanced Center Tap, CD636
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT4-1T+.pdf
+F https://www.minicircuits.com/pdfs/ADT4-1T+.pdf
 $ENDCMP
 #
 $CMP ADT4-1WT
 D 1-625MHz 1:4 RF Transformer, Unbalanced to Balanced Center Tap, CD637
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT4-1WT+.pdf
+F https://www.minicircuits.com/pdfs/ADT4-1WT+.pdf
 $ENDCMP
 #
 $CMP ADT4-5WT
 D 1-650MHz 1:4 RF Transformer, Unbalanced to Balanced Center Tap, CD637
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT4-5WT+.pdf
+F https://www.minicircuits.com/pdfs/ADT4-5WT+.pdf
 $ENDCMP
 #
 $CMP ADT4-6
 D 0.07-250MHz 1:4 RF Transformer, Balanced to Balanced, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT4-6+.pdf
+F https://www.minicircuits.com/pdfs/ADT4-6+.pdf
 $ENDCMP
 #
 $CMP ADT4-6T
 D 1.5-70MHz 1:4 RF Transformer, Unbalanced to Balanced Center Tap, CD637
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT4-6T+.pdf
+F https://www.minicircuits.com/pdfs/ADT4-6T+.pdf
 $ENDCMP
 #
 $CMP ADT4-6WT
 D 2-70MHz 1:4 RF Transformer, Unbalanced to Balanced Center Tap, CD637
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT4-6WT+.pdf
+F https://www.minicircuits.com/pdfs/ADT4-6WT+.pdf
 $ENDCMP
 #
 $CMP ADT8-1T
 D 8-775MHz 1:8 RF Transformer, Unbalanced to Balanced Center Tap, CD637
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT8-1T+.pdf
+F https://www.minicircuits.com/pdfs/ADT8-1T+.pdf
 $ENDCMP
 #
 $CMP ADT9-1T
 D 9-800MHz 1:9 RF Transformer, Unbalanced to Balanced Center Tap, CD637
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADT9-1T+.pdf
+F https://www.minicircuits.com/pdfs/ADT9-1T+.pdf
 $ENDCMP
 #
 $CMP ADTL1-12
 D 20-1200MHz 1:1 RF Transformer, Balanced Transmission Line, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADTL1-12+.pdf
+F https://www.minicircuits.com/pdfs/ADTL1-12+.pdf
 $ENDCMP
 #
 $CMP ADTL1-15-75
 D 10-1500MHz 1:1 RF Transformer, Balanced Transmission Line, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADTL1-15-75+.pdf
+F https://www.minicircuits.com/pdfs/ADTL1-15-75+.pdf
 $ENDCMP
 #
 $CMP ADTL1-18-75
 D 5-1800MHz 1:1 RF Transformer, Balanced Transmission Line, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADTL1-18-75+.pdf
+F https://www.minicircuits.com/pdfs/ADTL1-18-75+.pdf
 $ENDCMP
 #
 $CMP ADTL1-4-75
 D 0.5-1000MHz 1:1 RF Transformer, Balanced Transmission Line, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADTL1-4-75+.pdf
+F https://www.minicircuits.com/pdfs/ADTL1-4-75+.pdf
 $ENDCMP
 #
 $CMP ADTL2-18
 D 30-1800MHz 1:2 RF Transformer, Balanced Transmission Line, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADTL2-18+.pdf
+F https://www.minicircuits.com/pdfs/ADTL2-18+.pdf
 $ENDCMP
 #
 $CMP ADTT1-1
 D 0.3-300MHz 1:1 RF Transformer, Unbalanced to Balanced Center Tap at Primary/Secondary, CD542
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADTT1-1+.pdf
+F https://www.minicircuits.com/pdfs/ADTT1-1+.pdf
 $ENDCMP
 #
 $CMP ADTT1-6
 D 0.015-100MHz 1:1 RF Transformer, Unbalanced to Balanced Center Tap at Primary/Secondary, CD637
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADTT1-6+.pdf
+F https://www.minicircuits.com/pdfs/ADTT1-6+.pdf
 $ENDCMP
 #
 $CMP ADTT1.5-1
 D 0.25-300MHz 1:1.5 RF Transformer, Unbalanced to Balanced Center Tap at Primary/Secondary, CD636
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADTT1.5-1+.pdf
+F https://www.minicircuits.com/pdfs/ADTT1.5-1+.pdf
 $ENDCMP
 #
 $CMP ADTT3-2
 D 0.2-210MHz 1:3 RF Transformer, Unbalanced to Balanced Center Tap at Primary/Secondary, CD636
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADTT3-2+.pdf
+F https://www.minicircuits.com/pdfs/ADTT3-2+.pdf
 $ENDCMP
 #
 $CMP ADTT4-1
 D 0.2-120MHz 1:4 RF Transformer, Unbalanced to Balanced Center Tap at Primary/Secondary, CD636
 K Mini-Circuits RF Transformer
-F https://ww2.minicircuits.com/pdfs/ADTT4-1+.pdf
+F https://www.minicircuits.com/pdfs/ADTT4-1+.pdf
 $ENDCMP
 #
 $CMP CST1


### PR DESCRIPTION
As pointed out by @aewallin Mini-Circuits moved their datasheets from ww2.minicircuits.com to www.minicircuits.com. This fixes the existing symbols in the library