### PR TITLE
Add TestPoint_Small

### DIFF
--- a/Connector.dcm
+++ b/Connector.dcm
@@ -1698,6 +1698,12 @@ K test point tp
 F ~
 $ENDCMP
 #
+$CMP TestPoint_Small
+D test point
+K test point tp
+F ~
+$ENDCMP
+#
 $CMP UEXT_Host
 D Universal EXTension (UEXT) is a connector layout which includes power and three serial buses: Asynchronous, I2C, and SPI
 K UEXT, SPI, UART, I2C

--- a/Connector.lib
+++ b/Connector.lib
@@ -15373,6 +15373,23 @@ X 1 1 0 0 0 U 50 50 1 1 P
 ENDDRAW
 ENDDEF
 #
+# TestPoint_Small
+#
+DEF TestPoint_Small TP 0 30 N N 1 F N
+F0 "TP" 0 150 50 H V C CNN
+F1 "TestPoint_Small" 0 80 50 H V C CNN
+F2 "" 200 0 50 H I C CNN
+F3 "" 200 0 50 H I C CNN
+$FPLIST
+ Pin*
+ Test*
+$ENDFPLIST
+DRAW
+C 0 0 20 0 1 0 N
+X 1 1 0 0 0 U 50 50 1 1 P
+ENDDRAW
+ENDDEF
+#
 # UEXT_Host
 #
 DEF UEXT_Host J 0 20 Y Y 1 F N


### PR DESCRIPTION
Added a really small testpoint that's super useful for compact schematics, or just sprinkling on pins that would normally be NC.
![TestPoint_Small](https://user-images.githubusercontent.com/3586264/70855308-c4a62b80-1ec0-11ea-9535-97d0998525ce.png)

An example of the symbol being used, once on top of a wire junction and once not:
![2019-12-14-14:28:58](https://user-images.githubusercontent.com/3586264/70855343-367e7500-1ec1-11ea-8319-dd549697d294.png)

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the symbol(s) you are contributing
- [x] An example screenshot image is very helpful
- [x] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
  - A new fitting footprint must be submitted if the library does not yet contain one.
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [x] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.
