### PR TITLE
Update datasheet links for MCU_Microchip_SAME parts

### DIFF
--- a/MCU_Microchip_SAME.dcm
+++ b/MCU_Microchip_SAME.dcm
@@ -3,97 +3,97 @@ EESchema-DOCLIB  Version 2.0
 $CMP ATSAME51J18A-A
 D SAM E51 Microchip SMART ARM Cortex-M4F-based MCU, 256K Flash, 128K SRAM, TQFP-64
 K 32-bit ARM Cortex-M4F MCU Microcontroller
-F http://ww1.microchip.com/downloads/en/DeviceDoc/60001507C.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/60001507E.pdf
 $ENDCMP
 #
 $CMP ATSAME51J19A-A
 D SAM E51 Microchip SMART ARM Cortex-M4F-based MCU, 512K Flash, 192K SRAM, TQFP-64
 K 32-bit ARM Cortex-M4F MCU Microcontroller
-F http://ww1.microchip.com/downloads/en/DeviceDoc/60001507C.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/60001507E.pdf
 $ENDCMP
 #
 $CMP ATSAME51J20A-A
 D SAM E51 Microchip SMART ARM Cortex-M4F-based MCU, 1024K Flash, 256K SRAM, TQFP-64
 K 32-bit ARM Cortex-M4F MCU Microcontroller
-F http://ww1.microchip.com/downloads/en/DeviceDoc/60001507C.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/60001507E.pdf
 $ENDCMP
 #
 $CMP ATSAME53J18A-M
 D SAM E53 Microchip SMART ARM Cortex-M4F based MCU, 256K Flash, 128K SRAM, QFN-64
 K 32-bit ARM Cortex-M4F MCU Microcontroller
-F http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-D5xE5x-Family-Datasheet-01507B.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/60001507E.pdf
 $ENDCMP
 #
 $CMP ATSAME53J19A-M
 D SAM E53 Microchip SMART ARM Cortex-M4F based MCU, 512K Flash, 128K SRAM, QFN-64
 K 32-bit ARM Cortex-M4F MCU Microcontroller
-F http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-D5xE5x-Family-Datasheet-01507B.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/60001507E.pdf
 $ENDCMP
 #
 $CMP ATSAME53J20A-M
 D SAM E53 Microchip SMART ARM Cortex-M4F based MCU, 1024K Flash, 128K SRAM, QFN-64
 K 32-bit ARM Cortex-M4F MCU Microcontroller
-F http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-D5xE5x-Family-Datasheet-01507B.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/60001507E.pdf
 $ENDCMP
 #
 $CMP ATSAME54N19A-A
 D SAM E54 Microchip SMART ARM Cortex-M4F based MCU, 512K Flash, 192K SRAM, TQFP-100
 K 32-bit ARM Cortex-M4F MCU Microcontroller
-F http://ww1.microchip.com/downloads/en/DeviceDoc/60001507C.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/60001507E.pdf
 $ENDCMP
 #
 $CMP ATSAME70J19A-AN
 D SAM E70 Microchip SMART ARM Cortex-M7-based MCU, 2048K Flash, 384K SRAM, LQFP64
 K 32-bit ARM Cortex-M7 MCU Microcontroller
-F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11296-32-bit-Cortex-M7-Microcontroller-SAM-E70Q-SAM-E70N-SAM-E70J_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-E70-S70-V70-V71-Family-Data-Sheet-DS60001527D.pdf
 $ENDCMP
 #
 $CMP ATSAME70J20A-AN
 D SAM E70 Microchip SMART ARM Cortex-M7-based MCU, 512K Flash, 384K SRAM, LQFP64
 K 32-bit ARM Cortex-M7 MCU Microcontroller
