### PR TITLE
issue-2895 correcting fairchildsemi.com dead links

### DIFF
--- a/4xxx.dcm
+++ b/4xxx.dcm
@@ -141,7 +141,7 @@ $ENDCMP
 $CMP 4047
 D Monostable/Astable Multivibrator
 K CMOS monostable astable multivibrator
-F https://www.fairchildsemi.com/datasheets/CD/CD4047BC.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/CD4047BC.pdf
 $ENDCMP
 #
 $CMP 4049

--- a/4xxx.dcm
+++ b/4xxx.dcm
@@ -141,7 +141,7 @@ $ENDCMP
 $CMP 4047
 D Monostable/Astable Multivibrator
 K CMOS monostable astable multivibrator
-F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/CD4047BC.pdf
+https://www.ti.com/lit/ds/symlink/cd4047b.pdf
 $ENDCMP
 #
 $CMP 4049

--- a/Analog_Switch.dcm
+++ b/Analog_Switch.dcm
@@ -392,13 +392,13 @@ $ENDCMP
 $CMP FSA3157L6X
 D Single SPDT Low-Voltage Analog Switch or 2:1 Multiplexer/De-Multiplexer Bus Switch, 10Ohm Ron, MicroPak-6
 K CMOS Analog Switch
-F https://www.fairchildsemi.com/datasheets/NC/NC7SB3157.pdf
+F https://www.onsemi.com/pub/Collateral/NC7SB3157-D.PDF
 $ENDCMP
 #
 $CMP FSA3157P6X
 D Single SPDT Low-Voltage Analog Switch or 2:1 Multiplexer/De-Multiplexer Bus Switch, 10Ohm Ron, SC-70-6
 K CMOS Analog Switch
-F https://www.fairchildsemi.com/datasheets/NC/NC7SB3157.pdf
+F https://www.onsemi.com/pub/Collateral/NC7SB3157-D.PDF
 $ENDCMP
 #
 $CMP HI524
@@ -602,13 +602,13 @@ $ENDCMP
 $CMP NC7SB3157L6X
 D Single SPDT Low-Voltage Analog Switch or 2:1 Multiplexer/De-Multiplexer Bus Switch, 10Ohm Ron, MicroPak-6
 K CMOS Analog Switch
-F https://www.fairchildsemi.com/datasheets/NC/NC7SB3157.pdf
+F https://www.onsemi.com/pub/Collateral/NC7SB3157-D.PDF
 $ENDCMP
 #
 $CMP NC7SB3157P6X
 D Single SPDT Low-Voltage Analog Switch or 2:1 Multiplexer/De-Multiplexer Bus Switch, 10Ohm Ron, SC-70-6
 K CMOS Analog Switch
-F https://www.fairchildsemi.com/datasheets/NC/NC7SB3157.pdf
+F https://www.onsemi.com/pub/Collateral/NC7SB3157-D.PDF
 $ENDCMP
 #
 $CMP SN74CBT3253

--- a/Driver_FET.dcm
+++ b/Driver_FET.dcm
@@ -69,7 +69,7 @@ $ENDCMP
 $CMP FAN7371
 D High-Current High-Side Gate Driver, 600V Vs, 4A Io, SOIC-8
 K high-side gate driver
-F https://www.fairchildsemi.com/datasheets/FA/FAN7371.pdf
+F https://www.onsemi.com/pub/Collateral/FAN7371-D.pdf
 $ENDCMP
 #
 $CMP FAN7388

--- a/Isolator.dcm
+++ b/Isolator.dcm
@@ -381,19 +381,19 @@ $ENDCMP
 $CMP H11L1
 D Schmitt Trigger Output Optocoupler, High Speed, DIP-6, 1.6mA turn on threshold
 K High Speed Schmitt Optocoupler
-F https://www.fairchildsemi.com/datasheets/H1/H11L1M.pdf
+F https://www.onsemi.com/pub/Collateral/H11L3M-D.PDF
 $ENDCMP
 #
 $CMP H11L2
 D Schmitt Trigger Output Optocoupler, High Speed, DIP-6, 10mA turn on threshold
 K High Speed Schmitt Optocoupler
-F https://www.fairchildsemi.com/datasheets/H1/H11L1M.pdf
+F https://www.onsemi.com/pub/Collateral/H11L3M-D.PDF
 $ENDCMP
 #
 $CMP H11L3
 D Schmitt Trigger Output Optocoupler, High Speed, DIP-6, 5mA turn on threshold
 K High Speed Schmitt Optocoupler
-F https://www.fairchildsemi.com/datasheets/H1/H11L1M.pdf
+F https://www.onsemi.com/pub/Collateral/H11L3M-D.PDF
 $ENDCMP
 #
 $CMP HCNW2201

--- a/Regulator_Linear.dcm
+++ b/Regulator_Linear.dcm
@@ -1719,7 +1719,7 @@ $ENDCMP
 $CMP KA78M05_TO252
 D Positive 500mA 35V Linear Regulator, Fixed Output 5V, TO-252 (D-PAK)
 K Voltage Regulator 500mA Positive
-F https://www.ti.com/lit/ds/symlink/lm341.pdf
+F https://www.onsemi.com/pub/Collateral/MC78M00-D.PDF
 $ENDCMP
 #
 $CMP L200
@@ -3051,91 +3051,91 @@ $ENDCMP
 $CMP LM7805_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 5V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.cn/PowerSolutions/document/MC7800-D.PDF
 $ENDCMP
 #
 $CMP LM7806_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 6V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.cn/PowerSolutions/document/MC7800-D.PDF
 $ENDCMP
 #
 $CMP LM7808_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 8V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.cn/PowerSolutions/document/MC7800-D.PDF
 $ENDCMP
 #
 $CMP LM7809_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 9V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.cn/PowerSolutions/document/MC7800-D.PDF
 $ENDCMP
 #
 $CMP LM7810_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 10V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.cn/PowerSolutions/document/MC7800-D.PDF
 $ENDCMP
 #
 $CMP LM7812_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 12V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.cn/PowerSolutions/document/MC7800-D.PDF
 $ENDCMP
 #
 $CMP LM7815_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 15V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.cn/PowerSolutions/document/MC7800-D.PDF
 $ENDCMP
 #
 $CMP LM7818_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 18V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.cn/PowerSolutions/document/MC7800-D.PDF
 $ENDCMP
 #
 $CMP LM7824_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 24V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.cn/PowerSolutions/document/MC7800-D.PDF
 $ENDCMP
 #
 $CMP LM78L05_SO8
 D Positive 100mA 30V Linear Regulator, Fixed Output 5V, SO-8
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP LM78L05_TO92
 D Positive 100mA 30V Linear Regulator, Fixed Output 5V, TO-92
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP LM78L12_SO8
 D Positive 100mA 30V Linear Regulator, Fixed Output 12V, SO-8
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP LM78L12_TO92
 D Positive 100mA 30V Linear Regulator, Fixed Output 12V, TO-92
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP LM78M05_TO220
 D Positive 500mA 35V Linear Regulator, Fixed Output 5V, TO-220
 K Voltage Regulator 500mA Positive
-F https://www.ti.com/lit/ds/symlink/lm341.pdf
+F https://www.onsemi.com/pub/Collateral/MC78M00-D.PDF
 $ENDCMP
 #
 $CMP LM78M05_TO252
 D Positive 500mA 35V Linear Regulator, Fixed Output 5V, TO-252 (D-PAK)
 K Voltage Regulator 500mA Positive
-F https://www.ti.com/lit/ds/symlink/lm341.pdf
+F https://www.onsemi.com/pub/Collateral/MC78M00-D.PDF
 $ENDCMP
 #
 $CMP LM7905_TO220
@@ -4569,79 +4569,79 @@ $ENDCMP
 $CMP MC78L05_SO8
 D Positive 100mA 30V Linear Regulator, Fixed Output 5V, SO-8
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP MC78L05_SOT89
 D Positive 100mA 30V Linear Regulator, Fixed Output 5V, SOT-89
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP MC78L05_TO92
 D Positive 100mA 30V Linear Regulator, Fixed Output 5V, TO-92
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP MC78L06_SO8
 D Positive 100mA 30V Linear Regulator, Fixed Output 6V, SO-8
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP MC78L06_TO92
 D Positive 100mA 30V Linear Regulator, Fixed Output 6V, TO-92
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP MC78L08_SO8
 D Positive 100mA 30V Linear Regulator, Fixed Output 8V, SO-8
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP MC78L08_SOT89
 D Positive 100mA 30V Linear Regulator, Fixed Output 8V, SOT-89
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP MC78L08_TO92
 D Positive 100mA 30V Linear Regulator, Fixed Output 8V, TO-92
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP MC78L12_SO8
 D Positive 100mA 30V Linear Regulator, Fixed Output 12V, SO-8
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP MC78L12_SOT89
 D Positive 100mA 30V Linear Regulator, Fixed Output 12V, SOT-89
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP MC78L12_TO92
 D Positive 100mA 30V Linear Regulator, Fixed Output 12V, TO-92
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP MC78L15_SO8
 D Positive 100mA 30V Linear Regulator, Fixed Output 15V, SO-8
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP MC78L15_TO92
 D Positive 100mA 30V Linear Regulator, Fixed Output 15V, TO-92
 K Voltage Regulator 100mA Positive
-F http://www.farnell.com/datasheets/2283910.pdf
+F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
 $ENDCMP
 #
 $CMP MC78L18_SO8
@@ -4671,7 +4671,7 @@ $ENDCMP
 $CMP MC78M05_TO252
 D Positive 500mA 35V Linear Regulator, Fixed Output 5V, TO-252 (D-PAK)
 K Voltage Regulator 500mA Positive
-F https://www.ti.com/lit/ds/symlink/lm341.pdf
+F https://www.onsemi.com/pub/Collateral/MC78M00-D.PDF
 $ENDCMP
 #
 $CMP MC7905

