### PR TITLE
Update heatsink FP filters

### DIFF
--- a/Mechanical.lib
+++ b/Mechanical.lib
@@ -40,7 +40,7 @@ F1 "Heatsink" 0 -50 50 H V C CNN
 F2 "" 12 0 50 H I C CNN
 F3 "" 12 0 50 H I C CNN
 $FPLIST
- Heatsink:*
+ Heatsink_*
 $ENDFPLIST
 DRAW
 P 10 0 1 10 -13 50 -38 50 -38 150 -63 150 -63 50 -88 50 -88 150 -113 150 -113 0 -38 0 f
@@ -56,7 +56,7 @@ F1 "Heatsink_Pad" 0 150 50 H V C CNN
 F2 "" 12 -50 50 H I C CNN
 F3 "" 12 -50 50 H I C CNN
 $FPLIST
- Heatsink:*
+ Heatsink_*
 $ENDFPLIST
 DRAW
 P 10 0 1 10 -13 0 -38 0 -38 100 -63 100 -63 0 -88 0 -88 100 -113 100 -113 -50 -38 -50 f
@@ -73,7 +73,7 @@ F1 "Heatsink_Pad_2Pin" 0 150 50 H V C CNN
 F2 "" 12 -50 50 H I C CNN
 F3 "" 12 -50 50 H I C CNN
 $FPLIST
- Heatsink:*
+ Heatsink_*
 $ENDFPLIST
 DRAW
 P 10 0 1 10 -13 0 -38 0 -38 100 -63 100 -63 0 -88 0 -88 100 -113 100 -113 -50 -38 -50 f
@@ -91,7 +91,7 @@ F1 "Heatsink_Pad_3Pin" 0 150 50 H V C CNN
 F2 "" 12 -50 50 H I C CNN
 F3 "" 12 -50 50 H I C CNN
 $FPLIST
- Heatsink:*
+ Heatsink_*
 $ENDFPLIST
 DRAW
 P 10 0 1 10 -13 0 -38 0 -38 100 -63 100 -63 0 -88 0 -88 100 -113 100 -113 -50 -38 -50 f


### PR DESCRIPTION
I didn't catch this when I submitted https://github.com/KiCad/kicad-symbols/pull/2355, but the heatsink FP filters specified anything in the heatsink library. That is unlike the other generic symbols (resistors are `R_*`, for examples) and also all heatsink in that library start with `Heatsink_`. So I updated the FP filter to match footprints names rather than the library name.

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the symbol(s) you are contributing
- [ ] An example screenshot image is very helpful
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
  - A new fitting footprint must be submitted if the library does not yet contain one.
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.
