### PR TITLE
Fix simulation DIODE and OPAMP primitive types

### DIFF
--- a/Simulation_SPICE.lib
+++ b/Simulation_SPICE.lib
@@ -9,7 +9,7 @@ F1 "DIODE" 0 -100 50 H V C CNN
 F2 "" 0 0 50 H I C CNN
 F3 "" 0 0 50 H I C CNN
 F4 "Y" 0 0 50 H I L CNN "Spice_Netlist_Enabled"
-F5 "V" 0 0 50 H I L CNN "Spice_Primitive"
+F5 "D" 0 0 50 H I L CNN "Spice_Primitive"
 DRAW
 P 2 0 1 0 50 0 -50 0 N
 P 2 0 1 10 50 50 50 -50 N
@@ -233,7 +233,7 @@ F1 "OPAMP" 150 -125 50 H V L CNN
 F2 "" 0 0 50 H I C CNN
 F3 "" 0 0 50 H I C CNN
 F4 "Y" 0 0 50 H I L CNN "Spice_Netlist_Enabled"
-F5 "V" 0 0 50 H I L CNN "Spice_Primitive"
+F5 "X" 0 0 50 H I L CNN "Spice_Primitive"
 DRAW
 P 4 0 1 10 200 0 -200 200 -200 -200 200 0 f
 X + 1 -300 100 100 R 50 50 1 1 I


### PR DESCRIPTION
As mentioned at https://forum.kicad.info/t/where-is-the-right-place-to-get-in-touch-with-a-kicad-dev/20738/17. Makes the DIODE symbol default to a diode and the OPAMP symbol default to an opamp with a subcircuit implementation. The actual simulation model is still left up to the user.

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the symbol(s) you are contributing
- [ ] An example screenshot image is very helpful
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
  - A new fitting footprint must be submitted if the library does not yet contain one.
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.