--- a/Regulator_Linear.dcm
+++ b/Regulator_Linear.dcm
@@ -1701,25 +1701,25 @@ $ENDCMP
 $CMP KA378R05
 D Positive 3A 35V Linear Regulator with Disable Pin, LDO, Fixed Output 5V, TO-220F-4L
 K Voltage Regulator 3A Positive LDO Disable Pin
-F http://www.fairchildsemi.com/ds/KA/KA378R05.pdf
+F https://www.onsemi.com/pub/Collateral/KA378R05-D.pdf
 $ENDCMP
 #
 $CMP KA378R12C
 D Positive 3A 35V Linear Regulator with Disable Pin, LDO, Fixed Output 12V, TO-220F-4L
 K Voltage Regulator 3A Positive LDO Disable Pin
-F https://www.fairchildsemi.com/datasheets/KA/KA378R12CTU.pdf
+F https://www.onsemi.com/pub/Collateral/KA378R12CTU-D.pdf
 $ENDCMP
 #
 $CMP KA378R33
 D Positive 3A 35V Linear Regulator with Disable Pin, LDO, Fixed Output 3.3V, TO-220F-4L
 K Voltage Regulator 3A Positive LDO Disable Pin
-F https://www.fairchildsemi.com/datasheets/KA/KA378R33.pdf
+F https://www.onsemi.com/pub/Collateral/KA378R33-D.pdf
 $ENDCMP
 #
 $CMP KA78M05_TO252
 D Positive 500mA 35V Linear Regulator, Fixed Output 5V, TO-252 (D-PAK)
 K Voltage Regulator 500mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78M05.pdf
+F https://www.ti.com/lit/ds/symlink/lm341.pdf
 $ENDCMP
 #
 $CMP L200
@@ -2985,19 +2985,19 @@ $ENDCMP
 $CMP LM341T-05_TO220
 D Positive 500mA 35V Linear Regulator, Fixed Output 5V, TO-220
 K Voltage Regulator 500mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78M05.pdf
+F https://www.ti.com/lit/ds/symlink/lm341.pdf
 $ENDCMP
 #
 $CMP LM341T-12_TO220
 D Positive 500mA 35V Linear Regulator, Fixed Output 12V, TO-220
 K Voltage Regulator 500mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78M05.pdf
+F https://www.ti.com/lit/ds/symlink/lm341.pdf
 $ENDCMP
 #
 $CMP LM341T-15_TO220
 D Positive 500mA 35V Linear Regulator, Fixed Output 15V, TO-220
 K Voltage Regulator 500mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78M05.pdf
+F https://www.ti.com/lit/ds/symlink/lm341.pdf
 $ENDCMP
 #
 $CMP LM3480-12
@@ -3027,7 +3027,7 @@ $ENDCMP
 $CMP LM350_TO220
 D 3A 33V Adjustable Linear Regulator, TO-220
 K Adjustable Voltage Regulator 3A Positive
-F http://www.fairchildsemi.com/ds/LM/LM350.pdf
+F https://www.onsemi.com/pub/Collateral/LM350-D.pdf
 $ENDCMP
 #
 $CMP LM350_TO3
@@ -3051,145 +3051,145 @@ $ENDCMP
 $CMP LM7805_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 5V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.fairchildsemi.com/ds/LM/LM7805.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP LM7806_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 6V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.fairchildsemi.com/ds/LM/LM7805.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP LM7808_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 8V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.fairchildsemi.com/ds/LM/LM7805.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP LM7809_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 9V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.fairchildsemi.com/ds/LM/LM7805.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP LM7810_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 10V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.fairchildsemi.com/ds/LM/LM7805.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP LM7812_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 12V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.fairchildsemi.com/ds/LM/LM7805.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP LM7815_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 15V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.fairchildsemi.com/ds/LM/LM7805.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP LM7818_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 18V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.fairchildsemi.com/ds/LM/LM7805.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP LM7824_TO220
 D Positive 1A 35V Linear Regulator, Fixed Output 24V, TO-220
 K Voltage Regulator 1A Positive
-F http://www.fairchildsemi.com/ds/LM/LM7805.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP LM78L05_SO8
 D Positive 100mA 30V Linear Regulator, Fixed Output 5V, SO-8
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP LM78L05_TO92
 D Positive 100mA 30V Linear Regulator, Fixed Output 5V, TO-92
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP LM78L12_SO8
 D Positive 100mA 30V Linear Regulator, Fixed Output 12V, SO-8
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP LM78L12_TO92
 D Positive 100mA 30V Linear Regulator, Fixed Output 12V, TO-92
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP LM78M05_TO220
 D Positive 500mA 35V Linear Regulator, Fixed Output 5V, TO-220
 K Voltage Regulator 500mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78M05.pdf
+F https://www.ti.com/lit/ds/symlink/lm341.pdf
 $ENDCMP
 #
 $CMP LM78M05_TO252
 D Positive 500mA 35V Linear Regulator, Fixed Output 5V, TO-252 (D-PAK)
 K Voltage Regulator 500mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78M05.pdf
+F https://www.ti.com/lit/ds/symlink/lm341.pdf
 $ENDCMP
 #
 $CMP LM7905_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 5V, TO-220
 K Voltage Regulator 1A Negative
-F http://www.fairchildsemi.com/ds/LM/LM7905.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
 $ENDCMP
 #
 $CMP LM7906_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 6V, TO-220
 K Voltage Regulator 1A Negative
-F http://www.fairchildsemi.com/ds/LM/LM7905.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
 $ENDCMP
 #
 $CMP LM7908_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 8V, TO-220
 K Voltage Regulator 1A Negative
-F http://www.fairchildsemi.com/ds/LM/LM7905.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
 $ENDCMP
 #
 $CMP LM7909_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 9V, TO-220
 K Voltage Regulator 1A Negative
-F http://www.fairchildsemi.com/ds/LM/LM7905.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
 $ENDCMP
 #
 $CMP LM7910_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 10V, TO-220
 K Voltage Regulator 1A Negative
-F http://www.fairchildsemi.com/ds/LM/LM7905.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
 $ENDCMP
 #
 $CMP LM7912_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 12V, TO-220
 K Voltage Regulator 1A Negative
-F http://www.fairchildsemi.com/ds/LM/LM7905.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
 $ENDCMP
 #
 $CMP LM7915_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 15V, TO-220
 K Voltage Regulator 1A Negative
-F http://www.fairchildsemi.com/ds/LM/LM7905.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
 $ENDCMP
 #
 $CMP LM7918_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 18V, TO-220
 K Voltage Regulator 1A Negative
-F http://www.fairchildsemi.com/ds/LM/LM7905.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
 $ENDCMP
 #
 $CMP LM7924_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 24V, TO-220
 K Voltage Regulator 1A Negative
-F http://www.fairchildsemi.com/ds/LM/LM7905.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
 $ENDCMP
 #
 $CMP LM79L05_TO92
@@ -3213,19 +3213,19 @@ $ENDCMP
 $CMP LM79M05_TO220
 D Negative 500mA 35V Linear Regulator, Fixed Output 5V, TO-220
 K Voltage Regulator 500mA Negative
-F http://www.fairchildsemi.com/ds/LM/LM79M05.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/KA79MXX,LM79MXX.pdf
 $ENDCMP
 #
 $CMP LM79M12_TO220
 D Negative 500mA 35V Linear Regulator, Fixed Output 12V, TO-220
 K Voltage Regulator 500mA Negative
-F http://www.fairchildsemi.com/ds/LM/LM79M05.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/KA79MXX,LM79MXX.pdf
 $ENDCMP
 #
 $CMP LM79M15_TO220
 D Negative 500mA 35V Linear Regulator, Fixed Output 15V, TO-220
 K Voltage Regulator 500mA Negative
-F http://www.fairchildsemi.com/ds/LM/LM79M05.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/KA79MXX,LM79MXX.pdf
 $ENDCMP
 #
 $CMP LP2950-3.0_TO252
@@ -4569,79 +4569,79 @@ $ENDCMP
 $CMP MC78L05_SO8
 D Positive 100mA 30V Linear Regulator, Fixed Output 5V, SO-8
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP MC78L05_SOT89
 D Positive 100mA 30V Linear Regulator, Fixed Output 5V, SOT-89
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP MC78L05_TO92
 D Positive 100mA 30V Linear Regulator, Fixed Output 5V, TO-92
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP MC78L06_SO8
 D Positive 100mA 30V Linear Regulator, Fixed Output 6V, SO-8
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP MC78L06_TO92
 D Positive 100mA 30V Linear Regulator, Fixed Output 6V, TO-92
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP MC78L08_SO8
 D Positive 100mA 30V Linear Regulator, Fixed Output 8V, SO-8
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP MC78L08_SOT89
 D Positive 100mA 30V Linear Regulator, Fixed Output 8V, SOT-89
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP MC78L08_TO92
 D Positive 100mA 30V Linear Regulator, Fixed Output 8V, TO-92
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP MC78L12_SO8
 D Positive 100mA 30V Linear Regulator, Fixed Output 12V, SO-8
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP MC78L12_SOT89
 D Positive 100mA 30V Linear Regulator, Fixed Output 12V, SOT-89
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP MC78L12_TO92
 D Positive 100mA 30V Linear Regulator, Fixed Output 12V, TO-92
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP MC78L15_SO8
 D Positive 100mA 30V Linear Regulator, Fixed Output 15V, SO-8
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP MC78L15_TO92
 D Positive 100mA 30V Linear Regulator, Fixed Output 15V, TO-92
 K Voltage Regulator 100mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78L05A.pdf
+F http://www.farnell.com/datasheets/2283910.pdf
 $ENDCMP
 #
 $CMP MC78L18_SO8
@@ -4671,7 +4671,7 @@ $ENDCMP
 $CMP MC78M05_TO252
 D Positive 500mA 35V Linear Regulator, Fixed Output 5V, TO-252 (D-PAK)
 K Voltage Regulator 500mA Positive
