### PR TITLE
Updated jumper FP filters

### DIFF
--- a/Device.lib
+++ b/Device.lib
@@ -3061,6 +3061,8 @@ F2 "" 0 0 50 H I C CNN
 F3 "" 0 0 50 H I C CNN
 $FPLIST
  SolderJumper*
+ Jumper*
+ TestPoint*2Pads*
 $ENDFPLIST
 DRAW
 A 0 -26 125 1426 373 0 1 0 N -98 50 99 50
@@ -3080,6 +3082,8 @@ F2 "" 0 0 50 H I C CNN
 F3 "" 0 0 50 H I C CNN
 $FPLIST
  SolderJumper*Bridged*
+ Jumper*
+ TestPoint*2Pads*
 $ENDFPLIST
 DRAW
 A -60 10 64 386 1413 0 1 0 N -10 50 -110 50
@@ -3102,6 +3106,8 @@ F2 "" 0 0 50 H I C CNN
 F3 "" 0 0 50 H I C CNN
 $FPLIST
  SolderJumper*Bridged*
+ Jumper*
+ TestPoint*2Pads*
 $ENDFPLIST
 DRAW
 A 0 -10 57 450 1350 0 1 0 N 40 30 -40 30
@@ -3121,6 +3127,8 @@ F2 "" 0 0 50 H I C CNN
 F3 "" 0 0 50 H I C CNN
 $FPLIST
  SolderJumper*Open*
+ Jumper*
+ TestPoint*2Pads*
 $ENDFPLIST
 DRAW
 C -40 0 20 0 1 0 N

--- a/Device.lib
+++ b/Device.lib
@@ -3063,6 +3063,7 @@ $FPLIST
  SolderJumper*
  Jumper*
  TestPoint*2Pads*
+ TestPoint*Bridge*
 $ENDFPLIST
 DRAW
 A 0 -26 125 1426 373 0 1 0 N -98 50 99 50
@@ -3084,6 +3085,7 @@ $FPLIST
  SolderJumper*Bridged*
  Jumper*
  TestPoint*2Pads*
+ TestPoint*Bridge*
 $ENDFPLIST
 DRAW
 A -60 10 64 386 1413 0 1 0 N -10 50 -110 50
@@ -3108,6 +3110,7 @@ $FPLIST
  SolderJumper*Bridged*
  Jumper*
  TestPoint*2Pads*
+ TestPoint*Bridge*
 $ENDFPLIST
 DRAW
 A 0 -10 57 450 1350 0 1 0 N 40 30 -40 30
@@ -3129,6 +3132,7 @@ $FPLIST
  SolderJumper*Open*
  Jumper*
  TestPoint*2Pads*
+ TestPoint*Bridge*
 $ENDFPLIST
 DRAW
 C -40 0 20 0 1 0 N

--- a/Jumper.lib
+++ b/Jumper.lib
@@ -9,7 +9,8 @@ F1 "Jumper_2_Bridged" 0 -100 50 H V C CNN
 F2 "" 0 0 50 H I C CNN
 F3 "" 0 0 50 H I C CNN
 $FPLIST
- SolderJumper*Bridged*
+ Jumper*
+ TestPoint*2Pads*
 $ENDFPLIST
 DRAW
 A 0 -70 100 1269 531 0 1 0 N -60 10 60 10
@@ -28,7 +29,8 @@ F1 "Jumper_2_Open" 0 -90 50 H V C CNN
 F2 "" 0 0 50 H I C CNN
 F3 "" 0 0 50 H I C CNN
 $FPLIST
- SolderJumper*Open*
+ Jumper*
+ TestPoint*2Pads*
 $ENDFPLIST
 DRAW
 A 0 -30 100 1269 531 0 1 0 N -60 50 60 50
@@ -47,7 +49,8 @@ F1 "Jumper_3_Bridged12" 0 110 50 H V C CNN
 F2 "" 0 0 50 H I C CNN
 F3 "" 0 0 50 H I C CNN
 $FPLIST
- SolderJumper*Bridged12*
+ Jumper*
+ TestPoint*3Pads*
 $ENDFPLIST
 DRAW
 A -65 -50 89 1282 518 0 1 0 N -120 20 -10 20
@@ -69,7 +72,8 @@ F1 "Jumper_3_Open" 0 110 50 H V C CNN
 F2 "" 0 0 50 H I C CNN
 F3 "" 0 0 50 H I C CNN
 $FPLIST
- SolderJumper*Open*
+ Jumper*
+ TestPoint*3Pads*
 $ENDFPLIST
 DRAW
 A -65 -30 89 1282 518 0 1 0 N -120 40 -10 40

--- a/Jumper.lib
+++ b/Jumper.lib
@@ -11,6 +11,7 @@ F3 "" 0 0 50 H I C CNN
 $FPLIST
  Jumper*
  TestPoint*2Pads*
+ TestPoint*Bridge*
 $ENDFPLIST
 DRAW
 A 0 -70 100 1269 531 0 1 0 N -60 10 60 10
@@ -31,6 +32,7 @@ F3 "" 0 0 50 H I C CNN
 $FPLIST
  Jumper*
  TestPoint*2Pads*
+ TestPoint*Bridge*
 $ENDFPLIST
 DRAW
 A 0 -30 100 1269 531 0 1 0 N -60 50 60 50
@@ -51,6 +53,7 @@ F3 "" 0 0 50 H I C CNN
 $FPLIST
  Jumper*
  TestPoint*3Pads*
+ TestPoint*Bridge*
 $ENDFPLIST
 DRAW
 A -65 -50 89 1282 518 0 1 0 N -120 20 -10 20
@@ -74,6 +77,7 @@ F3 "" 0 0 50 H I C CNN
 $FPLIST
  Jumper*
  TestPoint*3Pads*
+ TestPoint*Bridge*
 $ENDFPLIST
 DRAW
 A -65 -30 89 1282 518 0 1 0 N -120 40 -10 40


### PR DESCRIPTION
Both solder jumpers and non-solder jumpers had FP filters for solder jumpers. I removed the solder jumper FP filter for the latter and added a non-solder jumper FP filter (of which we have none right now) and also a FP filter for testpoints with multiple pads which would work for jumpers.

We could add jumper footprints the same or similar to the testpoint footprints we have now, but I wasn't sure if that would be accepted having the same footprints twice.

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the symbol(s) you are contributing
- [ ] An example screenshot image is very helpful
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
  - A new fitting footprint must be submitted if the library does not yet contain one.
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.