-F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11296-32-bit-Cortex-M7-Microcontroller-SAM-E70Q-SAM-E70N-SAM-E70J_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-E70-S70-V70-V71-Family-Data-Sheet-DS60001527D.pdf
 $ENDCMP
 #
 $CMP ATSAME70J21A-AN
 D SAM E70 Microchip SMART ARM Cortex-M7-based MCU, 2048K Flash, 384K SRAM, LQFP64
 K 32-bit ARM Cortex-M7 MCU Microcontroller
-F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11296-32-bit-Cortex-M7-Microcontroller-SAM-E70Q-SAM-E70N-SAM-E70J_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-E70-S70-V70-V71-Family-Data-Sheet-DS60001527D.pdf
 $ENDCMP
 #
 $CMP ATSAME70N19A-AN
 D SAM E70 Microchip SMART ARM Cortex-M7-based MCU, 512K Flash, 256K SRAM, LQFP100
 K 32-bit ARM Cortex-M7 MCU Microcontroller
-F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11296-32-bit-Cortex-M7-Microcontroller-SAM-E70Q-SAM-E70N-SAM-E70J_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-E70-S70-V70-V71-Family-Data-Sheet-DS60001527D.pdf
 $ENDCMP
 #
 $CMP ATSAME70N20A-AN
 D SAM E70 Microchip SMART ARM Cortex-M7-based MCU, 1024K Flash, 384K SRAM, LQFP100
 K 32-bit ARM Cortex-M7 MCU Microcontroller
-F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11296-32-bit-Cortex-M7-Microcontroller-SAM-E70Q-SAM-E70N-SAM-E70J_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-E70-S70-V70-V71-Family-Data-Sheet-DS60001527D.pdf
 $ENDCMP
 #
 $CMP ATSAME70N21A-AN
 D SAM E70 Microchip SMART ARM Cortex-M7-based MCU, 2048K Flash, 384K SRAM, LQFP100
 K 32-bit ARM Cortex-M7 MCU Microcontroller
-F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11296-32-bit-Cortex-M7-Microcontroller-SAM-E70Q-SAM-E70N-SAM-E70J_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-E70-S70-V70-V71-Family-Data-Sheet-DS60001527D.pdf
 $ENDCMP
 #
 $CMP ATSAME70Q19A-AN
 D SAM E70 Microchip SMART ARM Cortex-M7-based MCU, 512K Flash, 256K SRAM, LQFP144
 K 32-bit ARM Cortex-M7 MCU Microcontroller
-F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11296-32-bit-Cortex-M7-Microcontroller-SAM-E70Q-SAM-E70N-SAM-E70J_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-E70-S70-V70-V71-Family-Data-Sheet-DS60001527D.pdf
 $ENDCMP
 #
 $CMP ATSAME70Q20A-AN
 D SAM E70 Microchip SMART ARM Cortex-M7-based MCU, 1024K Flash, 384K SRAM, LQFP144
 K 32-bit ARM Cortex-M7 MCU Microcontroller
-F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11296-32-bit-Cortex-M7-Microcontroller-SAM-E70Q-SAM-E70N-SAM-E70J_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-E70-S70-V70-V71-Family-Data-Sheet-DS60001527D.pdf
 $ENDCMP
 #
 $CMP ATSAME70Q21A-AN
 D SAM E70 Microchip SMART ARM Cortex-M7-based MCU, 2048K Flash, 384K SRAM, LQFP144
 K 32-bit ARM Cortex-M7 MCU Microcontroller
-F http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-11296-32-bit-Cortex-M7-Microcontroller-SAM-E70Q-SAM-E70N-SAM-E70J_Datasheet.pdf
+F http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-E70-S70-V70-V71-Family-Data-Sheet-DS60001527D.pdf
 $ENDCMP
 #
 #End Doc Library


### PR DESCRIPTION
MCU_Microchip_SAME now use one datasheet for the SAM E70/S70/V70/V71 family (https://www.microchip.com/mymicrochip/filehandler.aspx?ddocname=en589960), and one for the SAM D5x/E5x family (https://www.microchip.com/mymicrochip/filehandler.aspx?ddocname=en599585).