-F http://www.fairchildsemi.com/ds/LM/LM78M05.pdf
+F https://www.ti.com/lit/ds/symlink/lm341.pdf
 $ENDCMP
 #
 $CMP MC7905

--- a/Regulator_Linear.dcm
+++ b/Regulator_Linear.dcm
@@ -3105,25 +3105,25 @@ $ENDCMP
 $CMP LM78L05_SO8
 D Positive 100mA 30V Linear Regulator, Fixed Output 5V, SO-8
 K Voltage Regulator 100mA Positive
-F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
+F https://www.onsemi.com/pub/Collateral/MC78L06A-D.pdf
 $ENDCMP
 #
 $CMP LM78L05_TO92
 D Positive 100mA 30V Linear Regulator, Fixed Output 5V, TO-92
 K Voltage Regulator 100mA Positive
-F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
+F https://www.onsemi.com/pub/Collateral/MC78L06A-D.pdf
 $ENDCMP
 #
 $CMP LM78L12_SO8
 D Positive 100mA 30V Linear Regulator, Fixed Output 12V, SO-8
 K Voltage Regulator 100mA Positive
-F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
+F https://www.onsemi.com/pub/Collateral/MC78L06A-D.pdf
 $ENDCMP
 #
 $CMP LM78L12_TO92
 D Positive 100mA 30V Linear Regulator, Fixed Output 12V, TO-92
 K Voltage Regulator 100mA Positive
-F https://www.onsemi.com/pub/Collateral/MC78L00A-D.PDF
+F https://www.onsemi.com/pub/Collateral/MC78L06A-D.pdf
 $ENDCMP
 #
 $CMP LM78M05_TO220

--- a/Regulator_Linear.dcm
+++ b/Regulator_Linear.dcm
@@ -3141,55 +3141,55 @@ $ENDCMP
 $CMP LM7905_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 5V, TO-220
 K Voltage Regulator 1A Negative
-F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
+F https://www.onsemi.com/pub/Collateral/MC7900-D.PDF
 $ENDCMP
 #
 $CMP LM7906_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 6V, TO-220
 K Voltage Regulator 1A Negative
-F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
+F https://www.onsemi.com/pub/Collateral/MC7900-D.PDF
 $ENDCMP
 #
 $CMP LM7908_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 8V, TO-220
 K Voltage Regulator 1A Negative
-F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
+F https://www.onsemi.com/pub/Collateral/MC7900-D.PDF
 $ENDCMP
 #
 $CMP LM7909_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 9V, TO-220
 K Voltage Regulator 1A Negative
-F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
+F https://www.onsemi.com/pub/Collateral/MC7900-D.PDF
 $ENDCMP
 #
 $CMP LM7910_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 10V, TO-220
 K Voltage Regulator 1A Negative
-F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
+F https://www.onsemi.com/pub/Collateral/MC7900-D.PDF
 $ENDCMP
 #
 $CMP LM7912_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 12V, TO-220
 K Voltage Regulator 1A Negative
-F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
+F hhttps://www.onsemi.com/pub/Collateral/MC7900-D.PDF
 $ENDCMP
 #
 $CMP LM7915_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 15V, TO-220
 K Voltage Regulator 1A Negative
-F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
+F https://www.onsemi.com/pub/Collateral/MC7900-D.PDF
 $ENDCMP
 #
 $CMP LM7918_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 18V, TO-220
 K Voltage Regulator 1A Negative
-F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
+F https://www.onsemi.com/pub/Collateral/MC7900-D.PDF
 $ENDCMP
 #
 $CMP LM7924_TO220
 D Negative 1A 35V Linear Regulator, Fixed Output 24V, TO-220
 K Voltage Regulator 1A Negative
-F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/LM79xx_Rev2011.pdf
+F https://www.onsemi.com/pub/Collateral/MC7900-D.PDF
 $ENDCMP
 #
 $CMP LM79L05_TO92
@@ -3213,19 +3213,19 @@ $ENDCMP
 $CMP LM79M05_TO220
 D Negative 500mA 35V Linear Regulator, Fixed Output 5V, TO-220
 K Voltage Regulator 500mA Negative
-F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/KA79MXX,LM79MXX.pdf
+F https://www.onsemi.com/pub/Collateral/MC79M00-D.PDF
 $ENDCMP
 #
 $CMP LM79M12_TO220
 D Negative 500mA 35V Linear Regulator, Fixed Output 12V, TO-220
 K Voltage Regulator 500mA Negative
-F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/KA79MXX,LM79MXX.pdf
+F https://www.onsemi.com/pub/Collateral/MC79M00-D.PDF
 $ENDCMP
 #
 $CMP LM79M15_TO220
 D Negative 500mA 35V Linear Regulator, Fixed Output 15V, TO-220
 K Voltage Regulator 500mA Negative
-F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/KA79MXX,LM79MXX.pdf
+F https://www.onsemi.com/pub/Collateral/MC79M00-D.PDF
 $ENDCMP
 #
 $CMP LP2950-3.0_TO252

--- a/Regulator_Switching.dcm
+++ b/Regulator_Switching.dcm
@@ -435,13 +435,13 @@ $ENDCMP
 $CMP FSBH0170
 D Green Mode Fairchild Power Switch, 700V Vds, 1.0A Id, 15W/13W 230V/85-265V, VIN Pin, DIP-8
 K smps regulator
-F https://www.fairchildsemi.com/datasheets/FS/FSBH0370.pdf
+F https://www.onsemi.com/pub/Collateral/FSBH0270-D.PDF
 $ENDCMP
 #
 $CMP FSBH0170A
 D Green Mode Fairchild Power Switch, 700V Vds, 1.0A Id, 15W/13W 230V/85-265V, DIP-8
 K smps regulator
-F https://www.fairchildsemi.com/datasheets/FS/FSBH0370.pdf
+F https://www.onsemi.com/pub/Collateral/FSBH0270-D.PDF
 $ENDCMP
 #
 $CMP FSBH0170W
@@ -453,13 +453,13 @@ $ENDCMP
 $CMP FSBH0270
 D Green Mode Fairchild Power Switch, 700V Vds, 2.0A Id, 20W/16W 230V/85-265V, VIN Pin, DIP-8
 K smps regulator
-F https://www.fairchildsemi.com/datasheets/FS/FSBH0370.pdf
+F https://www.onsemi.com/pub/Collateral/FSBH0270-D.PDF
 $ENDCMP
 #
 $CMP FSBH0270A
 D Green Mode Fairchild Power Switch, 700V Vds, 2.0A Id, 20W/16W 230V/85-265V, DIP-8
 K smps regulator
-F https://www.fairchildsemi.com/datasheets/FS/FSBH0370.pdf
+F https://www.onsemi.com/pub/Collateral/FSBH0270-D.PDF
 $ENDCMP
 #
 $CMP FSBH0270W
@@ -471,13 +471,13 @@ $ENDCMP
 $CMP FSBH0370
 D Green Mode Fairchild Power Switch, 700V Vds, 3.0A Id, 25W/19W 230V/85-265V, VIN Pin, DIP-8
 K smps regulator
-F https://www.fairchildsemi.com/datasheets/FS/FSBH0370.pdf
+F https://www.onsemi.com/pub/Collateral/FSBH0270-D.PDF
 $ENDCMP
 #
 $CMP FSBH0F70A
 D Green Mode Fairchild Power Switch, 700V Vds, 0.5A Id, 10W/8W 230V/85-265V, DIP-8
 K smps regulator
-F https://www.fairchildsemi.com/datasheets/FS/FSBH0370.pdf
+F https://www.onsemi.com/pub/Collateral/FSBH0270-D.PDF
 $ENDCMP
 #
 $CMP FSBH0F70WA
@@ -489,31 +489,31 @@ $ENDCMP
 $CMP FSDH321
 D 17W SMPS Controller, 100kHz, AC-DC, PDIP-8
 K SMPS Controller with MOSFET 17W AC-DC
-F www.fairchildsemi.com/ds/FS/FSDH321.pdf
+F https://www.onsemi.com/pub/Collateral/FSDH321JP-D.pdf
 $ENDCMP
 #
 $CMP FSDH321L
 D 17W SMPS Controller, 100kHz, AC-DC, SMD-8
 K SMPS Controller with MOSFET 17W AC-DC
-F www.fairchildsemi.com/ds/FS/FSDH321.pdf
+F https://www.onsemi.com/pub/Collateral/FSDH321JP-D.pdf
 $ENDCMP
 #
 $CMP FSDL321
 D 17W SMPS Controller, 50kHz, AC-DC, PDIP-8
 K SMPS Controller with MOSFET 17W AC-DC
-F www.fairchildsemi.com/ds/FS/FSDH321.pdf
+F https://www.onsemi.com/pub/Collateral/FSDH321JP-D.pdf
 $ENDCMP
 #
 $CMP FSDL321L
 D 17W SMPS Controller, 50kHz, AC-DC, SMD-8
 K SMPS Controller with MOSFET 17W AC-DC
-F www.fairchildsemi.com/ds/FS/FSDH321.pdf
+F https://www.onsemi.com/pub/Collateral/FSDH321JP-D.pdf
 $ENDCMP
 #
 $CMP FSL136MRT
 D 67kHz SMPS Controller w/ Soft Start, max. 50W AC-DC, TO-220F-6L
 K SMPS Controller 50W AC-DC
-F http://www.fairchildsemi.com/ds/FS/FSL136MRT.pdf
+F https://www.onsemi.com/pub/Collateral/FSL136MRT-D.pdf
 $ENDCMP
 #
 $CMP FSQ0565RQLDTU

--- a/Relay_SolidState.dcm
+++ b/Relay_SolidState.dcm
@@ -45,61 +45,61 @@ $ENDCMP
 $CMP FOD420
 D Random Phase Opto-Triac, Vdrm 600V, Ift 0.75mA, Itm 300mA, DIP6
 K Opto-Triac Opto Triac Random Phase
