### PR TITLE
Correct SOIJ-8 in description to SOIC-8W

### DIFF
--- a/MCU_Microchip_ATtiny.dcm
+++ b/MCU_Microchip_ATtiny.dcm
@@ -49,7 +49,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2535.pdf
 $ENDCMP
 #
 $CMP ATtiny13-20S
-D 20MHz, 1kB Flash, 64B SRAM, 64B EEPROM, debugWIRE, SOIJ-8
+D 20MHz, 1kB Flash, 64B SRAM, 64B EEPROM, debugWIRE, SOIC-8W
 K AVR 8bit Microcontroller tinyAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2535.pdf
 $ENDCMP
@@ -79,7 +79,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8126.pdf
 $ENDCMP
 #
 $CMP ATtiny13A-S
-D 20MHz, 1kB Flash, 64B SRAM, 64B EEPROM, debugWIRE, SOIJ-8
+D 20MHz, 1kB Flash, 64B SRAM, 64B EEPROM, debugWIRE, SOIC-8W
 K AVR 8bit Microcontroller tinyAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/doc8126.pdf
 $ENDCMP
@@ -109,7 +109,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2535.pdf
 $ENDCMP
 #
 $CMP ATtiny13V-10S
-D 10MHz, 1kB Flash, 64B SRAM, 64B EEPROM, debugWIRE, SOIJ-8
+D 10MHz, 1kB Flash, 64B SRAM, 64B EEPROM, debugWIRE, SOIC-8W
 K AVR 8bit Microcontroller tinyAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/doc2535.pdf
 $ENDCMP
@@ -391,7 +391,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcont
 $ENDCMP
 #
 $CMP ATtiny25-20S
-D 20MHz, 2kB Flash, 128B SRAM, 128B EEPROM, debugWIRE, SOIJ-8
+D 20MHz, 2kB Flash, 128B SRAM, 128B EEPROM, debugWIRE, SOIC-8W
 K AVR 8bit Microcontroller tinyAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
@@ -415,7 +415,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcont
 $ENDCMP
 #
 $CMP ATtiny25V-10S
-D 10MHz, 2kB Flash, 128B SRAM, 128B EEPROM, debugWIRE, SOIJ-8
+D 10MHz, 2kB Flash, 128B SRAM, 128B EEPROM, debugWIRE, SOIC-8W
 K AVR 8bit Microcontroller tinyAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
@@ -757,7 +757,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcont
 $ENDCMP
 #
 $CMP ATtiny45-20S
-D 20MHz, 4kB Flash, 256B SRAM, 256B EEPROM, debugWIRE, SOIJ-8
+D 20MHz, 4kB Flash, 256B SRAM, 256B EEPROM, debugWIRE, SOIC-8W
 K AVR 8bit Microcontroller tinyAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
@@ -781,7 +781,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcont
 $ENDCMP
 #
 $CMP ATtiny45V-10S
-D 10MHz, 4kB Flash, 256B SRAM, 256B EEPROM, debugWIRE, SOIJ-8
+D 10MHz, 4kB Flash, 256B SRAM, 256B EEPROM, debugWIRE, SOIC-8W
 K AVR 8bit Microcontroller tinyAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
@@ -1051,7 +1051,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcont
 $ENDCMP
 #
 $CMP ATtiny85-20S
-D 20MHz, 8kB Flash, 512B SRAM, 512B EEPROM, debugWIRE, SOIJ-8
+D 20MHz, 8kB Flash, 512B SRAM, 512B EEPROM, debugWIRE, SOIC-8W
 K AVR 8bit Microcontroller tinyAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP
@@ -1069,7 +1069,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcont
 $ENDCMP
 #
 $CMP ATtiny85V-10S
-D 10MHz, 8kB Flash, 512B SRAM, 512B EEPROM, debugWIRE, SOIJ-8
+D 10MHz, 8kB Flash, 512B SRAM, 512B EEPROM, debugWIRE, SOIC-8W
 K AVR 8bit Microcontroller tinyAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf
 $ENDCMP

--- a/Memory_EEPROM.dcm
+++ b/Memory_EEPROM.dcm
@@ -385,7 +385,7 @@ F https://www.onsemi.com/pub/Collateral/CAT24M01-D.PDF
 $ENDCMP
 #
 $CMP CAT24M01X
-D 1 Mb I2C CMOS Serial EEPROM, SOIJ-8
+D 1 Mb I2C CMOS Serial EEPROM, SOIC-8W
 K EEPROM 1Mb I2C
 F https://www.onsemi.com/pub/Collateral/CAT24M01-D.PDF
 $ENDCMP