-F http://www.fairchildsemi.com/ds/FO/FOD4218.pdf
+F https://www.onsemi.com/pub/Collateral/FOD4218-D.PDF
 $ENDCMP
 #
 $CMP FOD4208
 D Random Phase Opto-Triac, Vdrm 800V, Ift 0.75mA, Itm 300mA, DIP6
 K Opto-Triac Opto Triac Random Phase
-F http://www.fairchildsemi.com/ds/FO/FOD4218.pdf
+F https://www.onsemi.com/pub/Collateral/FOD4218-D.PDF
 $ENDCMP
 #
 $CMP FOD4216
 D Random Phase Opto-Triac, Vdrm 600V, Ift 0.75mA, Itm 300mA, DIP6
 K Opto-Triac Opto Triac Random Phase
-F http://www.fairchildsemi.com/ds/FO/FOD4218.pdf
+F https://www.onsemi.com/pub/Collateral/FOD4218-D.PDF
 $ENDCMP
 #
 $CMP FOD4218
 D Random Phase Opto-Triac, Vdrm 800V, Ift 0.75mA, Itm 300mA, DIP6
 K Opto-Triac Opto Triac Random Phase
-F http://www.fairchildsemi.com/ds/FO/FOD4218.pdf
+F https://www.onsemi.com/pub/Collateral/FOD4218-D.PDF
 $ENDCMP
 #
 $CMP FODM3011
 D Full Pitch Mini-Flat Random Phase Opto-Triac, Vdrm 250V, Ift 10mA, MFP 4L
 K Opto-Triac Opto Triac Random Phase Mini-Flat
-F http://www.fairchildsemi.com/ds/FO/FODM3053.pdf
+F https://www.onsemi.com/pub/Collateral/FODM3053_NF098-D.PDF
 $ENDCMP
 #
 $CMP FODM3012
 D Full Pitch Mini-Flat Random Phase Opto-Triac, Vdrm 250V, Ift 5mA, MFP 4L
 K Opto-Triac Opto Triac Random Phase Mini-Flat
-F http://www.fairchildsemi.com/ds/FO/FODM3053.pdf
+F https://www.onsemi.com/pub/Collateral/FODM3053_NF098-D.PDF
 $ENDCMP
 #
 $CMP FODM3022
 D Full Pitch Mini-Flat Random Phase Opto-Triac, Vdrm 400V, Ift 10mA, MFP 4L
 K Opto-Triac Opto Triac Random Phase Mini-Flat
-F http://www.fairchildsemi.com/ds/FO/FODM3053.pdf
+F https://www.onsemi.com/pub/Collateral/FODM3053_NF098-D.PDF
 $ENDCMP
 #
 $CMP FODM3023
 D Full Pitch Mini-Flat Random Phase Opto-Triac, Vdrm 400V, Ift 5mA, MFP 4L
 K Opto-Triac Opto Triac Random Phase Mini-Flat
-F http://www.fairchildsemi.com/ds/FO/FODM3053.pdf
+F https://www.onsemi.com/pub/Collateral/FODM3053_NF098-D.PDF
 $ENDCMP
 #
 $CMP FODM3052
 D Full Pitch Mini-Flat Random Phase Opto-Triac, Vdrm 600V, Ift 10mA, MFP 4L
 K Opto-Triac Opto Triac Random Phase Mini-Flat
-F http://www.fairchildsemi.com/ds/FO/FODM3053.pdf
+F https://www.onsemi.com/pub/Collateral/FODM3053_NF098-D.PDF
 $ENDCMP
 #
 $CMP FODM3053
 D Full Pitch Mini-Flat Random Phase Opto-Triac, Vdrm 600V, Ift 5mA, MFP 4L
 K Opto-Triac Opto Triac Random Phase Mini-Flat
-F http://www.fairchildsemi.com/ds/FO/FODM3053.pdf
+F https://www.onsemi.com/pub/Collateral/FODM3053_NF098-D.PDF
 $ENDCMP
 #
 $CMP LAA110
@@ -123,139 +123,139 @@ $ENDCMP
 $CMP MOC3010M
 D Random Phase Opto-Triac, Vdrm 250V, Ift 15mA, DIP6
 K Opto-Triac Opto Triac Random Phase
-F http://www.fairchildsemi.com/ds/MO/MOC3020M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3023M-D.PDF
 $ENDCMP
 #
 $CMP MOC3011M
 D Random Phase Opto-Triac, Vdrm 250V, Ift 10mA, DIP6
 K Opto-Triac Opto Triac Random Phase
-F http://www.fairchildsemi.com/ds/MO/MOC3020M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3023M-D.PDF
 $ENDCMP
 #
 $CMP MOC3012M
 D Random Phase Opto-Triac, Vdrm 250V, Ift 5mA, DIP6
 K Opto-Triac Opto Triac Random Phase
-F http://www.fairchildsemi.com/ds/MO/MOC3020M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3023M-D.PDF
 $ENDCMP
 #
 $CMP MOC3020M
 D Random Phase Opto-Triac, Vdrm 400V, Ift 30mA, DIP6
 K Opto-Triac Opto Triac Random Phase
-F http://www.fairchildsemi.com/ds/MO/MOC3020M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3023M-D.PDF
 $ENDCMP
 #
 $CMP MOC3021M
 D Random Phase Opto-Triac, Vdrm 400V, Ift 15mA, DIP6
 K Opto-Triac Opto Triac Random Phase
-F http://www.fairchildsemi.com/ds/MO/MOC3020M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3023M-D.PDF
 $ENDCMP
 #
 $CMP MOC3022M
 D Random Phase Opto-Triac, Vdrm 400V, Ift 10mA, DIP6
 K Opto-Triac Opto Triac Random Phase
-F http://www.fairchildsemi.com/ds/MO/MOC3020M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3023M-D.PDF
 $ENDCMP
 #
 $CMP MOC3023M
 D Random Phase Opto-Triac, Vdrm 400V, Ift 5mA, DIP6
 K Opto-Triac Opto Triac Random Phase
-F http://www.fairchildsemi.com/ds/MO/MOC3020M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3023M-D.PDF
 $ENDCMP
 #
 $CMP MOC3031M
 D Zero Cross Opto-Triac, Vdrm 250V, Ift 15mA, DIP6
 K Opto-Triac Opto Triac Zero Cross
-F http://www.fairchildsemi.com/ds/MO/MOC3031M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3043M-D.pdf
 $ENDCMP
 #
 $CMP MOC3032M
 D Zero Cross Opto-Triac, Vdrm 250V, Ift 10mA, DIP6
 K Opto-Triac Opto Triac Zero Cross
-F http://www.fairchildsemi.com/ds/MO/MOC3031M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3043M-D.pdf
 $ENDCMP
 #
 $CMP MOC3033M
 D Zero Cross Opto-Triac, Vdrm 250V, Ift 5mA, DIP6
 K Opto-Triac Opto Triac Zero Cross
-F http://www.fairchildsemi.com/ds/MO/MOC3031M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3043M-D.pdf
 $ENDCMP
 #
 $CMP MOC3041M
 D Zero Cross Opto-Triac, Vdrm 400V, Ift 15mA, DIP6
 K Opto-Triac Opto Triac Zero Cross
-F http://www.fairchildsemi.com/ds/MO/MOC3031M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3043M-D.pdf
 $ENDCMP
 #
 $CMP MOC3042M
 D Zero Cross Opto-Triac, Vdrm 400V, Ift 10mA, DIP6
 K Opto-Triac Opto Triac Zero Cross
-F http://www.fairchildsemi.com/ds/MO/MOC3031M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3043M-D.pdf
 $ENDCMP
 #
 $CMP MOC3043M
 D Zero Cross Opto-Triac, Vdrm 400V, Ift 5mA, DIP6
 K Opto-Triac Opto Triac Zero Cross
-F http://www.fairchildsemi.com/ds/MO/MOC3031M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3043M-D.pdf
 $ENDCMP
 #
 $CMP MOC3051M
 D Random Phase Opto-Triac, Vdrm 600V, Ift 15mA, DIP6
 K Opto-Triac Opto Triac Random Phase
-F http://www.fairchildsemi.com/ds/MO/MOC3052M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3052M-D.PDF
 $ENDCMP
 #
 $CMP MOC3052M
 D Random Phase Opto-Triac, Vdrm 600V, Ift 10mA, DIP6
 K Opto-Triac Opto Triac Random Phase
-F http://www.fairchildsemi.com/ds/MO/MOC3052M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3052M-D.PDF
 $ENDCMP
 #
 $CMP MOC3061M
 D Zero Cross Opto-Triac, Vdrm 600V, Ift 15mA, DIP6
 K Opto-Triac Opto Triac Zero Cross
-F http://www.fairchildsemi.com/ds/MO/MOC3061M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3163M-D.pdf
 $ENDCMP
 #
 $CMP MOC3062M
 D Zero Cross Opto-Triac, Vdrm 600V, Ift 10mA, DIP6
 K Opto-Triac Opto Triac Zero Cross
-F http://www.fairchildsemi.com/ds/MO/MOC3061M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3163M-D.pdf
 $ENDCMP
 #
 $CMP MOC3063M
 D Zero Cross Opto-Triac, Vdrm 600V, Ift 5mA, DIP6
 K Opto-Triac Opto Triac Zero Cross
-F http://www.fairchildsemi.com/ds/MO/MOC3061M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3163M-D.pdf
 $ENDCMP
 #
 $CMP MOC3081M
 D Zero Cross Opto-Triac, Vdrm 800V, Ift 15mA, DIP6
 K Opto-Triac Opto Triac Zero Cross
-F http://www.fairchildsemi.com/ds/MO/MOC3081M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3083M-D.PDF
 $ENDCMP
 #
 $CMP MOC3082M
 D Zero Cross Opto-Triac, Vdrm 800V, Ift 10mA, DIP6
 K Opto-Triac Opto Triac Zero Cross
-F http://www.fairchildsemi.com/ds/MO/MOC3081M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3083M-D.PDF
 $ENDCMP
 #
 $CMP MOC3083M
 D Zero Cross Opto-Triac, Vdrm 800V, Ift 5mA, DIP6
 K Opto-Triac Opto Triac Zero Cross
-F http://www.fairchildsemi.com/ds/MO/MOC3081M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3083M-D.PDF
 $ENDCMP
 #
 $CMP MOC3162M
 D Zero Cross Opto-Triac, Vdrm 600V, Ift 10mA, dv/dt 1000, DIP6
 K Opto-Triac Opto Triac Zero Cross
-F http://www.fairchildsemi.com/ds/MO/MOC3061M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3163M-D.pdf
 $ENDCMP
 #
 $CMP MOC3163M
 D Zero Cross Opto-Triac, Vdrm 600V, Ift 5mA, dv/dt 1000, DIP6
 K Opto-Triac Opto Triac Zero Cross
-F http://www.fairchildsemi.com/ds/MO/MOC3061M.pdf
+F https://www.onsemi.com/pub/Collateral/MOC3163M-D.pdf
 $ENDCMP
 #
 $CMP S102S01

--- a/Transistor_BJT.dcm
+++ b/Transistor_BJT.dcm
@@ -27,19 +27,19 @@ $ENDCMP
 $CMP 2N3904
 D 0.2A Ic, 40V Vce, Small Signal NPN Transistor, TO-92
 K NPN Transistor
-F https://www.fairchildsemi.com/datasheets/2N/2N3904.pdf
+F https://www.onsemi.com/pub/Collateral/2N3903-D.PDF
 $ENDCMP
 #
 $CMP 2N3905
 D -0.2A Ic, -40V Vce, Small Signal PNP Transistor, TO-92
 K PNP Transistor
-F https://www.fairchildsemi.com/datasheets/2N/2N3905.pdf
+F https://www.mouser.fr/datasheet/2/308/FairchildSemiconductor_16142055386277-1191860.pdf
 $ENDCMP
 #
 $CMP 2N3906
 D -0.2A Ic, -40V Vce, Small Signal PNP Transistor, TO-92
 K PNP Transistor
-F https://www.fairchildsemi.com/datasheets/2N/2N3906.pdf
+F https://www.onsemi.com/pub/Collateral/2N3906-D.PDF
 $ENDCMP
 #
 $CMP 2SA1015
@@ -147,7 +147,7 @@ $ENDCMP
 $CMP BC240
 D 50mA Ic, 40V Vce, RF Signal NPN Transistor, TO-92
 K RF NPN Transistor
-F http://www.fairchildsemi.com/ds/BF/BF240.pdf
+F https://www.onsemi.com/pub/Collateral/BF420-D.PDF
 $ENDCMP
 #
 $CMP BC307
@@ -219,127 +219,127 @@ $ENDCMP
 $CMP BC516
 D 1A Ic, 30V Vce, Darlington PNP Transistor, TO-92
 K PNP Darlington Darl Transistor
-F http://www.fairchildsemi.com/ds/BC/BC516.pdf
+F https://www.onsemi.com/pub/Collateral/BC516-D.PDF
 $ENDCMP
 #
 $CMP BC517
 D 1A Ic, 30V Vce, Darlington NPN Transistor, TO-92
 K NPN Darlington Darl Transistor
-F http://www.fairchildsemi.com/ds/BC/BC517.pdf
+F https://www.onsemi.com/pub/Collateral/BC517-D74Z-D.PDF
 $ENDCMP
 #
 $CMP BC546
 D 0.1A Ic, 65V Vce, Small Signal NPN Transistor, TO-92
 K NPN Transistor
-F http://www.fairchildsemi.com/ds/BC/BC547.pdf
+F https://www.onsemi.com/pub/Collateral/BC550-D.pdf
 $ENDCMP
 #
 $CMP BC547
 D 0.1A Ic, 45V Vce, Small Signal NPN Transistor, TO-92
 K NPN Transistor
-F http://www.fairchildsemi.com/ds/BC/BC547.pdf
+F https://www.onsemi.com/pub/Collateral/BC550-D.pdf
 $ENDCMP
 #
 $CMP BC548
 D 0.1A Ic, 30V Vce, Small Signal NPN Transistor, TO-92
 K NPN Transistor
-F http://www.fairchildsemi.com/ds/BC/BC547.pdf
+F https://www.onsemi.com/pub/Collateral/BC550-D.pdf
 $ENDCMP
 #
 $CMP BC549
 D 0.1A Ic, 30V Vce, Small Signal NPN Transistor, TO-92
 K NPN Transistor
-F http://www.fairchildsemi.com/ds/BC/BC547.pdf
+F https://www.onsemi.com/pub/Collateral/BC550-D.pdf
 $ENDCMP
 #
 $CMP BC550
 D 0.1A Ic, 45V Vce, Small Signal NPN Transistor, TO-92
 K NPN Transistor
-F http://www.fairchildsemi.com/ds/BC/BC547.pdf
+F https://www.onsemi.com/pub/Collateral/BC550-D.pdf
 $ENDCMP
 #
 $CMP BC556
 D 0.1A Ic, 65V Vce, PNP Small Signal Transistor, TO-92
 K PNP Transistor
-F http://www.fairchildsemi.com/ds/BC/BC557.pdf
+F https://www.onsemi.com/pub/Collateral/BC556BTA-D.pdf
 $ENDCMP
 #
 $CMP BC557
 D 0.1A Ic, 45V Vce, PNP Small Signal Transistor, TO-92
 K PNP Transistor
-F http://www.fairchildsemi.com/ds/BC/BC557.pdf
+F https://www.onsemi.com/pub/Collateral/BC556BTA-D.pdf
 $ENDCMP
 #
 $CMP BC558
 D 0.1A Ic, 30V Vce, PNP Small Signal Transistor, TO-92
 K PNP Transistor
-F http://www.fairchildsemi.com/ds/BC/BC557.pdf
+F https://www.onsemi.com/pub/Collateral/BC556BTA-D.pdf
 $ENDCMP
 #
 $CMP BC559
 D 0.1A Ic, 30V Vce, PNP Small Signal Transistor, TO-92
 K PNP Transistor
-F http://www.fairchildsemi.com/ds/BC/BC557.pdf
+F https://www.onsemi.com/pub/Collateral/BC556BTA-D.pdf
 $ENDCMP
 #
 $CMP BC560
 D 0.1A Ic, 45V Vce, PNP Small Signal Transistor, TO-92
 K PNP Transistor
-F http://www.fairchildsemi.com/ds/BC/BC557.pdf
+F https://www.onsemi.com/pub/Collateral/BC556BTA-D.pdf
 $ENDCMP
 #
 $CMP BC636
 D 1A Ic, 45V Vce, PNP Medium Power Transistor, TO-92
 K PNP Transistor
-F http://www.fairchildsemi.com/ds/BC/BC636.pdf
+F https://www.onsemi.com/pub/Collateral/BC636-D.pdf
 $ENDCMP
 #
 $CMP BC807
 D 0.8A Ic, 45V Vce, PNP Transistor, SOT-23
 K PNP Transistor
-F http://www.fairchildsemi.com/ds/BC/BC807.pdf
+F https://www.onsemi.com/pub/Collateral/BC808-D.pdf
 $ENDCMP
 #
 $CMP BC807W
 D 0.8A Ic, 45V Vce, PNP Transistor, SOT-323
 K PNP transistor
-F http://www.fairchildsemi.com/ds/BC/BC807.pdf
+F https://www.onsemi.com/pub/Collateral/BC808-D.pdf
 $ENDCMP
 #
 $CMP BC808
 D 0.8A Ic, 25V Vce, PNP Transistor, SOT-23
 K PNP Transistor
-F http://www.fairchildsemi.com/ds/BC/BC807.pdf
+F https://www.onsemi.com/pub/Collateral/BC808-D.pdf
 $ENDCMP
 #
 $CMP BC808W
 D 0.8A Ic, 25V Vce, PNP Transistor, SOT-323
 K PNP transistor
-F http://www.fairchildsemi.com/ds/BC/BC807.pdf
+F https://www.onsemi.com/pub/Collateral/BC808-D.pdf
 $ENDCMP
 #
 $CMP BC817
 D 0.8A Ic, 45V Vce, NPN Transistor, SOT-23
 K NPN Transistor
-F http://www.fairchildsemi.com/ds/BC/BC817.pdf
+F https://www.onsemi.com/pub/Collateral/BC818-D.pdf
 $ENDCMP
 #
 $CMP BC817W
 D 0.8A Ic, 45V Vce, NPN Transistor, SOT-323
 K NPN Transistor
-F http://www.fairchildsemi.com/ds/BC/BC817.pdf
+F https://www.onsemi.com/pub/Collateral/BC818-D.pdf
 $ENDCMP
 #
 $CMP BC818
 D 0.8A Ic, 25V Vce, NPN Transistor, SOT-23
 K NPN Transistor
-F https://www.fairchildsemi.com/datasheets/BC/BC818.pdf
+F https://www.onsemi.com/pub/Collateral/BC818-D.pdf
 $ENDCMP
 #
 $CMP BC818W
 D 0.8A Ic, 25V Vce, NPN Transistor, SOT-323
 K NPN Transistor
-F https://www.fairchildsemi.com/datasheets/BC/BC818.pdf
+F https://www.onsemi.com/pub/Collateral/BC818-D.pdf
 $ENDCMP
 #
 $CMP BC846
@@ -447,7 +447,7 @@ $ENDCMP
 $CMP BC856
 D 0.1A Ic, 65V Vce, PNP Transistor, SOT-23
 K PNP transistor
-F http://www.fairchildsemi.com/ds/BC/BC856.pdf
+F https://www.onsemi.com/pub/Collateral/BC860-D.pdf
 $ENDCMP
 #
 $CMP BC856BDW1
@@ -465,13 +465,13 @@ $ENDCMP
 $CMP BC856W
 D 0.1A Ic, 65V Vce, PNP Transistor, SOT-323
 K PNP transistor