--- a/Memory_Flash.dcm
+++ b/Memory_Flash.dcm
@@ -123,13 +123,13 @@ F http://www.issi.com/WW/pdf/IS25LP(WP)256D.pdf
 $ENDCMP
 #
 $CMP M25PX32-VMP
-D 32Mb, Dual I/O, 4KB Subsector Erase, 3V Serial Flash Memory with 75 MHz SPI Bus Interface, QFN package
+D 32Mb, Dual I/O, 4KB Subsector Erase, 3V Serial Flash Memory with 75 MHz SPI Bus Interface, DFN-8
 K NOR Serial Flash Embedded Memory
 F https://www.micron.com/~/media/documents/products/data-sheet/nor-flash/serial-nor/m25px/m25px32.pdf
 $ENDCMP
 #
 $CMP M25PX32-VMW
-D 32Mb, Dual I/O, 4KB Subsector Erase, 3V Serial Flash Memory with 75 MHz SPI Bus Interface, SOIJ package
+D 32Mb, Dual I/O, 4KB Subsector Erase, 3V Serial Flash Memory with 75 MHz SPI Bus Interface, SOIC-8W
 K NOR Serial Flash Embedded Memory
 F https://www.micron.com/~/media/documents/products/data-sheet/nor-flash/serial-nor/m25px/m25px32.pdf
 $ENDCMP

--- a/obsolete/MCU_Microchip_ATtiny.dcm
+++ b/obsolete/MCU_Microchip_ATtiny.dcm
@@ -7,7 +7,7 @@ F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny%2011_12%20Comp
 $ENDCMP
 #
 $CMP ATtiny11-6SC
-D 6MHz, 1kB Flash, No SRAM, No EEPROM, SOIJ-8
+D 6MHz, 1kB Flash, No SRAM, No EEPROM, SOIC-8W
 K AVR 8bit Microcontroller tinyAVR
 F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny%2011_12%20Complete.pdf
 $ENDCMP
@@ -19,7 +19,7 @@ F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny%2011_12%20Comp
 $ENDCMP
 #
 $CMP ATtiny11L-2SC
-D 2MHz, 1kB Flash, No SRAM, No EEPROM, SOIJ-8
+D 2MHz, 1kB Flash, No SRAM, No EEPROM, SOIC-8W
 K AVR 8bit Microcontroller tinyAVR
 F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny%2011_12%20Complete.pdf
 $ENDCMP
@@ -31,7 +31,7 @@ F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny%2011_12%20Comp
 $ENDCMP
 #
 $CMP ATtiny12-8SC
-D 8MHz, 1kB Flash, No SRAM, 64B EEPROM, SOIJ-8
+D 8MHz, 1kB Flash, No SRAM, 64B EEPROM, SOIC-8W
 K AVR 8bit Microcontroller tinyAVR
 F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny%2011_12%20Complete.pdf
 $ENDCMP
@@ -43,7 +43,7 @@ F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny%2011_12%20Comp
 $ENDCMP
 #
 $CMP ATtiny12L-4SC
-D 4MHz, 1kB Flash, No SRAM, 64B EEPROM, SOIJ-8
+D 4MHz, 1kB Flash, No SRAM, 64B EEPROM, SOIC-8W
 K AVR 8bit Microcontroller tinyAVR
 F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny%2011_12%20Complete.pdf
 $ENDCMP
@@ -55,7 +55,7 @@ F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny%2011_12%20Comp
 $ENDCMP
 #
 $CMP ATtiny12V-1SC
-D 1.2MHz, 1kB Flash, No SRAM, 64B EEPROM, SOIJ-8
+D 1.2MHz, 1kB Flash, No SRAM, 64B EEPROM, SOIC-8W
 K AVR 8bit Microcontroller tinyAVR
 F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny%2011_12%20Complete.pdf
 $ENDCMP
@@ -67,7 +67,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1187.pdf
 $ENDCMP
 #
 $CMP ATtiny15L-1SC
-D 1.6MHz, 1kB Flash, No SRAM, 64B EEPROM, SOIJ-8
+D 1.6MHz, 1kB Flash, No SRAM, 64B EEPROM, SOIC-8W
 K AVR 8bit Microcontroller tinyAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1187.pdf
 $ENDCMP
@@ -79,7 +79,7 @@ F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny22L.pdf
 $ENDCMP
 #
 $CMP ATtiny22L-1SC