-F http://www.fairchildsemi.com/ds/BC/BC856.pdf
+F https://www.onsemi.com/pub/Collateral/BC860-D.pdf
 $ENDCMP
 #
 $CMP BC857
 D 0.1A Ic, 45V Vce, PNP Transistor, SOT-23
 K PNP transistor
-F http://www.fairchildsemi.com/ds/BC/BC856.pdf
+F https://www.onsemi.com/pub/Collateral/BC860-D.pdf
 $ENDCMP
 #
 $CMP BC857BDW1
@@ -495,7 +495,7 @@ $ENDCMP
 $CMP BC858
 D 0.1A Ic, 30V Vce, PNP Transistor, SOT-23
 K PNP transistor
-F http://www.fairchildsemi.com/ds/BC/BC856.pdf
+F https://www.onsemi.com/pub/Collateral/BC860-D.pdf
 $ENDCMP
 #
 $CMP BC858W
@@ -531,7 +531,7 @@ $ENDCMP
 $CMP BCP51
 D 1A Ic, 45V Vce, PNP Medium Power Transistor, SOT-223
 K PNP Transistor
-F http://www.fairchildsemi.com/ds/BC/BCP51.pdf
+F https://www.onsemi.com/pub/Collateral/BCP51-D.pdf
 $ENDCMP
 #
 $CMP BCP53
@@ -633,7 +633,7 @@ $ENDCMP
 $CMP BD233
 D 2A Ic, 45V Vce, Low Voltage Transistor, TO-126
 K Low Voltage Transistor
-F http://www.fairchildsemi.com/ds/BD/BD233.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Micro%20Commercial%20PDFs/BD233,235,237.pdf
 $ENDCMP
 #
 $CMP BD234
@@ -645,7 +645,7 @@ $ENDCMP
 $CMP BD235
 D 2A Ic, 60V Vce, Low Voltage Transistor, TO-126
 K Low Voltage Transistor
-F http://www.fairchildsemi.com/ds/BD/BD233.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Micro%20Commercial%20PDFs/BD233,235,237.pdf
 $ENDCMP
 #
 $CMP BD236
@@ -657,7 +657,7 @@ $ENDCMP
 $CMP BD237
 D 2A Ic, 80V Vce, Low Voltage Transistor, TO-126
 K Low Voltage Transistor
-F http://www.fairchildsemi.com/ds/BD/BD233.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Micro%20Commercial%20PDFs/BD233,235,237.pdf
 $ENDCMP
 #
 $CMP BD238
@@ -801,25 +801,25 @@ $ENDCMP
 $CMP BDW93
 D 12A Ic, 45V Vce, Power Darlington NPN Transistor, TO-220
 K Darlington NPN Transistor
-F https://www.fairchildsemi.com/datasheets/BD/BDW93C.pdf
+F https://www.onsemi.com/pub/Collateral/BDW93C-D.pdf
 $ENDCMP
 #
 $CMP BDW93A
 D 12A Ic, 60V Vce, Power Darlington NPN Transistor, TO-220
 K Darlington NPN Transistor
-F https://www.fairchildsemi.com/datasheets/BD/BDW93C.pdf
+F https://www.onsemi.com/pub/Collateral/BDW93C-D.pdf
 $ENDCMP
 #
 $CMP BDW93B
 D 12A Ic, 80V Vce, Power Darlington NPN Transistor, TO-220
 K Darlington NPN Transistor
-F https://www.fairchildsemi.com/datasheets/BD/BDW93C.pdf
+F https://www.onsemi.com/pub/Collateral/BDW93C-D.pdf
 $ENDCMP
 #
 $CMP BDW93C
 D 12A Ic, 100V Vce, Power Darlington NPN Transistor, TO-220
 K Darlington NPN Transistor
-F https://www.fairchildsemi.com/datasheets/BD/BDW93C.pdf
+F https://www.onsemi.com/pub/Collateral/BDW93C-D.pdf
 $ENDCMP
 #
 $CMP BDW94
@@ -885,13 +885,13 @@ $ENDCMP
 $CMP BUT11
 D 5A Ic, 400V Vce, Silicon Power NPN Transistors, TO-220
 K High Voltage Power NPN Transistor
-F http://www.fairchildsemi.com/ds/BU/BUT11.pdf
+F https://www.onsemi.com/pub/Collateral/BUT11A-D.pdf
 $ENDCMP
 #
 $CMP BUT11A
 D 5A Ic, 450V Vce, Silicon Power NPN Transistors, TO-220
 K High Voltage Power NPN Transistor
-F http://www.fairchildsemi.com/ds/BU/BUT11.pdf
+F https://www.onsemi.com/pub/Collateral/BUT11A-D.pdf
 $ENDCMP
 #
 $CMP DTA113T
@@ -1327,7 +1327,7 @@ $ENDCMP
 $CMP FFB2222A
 D 600mA IC, 40V Vce, Dual NPN/NPN Transistors, SOT-363
 K NPN/NPN Transistor
-F https://www.fairchildsemi.com/datasheets/FF/FFB2222A.pdf
+F https://www.onsemi.com/pub/Collateral/MMPQ2222A-D.pdf
 $ENDCMP
 #
 $CMP FFB2227A
@@ -1339,13 +1339,13 @@ $ENDCMP
 $CMP FFB3904
 D 200mA IC, 40V Vce, Dual NPN/NPN Transistors, SOT-363
 K NPN/NPN Transistor
-F https://www.fairchildsemi.com/datasheets/FF/FFB3904.pdf
+F https://www.onsemi.com/pub/Collateral/MMPQ3904-D.pdf
 $ENDCMP
 #
 $CMP FFB3906
 D 200mA IC, 40V Vce, Dual PNP/PNP Transistors, SOT-363
 K PNP/PNP Transistor
-F https://www.fairchildsemi.com/datasheets/FF/FFB3906.pdf
+F https://www.onsemi.com/pub/Collateral/MMPQ3906-D.pdf
 $ENDCMP
 #
 $CMP FFB3946
@@ -1357,7 +1357,7 @@ $ENDCMP
 $CMP FFB5551
 D 200mA IC, 160V Vce, Dual NPN/NPN Transistors, SOT-363
 K NPN/NPN Transistor
-F https://www.fairchildsemi.com/datasheets/FF/FFB5551.pdf
+F https://www.onsemi.com/pub/Collateral/FFB5551-D.PDF
 $ENDCMP
 #
 $CMP FMB2227A
@@ -1441,13 +1441,13 @@ $ENDCMP
 $CMP MMBT3904
 D 0.2A Ic, 40V Vce, Small Signal NPN Transistor, SOT-23
 K NPN Transistor
-F https://www.fairchildsemi.com/datasheets/2N/2N3904.pdf
+F https://www.onsemi.com/pub/Collateral/2N3903-D.PDF
 $ENDCMP
 #
 $CMP MMBT3906
 D -0.2A Ic, -40V Vce, Small Signal PNP Transistor, SOT-23
 K PNP Transistor
-F https://www.fairchildsemi.com/datasheets/2N/2N3906.pdf
+F https://www.onsemi.com/pub/Collateral/2N3906-D.PDF
 $ENDCMP
 #
 $CMP MMBT5550L
@@ -1561,7 +1561,7 @@ $ENDCMP
 $CMP PN2222A
 D 1A Ic, 40V Vce, NPN Transistor, General Purpose Transistor, TO-92
 K NPN Transistor
-F http://www.fairchildsemi.com/ds/PN/PN2222A.pdf
+F https://www.onsemi.com/pub/Collateral/PN2222-D.PDF
 $ENDCMP
 #
 $CMP PUMT1
@@ -1579,19 +1579,19 @@ $ENDCMP
 $CMP PZT2222A
 D 1A Ic, 40V Vce, NPN Transistor, General Purpose Transistor, SOT-223
 K NPN General Puprose Transistor SMD
-F http://www.fairchildsemi.com/ds/PN/PN2222A.pdf
+F https://www.onsemi.com/pub/Collateral/PN2222-D.PDF
 $ENDCMP
 #
 $CMP PZT3904
 D 0.2A Ic, 40V Vce, Small Signal NPN Transistor, SOT-223
 K NPN Transistor
-F https://www.fairchildsemi.com/datasheets/2N/2N3904.pdf
+F https://www.onsemi.com/pub/Collateral/2N3903-D.PDF
 $ENDCMP
 #
 $CMP PZT3906
 D -0.2A Ic, -40V Vce, Small Signal PNP Transistor, SOT-223
 K PNP Transistor
-F https://www.fairchildsemi.com/datasheets/2N/2N3906.pdf
+F https://www.onsemi.com/pub/Collateral/2N3906-D.PDF
 $ENDCMP
 #
 $CMP PZTA42
@@ -1633,37 +1633,37 @@ $ENDCMP
 $CMP TIP120
 D 5A Ic, 60V Vce, Silicon Darlington Power NPN Transistor, TO-220
 K Darlington Power NPN Transistor
-F http://www.fairchildsemi.com/ds/TI/TIP120.pdf
+F https://www.onsemi.com/pub/Collateral/TIP120-D.PDF
 $ENDCMP
 #
 $CMP TIP121
 D 5A Ic, 80V Vce, Silicon Darlington Power NPN Transistor, TO-220
 K Darlington Power NPN Transistor
-F http://www.fairchildsemi.com/ds/TI/TIP120.pdf
+F https://www.onsemi.com/pub/Collateral/TIP120-D.PDF
 $ENDCMP
 #
 $CMP TIP122
 D 5A Ic, 100V Vce, Silicon Darlington Power NPN Transistor, TO-220
 K Darlington Power NPN Transistor
-F http://www.fairchildsemi.com/ds/TI/TIP120.pdf
+F https://www.onsemi.com/pub/Collateral/TIP120-D.PDF
 $ENDCMP
 #
 $CMP TIP125
 D 5A Ic, 60V Vce, Silicon Darlington Power PNP Transistor, TO-220
 K Darlington Power PNP Transistor
-F http://www.fairchildsemi.com/ds/TI/TIP125.pdf
+F https://www.onsemi.com/pub/Collateral/TIP120-D.PDF
 $ENDCMP
 #
 $CMP TIP126
 D 5A Ic, 80V Vce, Silicon Darlington Power PNP Transistor, TO-220
 K Darlington Power PNP Transistor
-F http://www.fairchildsemi.com/ds/TI/TIP125.pdf
+F https://www.onsemi.com/pub/Collateral/TIP120-D.PDF
 $ENDCMP
 #
 $CMP TIP127
 D 5A Ic, 100V Vce, Silicon Darlington Power PNP Transistor, TO-220
 K Darlington Power PNP Transistor
-F http://www.fairchildsemi.com/ds/TI/TIP125.pdf
+F https://www.onsemi.com/pub/Collateral/TIP120-D.PDF
 $ENDCMP
 #
 $CMP TIP2955

--- a/Transistor_BJT.dcm
+++ b/Transistor_BJT.dcm
@@ -33,7 +33,7 @@ $ENDCMP
 $CMP 2N3905
 D -0.2A Ic, -40V Vce, Small Signal PNP Transistor, TO-92
 K PNP Transistor
-F https://www.mouser.fr/datasheet/2/308/FairchildSemiconductor_16142055386277-1191860.pdf
+F https://www.nteinc.com/specs/original/2N3905_06.pdf
 $ENDCMP
 #
 $CMP 2N3906

--- a/Transistor_FET.dcm
+++ b/Transistor_FET.dcm
@@ -3,13 +3,13 @@ EESchema-DOCLIB  Version 2.0
 $CMP 2N7000
 D 0.2A Id, 200V Vds, N-Channel MOSFET, 2.6V Logic Level, TO-92
 K N-Channel MOSFET Logic-Level
-F https://www.fairchildsemi.com/datasheets/2N/2N7000.pdf
+F https://www.onsemi.com/pub/Collateral/NDS7002A-D.PDF
 $ENDCMP
 #
 $CMP 2N7002
 D 0.115A Id, 60V Vds, N-Channel MOSFET, SOT-23
 K N-Channel Switching MOSFET
-F https://www.fairchildsemi.com/datasheets/2N/2N7002.pdf
+F https://www.onsemi.com/pub/Collateral/NDS7002A-D.PDF
 $ENDCMP
 #
 $CMP 2N7002E
@@ -51,37 +51,37 @@ $ENDCMP
 $CMP BF244A
 D 50mA Id, 30V Vgs, N-Channel FET Transistor, TO-92
 K N-Channel FET Transistor Low Voltage
-F http://www.fairchildsemi.com/ds/BF/BF244A.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/BF244x.pdf
 $ENDCMP
 #
 $CMP BF244B
 D 50mA Id, 30V Vgs, N-Channel FET Transistor, TO-92
 K N-Channel FET Transistor Low Voltage
-F http://www.fairchildsemi.com/ds/BF/BF244A.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/BF244x.pdf
 $ENDCMP
 #
 $CMP BF244C
 D 10mA Id, 30V Vgs, N-Channel FET Transistor, TO-92
 K N-Channel FET Transistor Low Voltage
-F http://www.fairchildsemi.com/ds/BF/BF244A.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/BF244x.pdf
 $ENDCMP
 #
 $CMP BF245A
 D 50mA Id, 30V Vgs, N-Channel FET Transistor, TO-92
 K N-Channel FET Transistor Low Voltage
-F http://www.fairchildsemi.com/ds/BF/BF245A.pdf
+F https://www.onsemi.com/pub/Collateral/BF245A-D.PDF
 $ENDCMP
 #
 $CMP BF245B
 D 10mA Id, 30V Vgs, N-Channel FET Transistor, TO-92
 K N-Channel FET Transistor Low Voltage
-F http://www.fairchildsemi.com/ds/BF/BF245A.pdf
+F https://www.onsemi.com/pub/Collateral/BF245A-D.PDF
 $ENDCMP
 #
 $CMP BF245C
 D 10mA Id, 30V Vgs, N-Channel FET Transistor, TO-92
 K N-Channel FET Transistor Low Voltage
-F http://www.fairchildsemi.com/ds/BF/BF245A.pdf
+F https://www.onsemi.com/pub/Collateral/BF245A-D.PDF
 $ENDCMP
 #
 $CMP BF545A
@@ -117,7 +117,7 @@ $ENDCMP
 $CMP BS170
 D 0.5A Id, 60V Vds, N-Channel MOSFET, TO-92
 K N-Channel MOSFET
-F http://www.fairchildsemi.com/ds/BS/BS170.pdf
+F https://www.onsemi.com/pub/Collateral/BS170-D.PDF
 $ENDCMP
 #
 $CMP BS170F
@@ -477,7 +477,7 @@ $ENDCMP
 $CMP BSS138
 D 50V Vds, 0.22A Id, N-Channel MOSFET, SOT-23
 K N-Channel MOSFET
-F https://www.fairchildsemi.com/datasheets/BS/BSS138.pdf
+F https://www.onsemi.com/pub/Collateral/BSS138-D.PDF
 $ENDCMP
 #
 $CMP BSS214NW
@@ -747,7 +747,7 @@ $ENDCMP
 $CMP BUZ11
 D 30A Id, 50V Vds, N-Channel Power MOSFET, TO-220
 K N-Channel Power MOSFET
-F http://www.fairchildsemi.com/ds/BU/BUZ11.pdf
+F https://media.digikey.com/pdf/Data%20Sheets/Fairchild%20PDFs/BUZ11.pdf
 $ENDCMP
 #
 $CMP C2M0025120D
@@ -1503,7 +1503,7 @@ $ENDCMP
 $CMP FDG1024NZ
 D 1.2A Id, 20V Vds, Dual N-Channel MOSFET, 175mOhm Ron, SC-70-6
 K Dual N-Channel MOSFET Logic Level
-F http://www.fairchildsemi.com/ds/FD/FDG1024NZ.pdf
+F https://www.onsemi.com/pub/Collateral/FDG1024NZ-D.pdf
 $ENDCMP
 #
 $CMP FDG6335N
@@ -1515,121 +1515,121 @@ $ENDCMP
 $CMP FDMC8032L
 D 7A Id, 40V Vds, Dual N-Channel MOSFET, 20mOhm Ron, Power33 Package
 K Dual N-Channel MOSFET
-F https://www.fairchildsemi.com/datasheets/FD/FDMC8032L.pdf
+F https://www.onsemi.com/pub/Collateral/FDMC8032L-D.PDF
 $ENDCMP
 #
 $CMP FDMS8050
 D 55A Id, 30V Vds, N-Channel PowerTrench MOSFET, 0.65mOhm Ron, 285nC Qgmax, -55 to 150 °C, 5x6mm SON8
 K powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMS8050.pdf
+F https://www.onsemi.com/pub/Collateral/FDMS8050-D.pdf
 $ENDCMP
 #
 $CMP FDMS8050ET30
 D 55A Id, 30V Vds, N-Channel PowerTrench MOSFET, 0.65mOhm Ron, 285nC Qgmax, -55 to 175 °C, 5x6mm SON8
 K powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMS8050ET30.pdf
+F https://www.onsemi.com/pub/Collateral/FDMS8050ET30-D.pdf
 $ENDCMP
 #
 $CMP FDMS8350L
 D 47A Id, 40V Vds, N-Channel PowerTrench MOSFET, 0.85mOhm Ron, 242nC Qgmax, -55 to 150 °C, 5x6mm SON8
 K powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMS8350L.pdf
+F https://www.onsemi.com/pub/Collateral/FDMS8350L-D.pdf
 $ENDCMP
 #
 $CMP FDMS8350LET40
 D 49A Id, 40V Vds, N-Channel PowerTrench MOSFET, 0.85mOhm Ron, 242nC Qgmax, -55 to 175 °C, 5x6mm SON8
 K powertrench-MOSFET MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMS8350LET40.pdf
+F https://www.onsemi.com/pub/Collateral/FDMS8350LET40-D.pdf
 $ENDCMP
 #
 $CMP FDMS86150
 D 16A Id, 100V Vds, N-Channel PowerTrench MOSFET, 4.85mOhm Ron, 62nC Qgmax, -55 to 150 °C, 5x6mm SON8
 K powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMS86150.pdf
+F https://www.onsemi.com/pub/Collateral/FDMS86150ET100-D.pdf
 $ENDCMP
 #
 $CMP FDMS86150ET100
 D 16A Id, 100V Vds, N-Channel PowerTrench MOSFET, 4.85mOhm Ron, 62nC Qgmax, -55 to 175 °C, 5x6mm SON8
 K powertrench-MOSFET MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMS86150ET100.pdf
+F https://www.mouser.fr/datasheet/2/308/FDMS86150ET100-D-1807744.pdf
 $ENDCMP
 #
 $CMP FDMS86152
 D 14A Id, 100V Vds, N-Channel PowerTrench MOSFET, 6mOhm Ron, 50nC Qgmax, -55 to 150 °C, 5x6mm SON8
 K powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMS86152.pdf
+F https://www.mouser.fr/datasheet/2/308/FDMS86152-D-1808412.pdf
 $ENDCMP
 #
 $CMP FDMS86202
 D 13.5A Id, 120V Vds, N-Channel Shielded Gate PowerTrench MOSFET, 7.2mOhm Ron, 64nC Qgmax, -55 to 150 °C, 5x6mm SON8
 K shielded-gate-powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMS86202.pdf
+F https://www.mouser.fr/datasheet/2/308/FDMS86202-D-1808220.pdf
 $ENDCMP
 #
 $CMP FDMS86202ET120
 D 13.5A Id, 120V Vds, N-Channel Shielded Gate PowerTrench MOSFET, 7.2mOhm Ron, 64nC Qgmax, -55 to 175 °C, 5x6mm SON8
 K shielded-gate-powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMS86202ET120.pdf