-D 1MHz, 2kB Flash, 128B SRAM, 128B EEPROM, SOIJ-8
+D 1MHz, 2kB Flash, 128B SRAM, 128B EEPROM, SOIC-8W
 K AVR 8bit Microcontroller tinyAVR
 F https://media.digikey.com/pdf/Data%20Sheets/Atmel%20PDFs/ATtiny22L.pdf
 $ENDCMP

--- a/obsolete/MCU_Microchip_AVR.dcm
+++ b/obsolete/MCU_Microchip_AVR.dcm
@@ -67,7 +67,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1004.pdf
 $ENDCMP
 #
 $CMP AT90S2323-10SC
-D 10MHz, 2kB Flash, 128B SRAM, 128B EEPROM, SOIJ-8
+D 10MHz, 2kB Flash, 128B SRAM, 128B EEPROM, SOIC-8W
 K AVR 8bit Microcontroller ClassicAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1004.pdf
 $ENDCMP
@@ -79,7 +79,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1004.pdf
 $ENDCMP
 #
 $CMP AT90S2323-4SC
-D 4MHz, 2kB Flash, 128B SRAM, 128B EEPROM, SOIJ-8
+D 4MHz, 2kB Flash, 128B SRAM, 128B EEPROM, SOIC-8W
 K AVR 8bit Microcontroller ClassicAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1004.pdf
 $ENDCMP
@@ -115,7 +115,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1004.pdf
 $ENDCMP
 #
 $CMP AT90S2343-10SC
-D 10MHz, 2kB Flash, 128B SRAM, 128B EEPROM, SOIJ-8
+D 10MHz, 2kB Flash, 128B SRAM, 128B EEPROM, SOIC-8W
 K AVR 8bit Microcontroller ClassicAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1004.pdf
 $ENDCMP
@@ -127,7 +127,7 @@ F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1004.pdf
 $ENDCMP
 #
 $CMP AT90S2343-4SC
-D 4MHz, 2kB Flash, 128B SRAM, 128B EEPROM, SOIJ-8
+D 4MHz, 2kB Flash, 128B SRAM, 128B EEPROM, SOIC-8W
 K AVR 8bit Microcontroller ClassicAVR
 F http://ww1.microchip.com/downloads/en/DeviceDoc/doc1004.pdf
 $ENDCMP


### PR DESCRIPTION
https://github.com/KiCad/kicad-symbols/pull/1587 changed the default packages on symbols from SOIJ to SOIC, but the descriptions didn't get updated. This was caught by @fauxpark at https://github.com/KiCad/kicad-symbols/pull/1587#issuecomment-700740888.

Only descriptions are changed. It's a minor thing, but that also means it should be easy to review and commit.

I threw in a fix for the description of `M25PX32-VMP` too since it was ugly and I was there.

---

## :warning: Deprecation warning
In preparation for the KiCad v6 release this repository will be locked down on Sept 1, 2020. No new pull requests will be accepted. Existing pull requests can be worked on until Oct 1, 2020. Changes breaking v5.1 compatibility can be merged starting Sept 1, 2020.

On Oct 1, 2020 this repository, including issues and pull requests, will be archived and transferred to [gitlab.com](https://gitlab.com/kicad/libraries/kicad-symbols/). In order for your pull requests and issues to be imported into GitLab you must set your email address on GitHub to public and use the same address for your GitLab account. Or login to GitLab at least once using the GitHub icon. Otherwise the importer can't correlate the account information and the issues/comments on GitLab will be owned by `kicad-bot` ([importer documentation](https://docs.gitlab.com/ee/user/project/import/github.html#how-it-works)).

We plan to convert the library to the new v6 S-expr format after it is imported to GitLab. That also means that old pull requests will need to be redone with the v6 format if they are not merged before then.

---

All contributions to the kicad library must follow the [KiCad library convention](http://kicad-pcb.org/libraries/klc/)

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the symbol(s) you are contributing
- [ ] Provide a screenshot of the symbol(s) from the symbol editor with the pin types visible
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
  - A new fitting footprint must be submitted if the library does not yet contain one.
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.

---

Be patient, we maintainers are volunteers with limited time and need to check your contribution against the datasheet. You can speed up the process by providing all the necessary information (see above). And you can speed up the process even more by providing additional info like the screenshot of the symbol editor pin table (or for high pin counts converted to csv) sorted in the same way as the pin table in the datasheet and a direct link to the datasheet page that contains the pin table.