+F https://www.onsemi.com/pub/Collateral/FDMS86202ET120-D.pdf
 $ENDCMP
 #
 $CMP FDMS86255
 D 10A Id, 150V Vds, N-Channel Shielded Gate PowerTrench MOSFET, 12.4mOhm Ron, 63nC Qgmax, -55 to 150 °C, 5x6mm SON8
 K shielded-gate-powertrench-MOSFET MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMS86255.pdf
+F https://www.onsemi.com/pub/Collateral/FDMS86255-D.pdf
 $ENDCMP
 #
 $CMP FDMS86255ET150
 D 10A Id, 150V Vds, N-Channel Shielded Gate PowerTrench MOSFET, 12.4mOhm Ron, 63nC Qgmax, -55 to 175 °C, 5x6mm SON8
 K shielded-gate-powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMS86255ET150.pdf
+F https://www.onsemi.com/pub/Collateral/FDMS86255ET150-D.pdf
 $ENDCMP
 #
 $CMP FDMS86350
 D 25A Id, 80V Vds, N-Channel PowerTrench MOSFET, 2.4mOhm Ron, 155nC Qgmax, -55 to 150 °C, 5x6mm SON8
 K powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMS86350.pdf
+F https://www.onsemi.com/pub/Collateral/FDMS86350-D.PDF
 $ENDCMP
 #
 $CMP FDMS86350ET80
 D 25A Id, 80V Vds, N-Channel PowerTrench MOSFET, 2.4mOhm Ron, 155nC Qgmax, -55 to 175 °C, 5x6mm SON8
 K powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMS86350ET80.pdf
+F https://www.onsemi.com/pub/Collateral/FDMS86350ET80-D.pdf
 $ENDCMP
 #
 $CMP FDMS86550
 D 32A Id, 60V Vds, N-Channel PowerTrench MOSFET, 1.65mOhm Ron, 154nC Qgmax, -55 to 150 °C, 5x6mm SON8
 K powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMS86550.pdf
+F https://www.onsemi.com/pub/Collateral/FDMS86550-D.pdf
 $ENDCMP
 #
 $CMP FDMS86550ET60
 D 32A Id, 60V Vds, N-Channel PowerTrench MOSFET, 1.65mOhm Ron, 154nC Qgmax, -55 to 175 °C, 5x6mm SON8
 K powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMS86550ET60.pdf
+F https://www.onsemi.com/pub/Collateral/FDMS86550ET60-D.pdf
 $ENDCMP
 #
 $CMP FDMT800100DC
 D 24A Id, 100V Vds, N-Channel Dual Cool PowerTrench MOSFET, 2.95mOhm Ron, 111nC Qgmax, -55 to 150 °C, 8x8mm MLP
 K dual-cool-powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMT800100DC.pdf
+F https://www.onsemi.com/pub/Collateral/FDMT800100DC-D.pdf
 $ENDCMP
 #
 $CMP FDMT800120DC
 D 20A Id, 120V Vds, N-Channel Dual cool 88 PowerTrench MOSFET, 4.2mOhm Ron, 107nC Qgmax, -55 to 150 °C, 8x8mm MLP
 K dual-cool-powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMT800120DC.pdf
+F https://www.onsemi.com/pub/Collateral/FDMT800120DC-D.pdf
 $ENDCMP
 #
 $CMP FDMT800150DC
 D 15A Id, 150V Vds, N-Channel Dual cool PowerTrench MOSFET, 6.5mOhm Ron, 108nC Qgmax, -55 to 150 °C, 8x8mm MLP
 K dual-cool-powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMT800150DC.pdf
+F https://www.onsemi.com/pub/Collateral/FDMT800150DC-D.pdf
 $ENDCMP
 #
 $CMP FDMT800152DC
 D 13A Id, 150V Vds, N-Channel Dual Cool PowerTrench MOSFET, 9.0mOhm Ron, 83nC Qgmax, -55 to 150 °C, 8x8mm MLP
 K dual-cool-powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMT800152DC.pdf
+F https://www.onsemi.com/pub/Collateral/FDMT800152DC-D.pdf
 $ENDCMP
 #
 $CMP FDMT80060DC
@@ -1641,7 +1641,7 @@ $ENDCMP
 $CMP FDMT80080DC
 D 36A Id, 80V Vds, N-Channel Dual Cool PowerTrench MOSFET, 1.35mOhm Ron, 273nC Qgmax, -55 to 150 °C, 8x8mm MLP
 K dual-cool-powertrench MOSFET fairchild
-F https://www.fairchildsemi.com/datasheets/FD/FDMT80080DC.pdf
+F https://www.onsemi.com/pub/Collateral/FDMT80080DC-D.pdf
 $ENDCMP
 #
 $CMP FDS2734
@@ -1653,19 +1653,19 @@ $ENDCMP
 $CMP FDS4559
 D 4.5A Id, 60V Vds, Dual N and P Channel MOSFET, 55mOhm Ron, 10V Vgs, SO8L
 K Dual N-Channel P-Channel MOSFET
-F https://www.fairchildsemi.com/datasheets/FD/FDS4559.pdf
+F https://www.onsemi.com/pub/Collateral/FDS4559-D.PDF
 $ENDCMP
 #
 $CMP FDS4897AC
 D 6.1A Id, 40V Vds, Dual N and P Channel MOSFET, 26mOhm Ron, 10V Vgs, SO8L
 K Dual N-Channel P-Channel MOSFET
-F https://www.fairchildsemi.com/datasheets/FD/FDS4897AC.pdf
+F https://www.onsemi.com/pub/Collateral/FDS4897AC-D.pdf
 $ENDCMP
 #
 $CMP FDS4897C
 D 6.2A Id, 40V Vds, Dual N and P Channel MOSFET, 29mOhm Ron, 10V Vgs, SO8L
 K Dual N-Channel P-Channel MOSFET
-F https://www.fairchildsemi.com/datasheets/FD/FDS4897C.pdf
+F https://www.onsemi.com/pub/Collateral/FDS4897C-D.pdf
 $ENDCMP
 #
 $CMP FDS6630A
@@ -1677,19 +1677,19 @@ $ENDCMP
 $CMP FDS6890A
 D 7.5A Id, 20V Vds, Dual N-Channel MOSFET, 18mOhm Ron, SO-8
 K Dual N-Channel MOSFET
-F http://www.fairchildsemi.com/ds/FD/FDS6890A.pdf
+F https://www.onsemi.com/pub/Collateral/FDS6890A-D.PDF
 $ENDCMP
 #
 $CMP FDS6892A
 D 7.5A Id, 20V Vds, Dual N-Channel MOSFET PWM Optimized, 18mOhm Ron, SO-8
 K Dual N-Channel MOSFET Low Gate Charge
-F http://www.fairchildsemi.com/ds/FD/FDS6892A.pdf
+F https://www.onsemi.com/pub/Collateral/FDS6892A-D.pdf
 $ENDCMP
 #
 $CMP FDS6898A
 D 9.4A Id, 20V Vds, Dual N-Channel MOSFET, 14mOhm Ron, SO-8
 K Dual N-Channel MOSFET
-F http://www.fairchildsemi.com/ds/FD/FDS6898A.pdf
+F https://www.onsemi.com/pub/Collateral/FDS6898A-D.PDF
 $ENDCMP
 #
 $CMP FDS6930A
@@ -1707,7 +1707,7 @@ $ENDCMP
 $CMP FDS8960C
 D 7A Id, 35V Vds, Dual N and P Channel MOSFET, 24mOhm Ron, 10V Vgs, SO8L
 K Dual N-Channel P-Channel MOSFET
-F https://www.fairchildsemi.com/datasheets/FD/FDS8960C.pdf
+F https://www.mouser.fr/datasheet/2/308/FDS8960C-D-1808807.pdf
 $ENDCMP
 #
 $CMP FDS9435A
@@ -1719,13 +1719,13 @@ $ENDCMP
 $CMP FDS9926A
 D 6.5A Id, 20V Vds, Dual N-Channel MOSFET, 30mOhm Ron, SO-8
 K Dual N-Channel MOSFET
-F http://www.fairchildsemi.com/ds/FD/FDS9926A.pdf
+F https://www.onsemi.com/pub/Collateral/FDS9926A-D.pdf
 $ENDCMP
 #
 $CMP FDS9934C
 D 6.5A Id, 20V Vds, Dual N and P Channel MOSFET, 30mOhm Ron, 4.5V Vgs, SO8L
 K Dual N-Channel P-Channel MOSFET
-F https://www.fairchildsemi.com/datasheets/FD/FDS9934C.pdf
+F https://www.onsemi.com/pub/Collateral/FDS9934C-D.pdf
 $ENDCMP
 #
 $CMP FQP27P06
@@ -2709,13 +2709,13 @@ $ENDCMP
 $CMP Si4532DY
 D 3.9A Id, 30V Vds, Dual N and P Channel MOSFET, 65mOhm Ron, 10V Vgs, SO8L
 K Dual N-Channel P-Channel MOSFET
-F https://www.fairchildsemi.com/datasheets/SI/SI4532DY.pdf
+F https://www.onsemi.com/pub/Collateral/SI4532DY-D.PDF
 $ENDCMP
 #
 $CMP Si4542DY
 D Dual N and P Channel MOSFET, 6A Id, 30V Vds, 28mOhm Ron, 10V Vgs, SO8L
 K Dual N-Channel P-Channel MOSFET
-F https://www.fairchildsemi.com/datasheets/SI/SI4542DY.pdf
+F https://www.onsemi.com/pub/Collateral/SI4542DY-D.PDF
 $ENDCMP
 #
 $CMP Si7141DP


### PR DESCRIPTION
this is part of issue-2895 : fairechildsemi.com links for datasheet are leading to a page that is not a pdf file
I've replaced most of them with new onsemi.com links, but some others couldn't be found so I've used links from digikey, farnell or ti.